### PR TITLE
feat: [CI-14420]: FileOps migration: FileCreateOperation support

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -549,6 +549,52 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 
 	case "untar":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertUntar(currentNode, variables), ID: id})
+	case "fileOperations":
+		// Step 1: Extract the 'delegate' map from the 'parameterMap'
+		delegate, ok := currentNode.ParameterMap["delegate"].(map[string]interface{})
+		if !ok {
+			fmt.Println("Missing 'delegate' in parameterMap")
+			break
+		}
+
+		// Step 2: Extract the 'arguments' map from the 'delegate'
+		arguments, ok := delegate["arguments"].(map[string]interface{})
+		if !ok {
+			fmt.Println("Missing 'arguments' in delegate map")
+			break
+		}
+
+		// Step 3: Extract the list of anonymous operations
+		anonymousOps, ok := arguments["<anonymous>"].([]interface{})
+		if !ok {
+			fmt.Println("No anonymous operations found in arguments")
+			break
+		}
+
+		// Step 4: Iterate over each operation and handle based on the 'symbol' type
+		for _, op := range anonymousOps {
+			// Convert the operation to a map for easy access
+			operation, ok := op.(map[string]interface{})
+			if !ok {
+				fmt.Println("Invalid operation format")
+				continue
+			}
+
+			// Extract the 'symbol' to determine the type of file operation
+			symbol, ok := operation["symbol"].(string)
+			if !ok {
+				fmt.Println("Operation symbol not found or not a string")
+				continue
+			}
+
+			// Step 5: Process each operation based on its 'symbol'
+			switch symbol {
+			case "fileCreateOperation":
+				*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertFileCreate(currentNode, operation), ID: id})
+			default:
+				fmt.Println("Unsupported file operation:", symbol)
+			}
+		}
 
 	default:
 		placeholderStr := fmt.Sprintf("echo %q", "This is a place holder for: "+currentNode.AttributesMap["jenkins.pipeline.step.type"])

