### PR TITLE
(bug) fixes a few issues with downgrading from new harness to old harness yaml

### DIFF
--- a/convert/harness/downgrader/downgrade.go
+++ b/convert/harness/downgrader/downgrade.go
@@ -423,7 +423,7 @@ func (d *Downgrader) convertStepPlugin(src *v1.Step) *v0.Step {
 		Name:    src.Name,
 		Type:    v0.StepTypePlugin,
 		Timeout: convertTimeout(src.Timeout),
-		Spec: v0.StepPlugin{
+		Spec: &v0.StepPlugin{
 			ConnRef:         d.dockerhubConn,
 			Image:           spec_.Image,
 			ImagePullPolicy: convertImagePull(spec_.Pull),
@@ -445,7 +445,7 @@ func (d *Downgrader) convertStepAction(src *v1.Step) *v0.Step {
 		Name:    src.Name,
 		Type:    v0.StepTypeAction,
 		Timeout: convertTimeout(src.Timeout),
-		Spec: v0.StepAction{
+		Spec: &v0.StepAction{
 			Uses: spec_.Uses,
 			With: convertSettings(spec_.With),
 			Envs: spec_.Envs,
@@ -464,7 +464,7 @@ func (d *Downgrader) convertStepBitrise(src *v1.Step) *v0.Step {
 		Name:    src.Name,
 		Type:    v0.StepTypeBitrise,
 		Timeout: convertTimeout(src.Timeout),
-		Spec: v0.StepBitrise{
+		Spec: &v0.StepBitrise{
 			Uses: spec_.Uses,
 			With: convertSettings(spec_.With),
 			Envs: spec_.Envs,

--- a/convert/harness/downgrader/downgrade.go
+++ b/convert/harness/downgrader/downgrade.go
@@ -120,13 +120,12 @@ func (d *Downgrader) DowngradeFile(path string) ([]byte, error) {
 
 // downgrade downgrades a v1 pipeline.
 func (d *Downgrader) downgrade(src *v1.Pipeline) ([]byte, error) {
-	dst := new(v0.Pipeline)
-
-	dst.ID = d.pipelineId
-	dst.Name = d.pipelineName
-	dst.Org = d.pipelineOrg
-	dst.Project = d.pipelineProj
-	dst.Props.CI.Codebase = v0.Codebase{
+	config := new(v0.Config)
+	config.Pipeline.ID = d.pipelineId
+	config.Pipeline.Name = d.pipelineName
+	config.Pipeline.Org = d.pipelineOrg
+	config.Pipeline.Project = d.pipelineId
+	config.Pipeline.Props.CI.Codebase = v0.Codebase{
 		Name:  d.codebaseName,
 		Conn:  d.codebaseConn,
 		Build: "<+input>",
@@ -146,12 +145,12 @@ func (d *Downgrader) downgrade(src *v1.Pipeline) ([]byte, error) {
 		}
 
 		// convert the stage and add to the list
-		dst.Stages = append(dst.Stages, &v0.Stages{
+		config.Pipeline.Stages = append(config.Pipeline.Stages, &v0.Stages{
 			Stage: d.convertStage(stage),
 		})
 	}
 
-	return yaml.Marshal(dst)
+	return yaml.Marshal(config)
 }
 
 // helper function converts a drone pipeline stage to a
@@ -365,7 +364,7 @@ func (d *Downgrader) convertStepRun(src *v1.Step) *v0.Step {
 		Name:    src.Name,
 		Type:    v0.StepTypeRun,
 		Timeout: convertTimeout(src.Timeout),
-		Spec: &v0.StepRun{
+		Spec: v0.StepRun{
 			Env:             spec_.Envs,
 			Command:         spec_.Run,
 			ConnRef:         d.dockerhubConn,
@@ -397,7 +396,7 @@ func (d *Downgrader) convertStepBackground(src *v1.Step) *v0.Step {
 		),
 		Name: src.Name,
 		Type: v0.StepTypeBackground,
-		Spec: &v0.StepBackground{
+		Spec: v0.StepBackground{
 			Command:         spec_.Run,
 			ConnRef:         d.dockerhubConn,
 			Entrypoint:      entypoint,
@@ -422,9 +421,9 @@ func (d *Downgrader) convertStepPlugin(src *v1.Step) *v0.Step {
 			slug.Create(src.Name),
 		),
 		Name:    src.Name,
-		Type:    v0.StepTypeRun,
+		Type:    v0.StepTypePlugin,
 		Timeout: convertTimeout(src.Timeout),
-		Spec: &v0.StepPlugin{
+		Spec: v0.StepPlugin{
 			ConnRef:         d.dockerhubConn,
 			Image:           spec_.Image,
 			ImagePullPolicy: convertImagePull(spec_.Pull),
@@ -446,7 +445,7 @@ func (d *Downgrader) convertStepAction(src *v1.Step) *v0.Step {
 		Name:    src.Name,
 		Type:    v0.StepTypeAction,
 		Timeout: convertTimeout(src.Timeout),
-		Spec: &v0.StepAction{
+		Spec: v0.StepAction{
 			Uses: spec_.Uses,
 			With: convertSettings(spec_.With),
 			Envs: spec_.Envs,
@@ -465,7 +464,7 @@ func (d *Downgrader) convertStepBitrise(src *v1.Step) *v0.Step {
 		Name:    src.Name,
 		Type:    v0.StepTypeBitrise,
 		Timeout: convertTimeout(src.Timeout),
-		Spec: &v0.StepBitrise{
+		Spec: v0.StepBitrise{
 			Uses: spec_.Uses,
 			With: convertSettings(spec_.With),
 			Envs: spec_.Envs,

--- a/convert/harness/downgrader/downgrade.go
+++ b/convert/harness/downgrader/downgrade.go
@@ -364,7 +364,7 @@ func (d *Downgrader) convertStepRun(src *v1.Step) *v0.Step {
 		Name:    src.Name,
 		Type:    v0.StepTypeRun,
 		Timeout: convertTimeout(src.Timeout),
-		Spec: v0.StepRun{
+		Spec: &v0.StepRun{
 			Env:             spec_.Envs,
 			Command:         spec_.Run,
 			ConnRef:         d.dockerhubConn,
@@ -396,7 +396,7 @@ func (d *Downgrader) convertStepBackground(src *v1.Step) *v0.Step {
 		),
 		Name: src.Name,
 		Type: v0.StepTypeBackground,
-		Spec: v0.StepBackground{
+		Spec: &v0.StepBackground{
 			Command:         spec_.Run,
 			ConnRef:         d.dockerhubConn,
 			Entrypoint:      entypoint,

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,15 @@ module github.com/drone/go-convert
 go 1.19
 
 require (
+	github.com/bmatcuk/doublestar v1.3.4
 	github.com/docker/go-units v0.4.0
+	github.com/drone/spec v0.0.0-20230302183458-cff49edf8116
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/subcommands v1.2.0
 	github.com/gotidy/ptr v1.4.0
+	golang.org/x/text v0.7.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require (
-	github.com/bmatcuk/doublestar v1.3.4 // indirect
-	github.com/drone/spec v0.0.0-20230302183458-cff49edf8116 // indirect
-	golang.org/x/text v0.7.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-)
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,6 @@ github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQ
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
-github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/drone/spec v0.0.0-20230302154157-736b66c3e93b h1:JnMP1rRAoD5wz3mGjJb8lHnNHOQq3Le03EK87Vl9bh0=
-github.com/drone/spec v0.0.0-20230302154157-736b66c3e93b/go.mod h1:ToM1HG/JNy3GghchmT/Sv4fzfSFWIqpws5umZIxeEkY=
 github.com/drone/spec v0.0.0-20230302183458-cff49edf8116 h1:D28J4V/9LHEqfgcvr6dMbH+Y+D0sK/ZK49CYrY1WGeg=
 github.com/drone/spec v0.0.0-20230302183458-cff49edf8116/go.mod h1:pdaL6nOipGF/5L6jAu1DwAeLzmZdaU3+UIvQ1MUIZ9Y=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=


### PR DESCRIPTION
- pipeline was missing from the returned yaml
- Spec field was being assigned directly to a pointer to the v0.StepPlugin type, which caused the type assertion error.