### PR TITLE
fix: ignore all errors for gitlab conversions

### DIFF
--- a/convert/gitlab/convert.go
+++ b/convert/gitlab/convert.go
@@ -325,11 +325,10 @@ func convertJobToStep(ctx *context, jobName string, job *gitlab.Job, matrix map[
 		on = convertAllowFailure(job)
 	}
 
-
 	if job.Secrets != nil {
 		spec.Envs = convertSecrets(job.Secrets)
-  }
-  
+	}
+
 	var strategy *harness.Strategy
 	if matrix != nil {
 		strategy = convertStrategy(matrix)
@@ -504,7 +503,8 @@ func convertAllowFailure(job *gitlab.Job) *harness.On {
 
 		on := &harness.On{
 			Failure: &harness.Failure{
-				Type: "ignore",
+				Errors: []string{"all"},
+				Type:   "ignore",
 			},
 		}
 		if len(exitCodesStr) > 0 {
@@ -550,7 +550,6 @@ func convertRetry(job *gitlab.Job) *harness.On {
 	}
 }
 
-
 // convertSecrets converts a GitLab secrets map to a Harness secrets map.
 func convertSecrets(secrets map[string]*gitlab.Secret) map[string]string {
 	result := make(map[string]string)
@@ -567,7 +566,7 @@ func convertSecrets(secrets map[string]*gitlab.Secret) map[string]string {
 
 	return result
 }
-  
+
 func convertStrategy(axis map[string][]string) *harness.Strategy {
 	return &harness.Strategy{
 		Type: "matrix",

--- a/convert/gitlab/testdata/templates/allow_failure.yaml.golden
+++ b/convert/gitlab/testdata/templates/allow_failure.yaml.golden
@@ -5,6 +5,8 @@ stages:
     - name: job1
       on:
         failure:
+          errors:
+          - all
           type: ignore
       spec:
         run: execute_script_1

--- a/convert/gitlab/testdata/templates/exit_codes.yaml.golden
+++ b/convert/gitlab/testdata/templates/exit_codes.yaml.golden
@@ -7,6 +7,8 @@ stages:
         - name: test_job_1
           on:
             failure:
+              errors:
+              - all
               exit_codes:
               - "137"
               type: ignore
@@ -18,6 +20,8 @@ stages:
         - name: test_job_2
           on:
             failure:
+              errors:
+              - all
               exit_codes:
               - "137"
               - "255"

--- a/convert/gitlab/testdata/templates/extends.yaml.golden
+++ b/convert/gitlab/testdata/templates/extends.yaml.golden
@@ -5,6 +5,8 @@ stages:
     - name: rspec
       on:
         failure:
+          errors:
+          - all
           type: ignore
       spec:
         run: rake rspec


### PR DESCRIPTION
allow_failure should convert to ignore all error types