### PR TITLE
fix: use targetBranch not branch for conditions

### DIFF
--- a/convert/harness/downgrader/downgrade.go
+++ b/convert/harness/downgrader/downgrade.go
@@ -810,14 +810,14 @@ func convertStepWhen(when *v1.When, stepId string) *v0.StepWhen {
 				if v.In != nil {
 					var branchConditions []string
 					for _, branch := range v.In {
-						branchConditions = append(branchConditions, fmt.Sprintf("<+trigger.branch> == %q", branch))
+						branchConditions = append(branchConditions, fmt.Sprintf("<+trigger.targetBranch> == %q", branch))
 					}
 					conditions = append(conditions, fmt.Sprintf("%s", strings.Join(branchConditions, " || ")))
 				}
 				if v.Not != nil && v.Not.In != nil {
 					var notBranchConditions []string
 					for _, branch := range v.Not.In {
-						notBranchConditions = append(notBranchConditions, fmt.Sprintf("<+trigger.branch> != %q", branch))
+						notBranchConditions = append(notBranchConditions, fmt.Sprintf("<+trigger.targetBranch> != %q", branch))
 					}
 					conditions = append(conditions, fmt.Sprintf("%s", strings.Join(notBranchConditions, " && ")))
 				}
@@ -917,14 +917,14 @@ func convertStageWhen(when *v1.When, stepId string) *v0.StageWhen {
 				if v.In != nil {
 					var branchConditions []string
 					for _, branch := range v.In {
-						branchConditions = append(branchConditions, fmt.Sprintf("<+trigger.branch> == %q", branch))
+						branchConditions = append(branchConditions, fmt.Sprintf("<+trigger.targetBranch> == %q", branch))
 					}
 					conditions = append(conditions, fmt.Sprintf("%s", strings.Join(branchConditions, " || ")))
 				}
 				if v.Not != nil && v.Not.In != nil {
 					var notBranchConditions []string
 					for _, branch := range v.Not.In {
-						notBranchConditions = append(notBranchConditions, fmt.Sprintf("<+trigger.branch> != %q", branch))
+						notBranchConditions = append(notBranchConditions, fmt.Sprintf("<+trigger.targetBranch> != %q", branch))
 					}
 					conditions = append(conditions, fmt.Sprintf("%s", strings.Join(notBranchConditions, " && ")))
 				}

--- a/convert/harness/downgrader/testdata/stage-conditional.yaml
+++ b/convert/harness/downgrader/testdata/stage-conditional.yaml
@@ -1,0 +1,26 @@
+options: {}
+stages:
+- name: test
+  spec:
+    clone:
+      depth: 50
+    runtime:
+      spec: {}
+      type: machine
+    steps:
+    - name: test
+      spec:
+        image: golang
+        run: |-
+          go build
+          go test
+      type: script
+  type: ci
+  when:
+  - branch:
+      in:
+      - main
+  - event:
+      in:
+      - push
+version: 1

--- a/convert/harness/downgrader/testdata/stage-conditional.yaml.golden
+++ b/convert/harness/downgrader/testdata/stage-conditional.yaml.golden
@@ -1,0 +1,37 @@
+pipeline:
+  identifier: default
+  name: default
+  orgIdentifier: default
+  projectIdentifier: default
+  properties:
+    ci:
+      codebase:
+        build: <+input>
+  stages:
+  - stage:
+      identifier: test1
+      name: test
+      spec:
+        cloneCodebase: true
+        execution:
+          steps:
+          - step:
+              identifier: test
+              name: test
+              spec:
+                command: |-
+                  go build
+                  go test
+                image: golang
+              timeout: ""
+              type: Run
+        platform:
+          arch: Amd64
+          os: Linux
+        runtime:
+          spec: {}
+          type: Cloud
+      type: CI
+      when:
+        condition: <+trigger.targetBranch> == "main" && (<+trigger.event> == "PUSH")
+        pipelineStatus: Success

--- a/convert/harness/downgrader/testdata/step-conditional.yaml
+++ b/convert/harness/downgrader/testdata/step-conditional.yaml
@@ -1,0 +1,29 @@
+options: {}
+stages:
+- name: test
+  spec:
+    clone:
+      depth: 50
+    runtime:
+      spec: {}
+      type: machine
+    steps:
+    - name: test
+      spec:
+        image: golang
+        run: |-
+          go build
+          go test
+      type: script
+      when:
+      - branch:
+          in:
+          - main
+          - develop
+  type: ci
+  when:
+  - event:
+      in:
+      - push
+      - pull_request
+version: 1

--- a/convert/harness/downgrader/testdata/step-conditional.yaml.golden
+++ b/convert/harness/downgrader/testdata/step-conditional.yaml.golden
@@ -1,0 +1,41 @@
+pipeline:
+  identifier: default
+  name: default
+  orgIdentifier: default
+  projectIdentifier: default
+  properties:
+    ci:
+      codebase:
+        build: <+input>
+  stages:
+  - stage:
+      identifier: test1
+      name: test
+      spec:
+        cloneCodebase: true
+        execution:
+          steps:
+          - step:
+              identifier: test
+              name: test
+              spec:
+                command: |-
+                  go build
+                  go test
+                image: golang
+              timeout: ""
+              type: Run
+              when:
+                condition: <+trigger.targetBranch> == "main" || <+trigger.targetBranch>
+                  == "develop"
+                stageStatus: Success
+        platform:
+          arch: Amd64
+          os: Linux
+        runtime:
+          spec: {}
+          type: Cloud
+      type: CI
+      when:
+        condition: (<+trigger.event> == "PUSH" || <+trigger.event> == "PR")
+        pipelineStatus: Success


### PR DESCRIPTION
<+trigger.branch> will always contain the current branch

<+trigger.targetBranch> will contain the current branch on a push event, but on a pull request event it will contain the target branch for the pull request