--- a/convert/jenkinsjson/convertTestFiles/fileOps/fileOpsCreate/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/fileOps/fileOpsCreate/Jenkinsfile
@@ -1,0 +1,12 @@
+pipeline {
+    agent any
+    stages {
+        stage('Create File') {
+            steps {
+                fileOperations([
+                    fileCreateOperation(fileName: 'newfile.txt', fileContent: 'Hello, World!')
+                ])
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/fileOps/fileOpsCreate/fileOpsCreate.yaml
+++ b/convert/jenkinsjson/convertTestFiles/fileOps/fileOpsCreate/fileOpsCreate.yaml
@@ -1,0 +1,8 @@
+- step:
+    identifier: fileoperations9b3c55
+    name: fileCreateOperation
+    spec:
+      command: 'echo ''Hello, World!'' > newfile.txt'
+      image: alpine
+    timeout: ''
+    type: Run

--- a/convert/jenkinsjson/convertTestFiles/fileOps/fileOpsCreate/fileOpsCreate_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/fileOps/fileOpsCreate/fileOpsCreate_snippet.json
@@ -1,0 +1,43 @@
+{
+    "spanId": "9b3c555cf009005f",
+    "traceId": "5c4a042d6d48afeba2d56a38cb497c1e",
+    "parent": "op-filecreateoperations",
+    "name": "op-filecreateoperations #2",
+    "attributesMap": {
+        "harness-others": "-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep",
+        "jenkins.pipeline.step.name": "File Operations",
+        "ci.pipeline.run.user": "SYSTEM",
+        "jenkins.pipeline.step.id": "7",
+        "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@5fad4a0b": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@5fad4a0b",
+        "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1e9f64fb": "org.jenkinsci.plugins.workflow.actions.TimingAction@1e9f64fb",
+        "jenkins.pipeline.step.type": "fileOperations",
+        "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@bd3676d": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@bd3676d",
+        "harness-attribute": "{\n  \"delegate\" : {\n    \"symbol\" : \"fileOperations\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"<anonymous>\" : [ {\n        \"symbol\" : \"fileCreateOperation\",\n        \"klass\" : null,\n        \"arguments\" : {\n          \"fileName\" : \"newfile.txt\",\n          \"fileContent\" : \"Hello, World!\"\n        },\n        \"model\" : null,\n        \"interpolatedStrings\" : [ ]\n      } ]\n    },\n    \"model\" : null\n  }\n}",
+        "jenkins.pipeline.step.plugin.name": "file-operations",
+        "jenkins.pipeline.step.plugin.version": "266.v9d4e1eb_235b_a_"
+    },
+    "type": "Run Phase Span",
+    "parentSpanId": "5fc14ef50c3e4cda",
+    "parameterMap": {
+        "delegate": {
+            "symbol": "fileOperations",
+            "klass": null,
+            "arguments": {
+                "<anonymous>": [
+                    {
+                        "symbol": "fileCreateOperation",
+                        "klass": null,
+                        "interpolatedStrings": [],
+                        "arguments": {
+                            "fileName": "newfile.txt",
+                            "fileContent": "Hello, World!"
+                        },
+                        "model": null
+                    }
+                ]
+            },
+            "model": null
+        }
+    },
+    "spanName": "fileOperations"
+}

--- a/convert/jenkinsjson/json/fileOperations.go
+++ b/convert/jenkinsjson/json/fileOperations.go
@@ -1,0 +1,24 @@
+package json
+
+import (
+	"fmt"
+
+	harness "github.com/drone/spec/dist/go"
+)
+
+// createFileCreateStep creates a Harness step for file Create operations.
+func ConvertFileCreate(node Node, operation map[string]interface{}) *harness.Step {
+	args := operation["arguments"].(map[string]interface{})
+	fileName, _ := args["fileName"].(string)
+	fileContent, _ := args["fileContent"].(string)
+	createFileStep := &harness.Step{
+		Name: operation["symbol"].(string),
+		Type: "script",
+		Id:   SanitizeForId(node.SpanName, node.SpanId),
+		Spec: &harness.StepExec{
+			Image: "alpine",
+			Run:   fmt.Sprintf("echo '%s' > %s", fileContent, fileName),
+		},
+	}
+	return createFileStep
+}

--- a/convert/jenkinsjson/json/fileOperations_test.go
+++ b/convert/jenkinsjson/json/fileOperations_test.go
@@ -2,13 +2,21 @@ package json
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	harness "github.com/drone/spec/dist/go"
 	"github.com/google/go-cmp/cmp"
 )
+
+type testRunner struct {
+	name  string
+	input Node
+	want  *harness.Step
+}
 
 func TestConvertFileOpsCreate(t *testing.T) {
 	// Get the working directory
@@ -89,4 +97,85 @@ func TestConvertFileOpsCreate(t *testing.T) {
 			t.Log(diff)
 		}
 	}
+}
+
+func prepareFileOpsTest(t *testing.T, filename string, folderName string, step *harness.Step) testRunner {
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	jsonData, err := os.ReadFile(filepath.Join(workingDir, "../convertTestFiles/fileOps/"+folderName, filename+".json"))
+	if err != nil {
+		t.Fatalf("failed to read JSON file: %v", err)
+	}
+
+	var inputNode Node
+	if err := json.Unmarshal(jsonData, &inputNode); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	return testRunner{
+		name:  filename,
+		input: inputNode,
+		want:  step,
+	}
+}
+
+func TestConvertFileOpsCreateFunction(t *testing.T) {
+
+	var tests []testRunner
+	tests = append(tests, prepareFileOpsTest(t, "fileOpsCreate_snippet", "fileOpsCreate", &harness.Step{
+		Id:   "fileOperations9b3c55",
+		Name: "fileCreateOperation",
+		Type: "script",
+		Spec: &harness.StepExec{
+			Image: "alpine",
+			Run:   string("echo 'Hello, World!' > newfile.txt"),
+		},
+	}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			operation := extractAnanymousOperation(tt.input)
+			got := ConvertFileCreate(tt.input, operation)
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("ConvertFileCreate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func extractAnanymousOperation(currentNode Node) map[string]interface{} {
+	// Step 1: Extract the 'delegate' map from the 'parameterMap'
+	delegate, ok := currentNode.ParameterMap["delegate"].(map[string]interface{})
+	if !ok {
+		fmt.Println("Missing 'delegate' in parameterMap")
+	}
+
+	// Step 2: Extract the 'arguments' map from the 'delegate'
+	arguments, ok := delegate["arguments"].(map[string]interface{})
+	if !ok {
+		fmt.Println("Missing 'arguments' in delegate map")
+	}
+
+	// Step 3: Extract the list of anonymous operations
+	anonymousOps, ok := arguments["<anonymous>"].([]interface{})
+	if !ok {
+		fmt.Println("No anonymous operations found in arguments")
+	}
+	var extractedOperation map[string]interface{}
+	// Step 4: Iterate over each operation and handle based on the 'symbol' type
+	for _, op := range anonymousOps {
+		// Convert the operation to a map for easy access
+		operation, ok := op.(map[string]interface{})
+		if !ok {
+			fmt.Println("Invalid operation format")
+			continue
+		}
+		extractedOperation = operation
+	}
+	return extractedOperation
 }

--- a/convert/jenkinsjson/json/fileOperations_test.go
+++ b/convert/jenkinsjson/json/fileOperations_test.go
@@ -1,0 +1,92 @@
+package json
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertFileOpsCreate(t *testing.T) {
+	// Get the working directory
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	// Update file path according to the location of fileOps_test.json
+	filePath := filepath.Join(workingDir, "../convertTestFiles/fileOps/fileOpsCreate/fileOpsCreate_snippet.json")
+	jsonData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read JSON file: %v", err)
+	}
+
+	// Unmarshal the JSON into a Node struct
+	var node1 Node
+	if err := json.Unmarshal(jsonData, &node1); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	tests := []struct {
+		json Node
+		want Node
+	}{
+		{
+			json: node1,
+			want: Node{
+				SpanId:  "9b3c555cf009005f",
+				TraceId: "5c4a042d6d48afeba2d56a38cb497c1e",
+				Parent:  "op-filecreateoperations",
+				Name:    "op-filecreateoperations #2",
+				AttributesMap: map[string]string{
+					"harness-others":             "-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep",
+					"jenkins.pipeline.step.name": "File Operations",
+					"ci.pipeline.run.user":       "SYSTEM",
+					"jenkins.pipeline.step.id":   "7",
+					"harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@5fad4a0b": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@5fad4a0b",
+					"harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1e9f64fb":           "org.jenkinsci.plugins.workflow.actions.TimingAction@1e9f64fb",
+					"jenkins.pipeline.step.type": "fileOperations",
+					"harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@bd3676d": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@bd3676d",
+					"harness-attribute":                    "{\n  \"delegate\" : {\n    \"symbol\" : \"fileOperations\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"<anonymous>\" : [ {\n        \"symbol\" : \"fileCreateOperation\",\n        \"klass\" : null,\n        \"arguments\" : {\n          \"fileName\" : \"newfile.txt\",\n          \"fileContent\" : \"Hello, World!\"\n        },\n        \"model\" : null,\n        \"interpolatedStrings\" : [ ]\n      } ]\n    },\n    \"model\" : null\n  }\n}",
+					"jenkins.pipeline.step.plugin.name":    "file-operations",
+					"jenkins.pipeline.step.plugin.version": "266.v9d4e1eb_235b_a_",
+				},
+				ParentSpanId: "5fc14ef50c3e4cda",
+				SpanName:     "fileOperations",
+				Type:         "Run Phase Span",
+				ParameterMap: map[string]interface{}{
+					"delegate": map[string]interface{}{
+						"symbol": "fileOperations",
+						"klass":  nil,
+						"arguments": map[string]interface{}{
+							"<anonymous>": []interface{}{
+								map[string]interface{}{
+									"symbol":              "fileCreateOperation",
+									"klass":               nil,
+									"interpolatedStrings": []interface{}{},
+									"arguments": map[string]interface{}{
+										"fileName":    "newfile.txt",
+										"fileContent": "Hello, World!",
+									},
+									"model": nil,
+								},
+							},
+						},
+						"model": nil,
+					},
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		got := test.json
+		if diff := cmp.Diff(got, test.want); diff != "" {
+			t.Errorf("Unexpected parsing results for test %v", i)
+			t.Log(diff)
+		}
+	}
+}


### PR DESCRIPTION
Added "FileCreateOperation " support to go
[fileCreateOperation.json](https://github.com/user-attachments/files/17213426/fileCreateOperation.json)

Output V0 yaml:

pipeline:
  identifier: default
  name: default
  orgIdentifier: default
  projectIdentifier: default
  properties:
    ci:
      codebase:
        build: <+input>
  stages:
  - stage:
      identifier: build
      name: build
      spec:
        cloneCodebase: true
        execution:
          steps:
          - stepGroup:
              identifier: Stage__null2771a5
              name: Create File
              steps:
              - step:
                  identifier: fileoperations9b3c55
                  name: fileCreateOperation
                  spec:
                    command: echo 'Hello, World!' > newfile.txt
                    image: alpine
                  timeout: ""
                  type: Run
              timeout: ""
        platform:
          arch: Amd64
          os: Linux
        runtime:
          spec: {}
          type: Cloud
      type: CI