### PR TITLE
fix: [CI-14643]: fixed error occuring while downgrading dockerPushStep and artifactUpload.

### DIFF
--- a/convert/harness/downgrader/downgrade.go
+++ b/convert/harness/downgrader/downgrade.go
@@ -546,7 +546,7 @@ func (d *Downgrader) convertStepBackground(src *v1.Step) *v0.Step {
 func (d *Downgrader) convertStepPlugin(src *v1.Step) *v0.Step {
 	spec_ := src.Spec.(*v1.StepPlugin)
 
-	if strings.Contains(spec_.Image, "kaniko-docker") {
+	if strings.Contains(spec_.Image, "plugins/kaniko:latest") {
 		return d.convertStepPluginToDocker(src)
 	}
 
@@ -559,7 +559,7 @@ func (d *Downgrader) convertStepPlugin(src *v1.Step) *v0.Step {
 	}
 
 	switch spec_.Image {
-	case "checkout_plugin":
+	case "plugins/drone-git:latest":
 		setting := convertSettings(spec_.With)
 		return &v0.Step{
 			ID:   id,
@@ -573,7 +573,7 @@ func (d *Downgrader) convertStepPlugin(src *v1.Step) *v0.Step {
 			},
 			When: convertStepWhen(src.When, id),
 		}
-	case "artifactJfrog_plugin":
+	case "plugins/artifactory:latest":
 		setting := convertSettings(spec_.With)
 		return &v0.Step{
 			ID:   id,
@@ -582,7 +582,7 @@ func (d *Downgrader) convertStepPlugin(src *v1.Step) *v0.Step {
 
 			Spec: &v0.StepArtifactoryUpload{
 				Target:     setting["target"].(string),
-				SourcePath: setting["sourcePath"].(string),
+				SourcePath: setting["source"].(string),
 			},
 			When: convertStepWhen(src.When, id),
 		}


### PR DESCRIPTION
Error was in line - 585 of case "plugins/artifactory:latest" inside downgrade.go. Instead of sourcePath it should be source.

Sample yaml before downgrading - 
```yaml
version: 1
kind: pipeline
type: ""
name: ""
spec:
  stages:
  - desc: ""
    id: build
    name: build
    strategy: null
    delegate: []
    status: null
    type: ci
    when: null
    failure: null
    inputs: {}
    spec:
      cache: null
      clone: null
      platform: null
      runtime: null
      steps:
      - id: Stage__null6c2707
        name: Build image
        desc: ""
        type: group
        timeout: ""
        strategy: null
        when: null
        failure: null
        inputs: {}
        spec:
          steps: []
      - id: Stage__null92ca9e
        name: Push image to Artifactory
        desc: ""
        type: group
        timeout: ""
        strategy: null
        when: null
        failure: null
        inputs: {}
        spec:
          steps:
          - id: rtDockerPushf4ba5f
            name: rtDockerPush
            desc: ""
            type: plugin
            timeout: ""
            strategy: null
            when: null
            failure: null
            inputs: {}
            spec:
              image: plugins/kaniko:latest
              name: ""
              uses: ""
              connector: ""
              pull: ""
              envs: {}
              reports: []
              privileged: false
              user: ""
              group: ""
              network: ""
              with:
                repo: 10.20.111.23:8081/docker-virtual/hello-world
                tags: latest
                target: local-repo
              inputs: {}
              outputs: []
              resources: null
              mount: []
      envs: {}
      volumes: []
  inputs: {}
  options: null
```
Yaml after downgrading - 
```yaml
pipeline:
  identifier: default
  name: default
  orgIdentifier: default
  projectIdentifier: default
  properties:
    ci:
      codebase:
        build: <+input>
  stages:
  - stage:
      identifier: build
      name: build
      spec:
        cloneCodebase: true
        execution:
          steps:
          - stepGroup:
              identifier: Stage__null6c2707
              name: Build image
              timeout: ""
          - stepGroup:
              identifier: Stage__null92ca9e
              name: Push image to Artifactory
              steps:
              - step:
                  identifier: rtdockerpushf4ba5f
                  name: rtDockerPush
                  spec:
                    caching: true
                    connectorRef: <+input>
                    repo: 10.20.111.23:8081/docker-virtual/hello-world
                    tags:
                    - latest
                    target: local-repo
                  timeout: ""
                  type: BuildAndPushDockerRegistry
              timeout: ""
        platform:
          arch: Amd64
          os: Linux
        runtime:
          spec: {}
          type: Cloud
      type: CI
```