### PR TITLE
feat: [CI-14066]: Jenkins pwsh function

### DIFF
--- a/convert/jenkinsjson/convertTestFiles/pwsh/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/pwsh/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage('example') {
+            steps {
+                pwsh(script: 'Write-Output "Hello from powershell"')
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/pwsh/pwsh.yaml
+++ b/convert/jenkinsjson/convertTestFiles/pwsh/pwsh.yaml
@@ -1,0 +1,9 @@
+- step:
+    identifier: pwsh48add0
+    name: pwsh
+    spec:
+      command: Write-Output "Hello from powershell"
+      image: mcr.microsoft.com/powershell
+      shell: Pwsh
+    timeout: ""
+    type: Run

--- a/convert/jenkinsjson/convertTestFiles/pwsh/pwshSnippet.json
+++ b/convert/jenkinsjson/convertTestFiles/pwsh/pwshSnippet.json
@@ -1,0 +1,20 @@
+{
+  "spanId": "48add07c4c323c37",
+  "traceId": "c7ae9b130161e9586c66041e8022c888",
+  "parent": "pwsh-test",
+  "name": "pwsh-test #4",
+  "attributesMap": {
+    "ci.pipeline.run.user": "SYSTEM",
+    "jenkins.pipeline.step.id": "7",
+    "jenkins.pipeline.step.name": "PowerShell Core Script",
+    "jenkins.pipeline.step.plugin.name": "workflow-durable-task-step",
+    "jenkins.pipeline.step.plugin.version": "1353.v1891a_b_01da_18",
+    "jenkins.pipeline.step.type": "pwsh",
+    "harness-attribute": "{\n  \"script\" : \"Write-Output \\\"Hello from powershell\\\"\"\n}",
+    "harness-others": "-WATCHING_RECURRENCE_PERIOD-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep WATCHING_RECURRENCE_PERIOD-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.WATCHING_RECURRENCE_PERIOD-long-USE_WATCHING-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep USE_WATCHING-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING-boolean-REMOTE_TIMEOUT-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep REMOTE_TIMEOUT-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT-long"
+  },
+  "type": "Run Phase Span",
+  "parentSpanId": "ae814e400d403a68",
+  "spanName": "pwsh",
+  "parameterMap": { "script": "Write-Output \"Hello from powershell\"" }
+}

--- a/convert/jenkinsjson/covert.go
+++ b/convert/jenkinsjson/covert.go
@@ -387,6 +387,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 		}
 	case "sh":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertSh(currentNode, variables, timeout, dockerImage), ID: id})
+	case "pwsh":
+		dockerImage = "mcr.microsoft.com/powershell"
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertPwsh(currentNode, variables, timeout, dockerImage), ID: id})
 	case "timeout":
 		if len(currentNode.ParameterMap) > 0 {
 			var unit string

--- a/convert/jenkinsjson/json/pwsh.go
+++ b/convert/jenkinsjson/json/pwsh.go
@@ -1,0 +1,25 @@
+package json
+
+import (
+	"fmt"
+
+	harness "github.com/drone/spec/dist/go"
+)
+
+func ConvertPwsh(node Node, variables map[string]string, timeout string, dockerImage string) *harness.Step {
+	pwshStep := &harness.Step{
+		Name:    node.SpanName,
+		Timeout: timeout,
+		Id:      SanitizeForId(node.SpanName, node.SpanId),
+		Type:    "script",
+		Spec: &harness.StepExec{
+			Image: dockerImage,
+			Shell: "pwsh",
+			Run:   fmt.Sprintf("%v", node.ParameterMap["script"]),
+		},
+	}
+	if len(variables) > 0 {
+		pwshStep.Spec.(*harness.StepExec).Envs = variables
+	}
+	return pwshStep
+}

--- a/convert/jenkinsjson/json/pwsh_test.go
+++ b/convert/jenkinsjson/json/pwsh_test.go
@@ -1,0 +1,67 @@
+package json
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertPwsh(t *testing.T) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	// Path to the test JSON file for pwsh
+	filePath := filepath.Join(workingDir, "../convertTestFiles/pwsh/pwshSnippet.json")
+	jsonData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read JSON file: %v", err)
+	}
+
+	// Unmarshal the JSON data into a Node object
+	var node1 Node
+	if err := json.Unmarshal(jsonData, &node1); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	tests := []struct {
+		json Node
+		want Node
+	}{
+		{
+			json: node1,
+			want: Node{
+				AttributesMap: map[string]string{
+					"ci.pipeline.run.user":                 "SYSTEM",
+					"jenkins.pipeline.step.id":             "7",
+					"jenkins.pipeline.step.name":           "PowerShell Core Script",
+					"jenkins.pipeline.step.plugin.name":    "workflow-durable-task-step",
+					"jenkins.pipeline.step.plugin.version": "1353.v1891a_b_01da_18",
+					"jenkins.pipeline.step.type":           "pwsh",
+					"harness-attribute":                    "{\n  \"script\" : \"Write-Output \\\"Hello from powershell\\\"\"\n}",
+					"harness-others":                       "-WATCHING_RECURRENCE_PERIOD-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep WATCHING_RECURRENCE_PERIOD-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.WATCHING_RECURRENCE_PERIOD-long-USE_WATCHING-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep USE_WATCHING-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING-boolean-REMOTE_TIMEOUT-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep REMOTE_TIMEOUT-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT-long",
+				},
+				Name:         "pwsh-test #4",
+				Parent:       "pwsh-test",
+				ParentSpanId: "ae814e400d403a68",
+				SpanId:       "48add07c4c323c37",
+				SpanName:     "pwsh",
+				TraceId:      "c7ae9b130161e9586c66041e8022c888",
+				Type:         "Run Phase Span",
+				ParameterMap: map[string]any{"script": "Write-Output \"Hello from powershell\""},
+			},
+		},
+	}
+	for i, test := range tests {
+		got := test.json
+		if diff := cmp.Diff(got, test.want); diff != "" {
+			t.Errorf("Unexpected parsing results for test %v", i)
+			t.Log(diff)
+		}
+	}
+}


### PR DESCRIPTION
Added "pwsh" support to go-convert specific to jenkins migration.

PWSH Jenkins Trace: [pwsh-test__4.json](https://github.com/user-attachments/files/16837700/pwsh-test__4.json)

Test Output:
```bash
go run main.go jenkinsjson -downgrade pwsh-test__4.json
```
```
pipeline:
  identifier: default
  name: default
  orgIdentifier: default
  projectIdentifier: default
  properties:
    ci:
      codebase:
        build: <+input>
  stages:
  - stage:
      identifier: build
      name: build
      spec:
        cloneCodebase: true
        execution:
          steps:
          - stepGroup:
              identifier: Stage__nullebf434
              name: example
              steps:
              - step:
                  identifier: pwsh48add0
                  name: pwsh
                  spec:
                    command: Write-Output "Hello from powershell"
                    image: mcr.microsoft.com/powershell
                    shell: Pwsh
                  timeout: ""
                  type: Run
              timeout: ""
        platform:
          arch: Amd64
          os: Linux
        runtime:
          spec: {}
          type: Cloud
      type: CI
```