### PR TITLE
nunit go-conversion

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -636,6 +636,22 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 	case "jiraSendDeploymentInfo":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertJiraDeploymentInfo(currentNode, variables), ID: id})
 
+	case "nunit":
+		// Step 1: Extract the 'delegate' map from the 'parameterMap'
+		delegate, ok := currentNode.ParameterMap["delegate"].(map[string]interface{})
+		if !ok {
+			fmt.Println("Missing 'delegate' in parameterMap")
+			break
+		}
+
+		// Step 2: Extract the 'arguments' map from the 'delegate'
+		arguments, ok := delegate["arguments"].(map[string]interface{})
+		if !ok {
+			fmt.Println("Missing 'arguments' in delegate map")
+			break
+		}
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertNunit(currentNode, arguments), ID: id})
+
 	default:
 		placeholderStr := fmt.Sprintf("echo %q", "This is a place holder for: "+currentNode.AttributesMap["jenkins.pipeline.step.type"])
 		b, err := json.MarshalIndent(currentNode.ParameterMap, "", "  ")

--- a/convert/jenkinsjson/convertTestFiles/nunit/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/nunit/Jenkinsfile
@@ -1,0 +1,39 @@
+pipeline {
+    agent any
+    stages {
+        stage('Run NUnit') {
+            steps {
+            	writeFile(file: "TestResult.xml", text: '''
+       			<test-run id="2" duration="0.0015729000000000001" testcasecount="11" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:06Z" end-time="2024-09-18T 21:41:07Z">
+  <test-suite type="Assembly" name="PrimeService.Tests.dll" fullname="/opt/PrimeService.Tests/bin/Debug/net8.0/PrimeService.Tests.dll" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
+    <test-suite type="TestSuite" name="PrimeService" fullname="PrimeService" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
+      <test-suite type="TestSuite" name="Tests" fullname="PrimeService.Tests" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
+        <test-suite type="TestSuite" name="PrimeService" fullname="PrimeService.Tests.PrimeService" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
+          <test-suite type="TestSuite" name="Tests" fullname="PrimeService.Tests.PrimeService.Tests" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
+            <test-suite type="TestFixture" name="PrimeService_IsPrimeShould" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
+              <test-case name="IsPrime_NonPrimesLessThan10_ReturnFalse(4)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_NonPrimesLessThan10_ReturnFalse(4)" methodname="IsPrime_NonPrimesLessThan10_ReturnFalse(4)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.00125" asserts="0" />
+              <test-case name="IsPrime_NonPrimesLessThan10_ReturnFalse(6)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_NonPrimesLessThan10_ReturnFalse(6)" methodname="IsPrime_NonPrimesLessThan10_ReturnFalse(6)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="9.3E-05" asserts="0" />
+              <test-case name="IsPrime_NonPrimesLessThan10_ReturnFalse(8)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_NonPrimesLessThan10_ReturnFalse(8)" methodname="IsPrime_NonPrimesLessThan10_ReturnFalse(8)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="4E-06" asserts="0" />
+              <test-case name="IsPrime_NonPrimesLessThan10_ReturnFalse(9)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_NonPrimesLessThan10_ReturnFalse(9)" methodname="IsPrime_NonPrimesLessThan10_ReturnFalse(9)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="2E-06" asserts="0" />
+              <test-case name="IsPrime_PrimesLessThan10_ReturnTrue(2)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_PrimesLessThan10_ReturnTrue(2)" methodname="IsPrime_PrimesLessThan10_ReturnTrue(2)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="9.8E-05" asserts="0" />
+              <test-case name="IsPrime_PrimesLessThan10_ReturnTrue(3)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_PrimesLessThan10_ReturnTrue(3)" methodname="IsPrime_PrimesLessThan10_ReturnTrue(3)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="5.2E-05" asserts="0" />
+              <test-case name="IsPrime_PrimesLessThan10_ReturnTrue(5)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_PrimesLessThan10_ReturnTrue(5)" methodname="IsPrime_PrimesLessThan10_ReturnTrue(5)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="2E-06" asserts="0" />
+              <test-case name="IsPrime_PrimesLessThan10_ReturnTrue(7)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_PrimesLessThan10_ReturnTrue(7)" methodname="IsPrime_PrimesLessThan10_ReturnTrue(7)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="1E-06" asserts="0" />
+              <test-case name="IsPrime_ValuesLessThan2_ReturnFalse(-1)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_ValuesLessThan2_ReturnFalse(-1)" methodname="IsPrime_ValuesLessThan2_ReturnFalse(-1)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="3.49E-05" asserts="0" />
+              <test-case name="IsPrime_ValuesLessThan2_ReturnFalse(0)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_ValuesLessThan2_ReturnFalse(0)" methodname="IsPrime_ValuesLessThan2_ReturnFalse(0)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="3.4E-05" asserts="0" />
+              <test-case name="IsPrime_ValuesLessThan2_ReturnFalse(1)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_ValuesLessThan2_ReturnFalse(1)" methodname="IsPrime_ValuesLessThan2_ReturnFalse(1)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="2E-06" asserts="0" />
+            </test-suite>
+          </test-suite>
+        </test-suite>
+      </test-suite>
+    </test-suite>
+    <errors />
+  </test-suite>
+</test-run>	
+            	'''
+            	, encoding: "UTF-8")
+                nunit testResultsPattern: 'TestResult.xml', failIfNoResults: true, skipJUnitArchiver: false, failedTestsFailBuild: true
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/nunit/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/nunit/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
         stage('Run NUnit') {
             steps {
                 script {
-                    def xmlFileUrl = 'https://raw.githubusercontent.com/harness-community/test-jenkins-to-harness/refs/heads/main/nunit-test-result.xml' // Replace with the actual URL
+                    def xmlFileUrl = 'https://raw.githubusercontent.com/harness-community/test-jenkins-to-harness/refs/heads/main/nunit-test-result.xml'
                     def outputFilePath = 'TestResult.xml'
                     
                     bat """

--- a/convert/jenkinsjson/convertTestFiles/nunit/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/nunit/Jenkinsfile
@@ -3,35 +3,14 @@ pipeline {
     stages {
         stage('Run NUnit') {
             steps {
-            	writeFile(file: "TestResult.xml", text: '''
-       			<test-run id="2" duration="0.0015729000000000001" testcasecount="11" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:06Z" end-time="2024-09-18T 21:41:07Z">
-  <test-suite type="Assembly" name="PrimeService.Tests.dll" fullname="/opt/PrimeService.Tests/bin/Debug/net8.0/PrimeService.Tests.dll" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
-    <test-suite type="TestSuite" name="PrimeService" fullname="PrimeService" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
-      <test-suite type="TestSuite" name="Tests" fullname="PrimeService.Tests" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
-        <test-suite type="TestSuite" name="PrimeService" fullname="PrimeService.Tests.PrimeService" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
-          <test-suite type="TestSuite" name="Tests" fullname="PrimeService.Tests.PrimeService.Tests" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
-            <test-suite type="TestFixture" name="PrimeService_IsPrimeShould" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould" total="11" passed="11" failed="0" inconclusive="0" skipped="0" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.0015729">
-              <test-case name="IsPrime_NonPrimesLessThan10_ReturnFalse(4)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_NonPrimesLessThan10_ReturnFalse(4)" methodname="IsPrime_NonPrimesLessThan10_ReturnFalse(4)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="0.00125" asserts="0" />
-              <test-case name="IsPrime_NonPrimesLessThan10_ReturnFalse(6)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_NonPrimesLessThan10_ReturnFalse(6)" methodname="IsPrime_NonPrimesLessThan10_ReturnFalse(6)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="9.3E-05" asserts="0" />
-              <test-case name="IsPrime_NonPrimesLessThan10_ReturnFalse(8)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_NonPrimesLessThan10_ReturnFalse(8)" methodname="IsPrime_NonPrimesLessThan10_ReturnFalse(8)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="4E-06" asserts="0" />
-              <test-case name="IsPrime_NonPrimesLessThan10_ReturnFalse(9)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_NonPrimesLessThan10_ReturnFalse(9)" methodname="IsPrime_NonPrimesLessThan10_ReturnFalse(9)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="2E-06" asserts="0" />
-              <test-case name="IsPrime_PrimesLessThan10_ReturnTrue(2)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_PrimesLessThan10_ReturnTrue(2)" methodname="IsPrime_PrimesLessThan10_ReturnTrue(2)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="9.8E-05" asserts="0" />
-              <test-case name="IsPrime_PrimesLessThan10_ReturnTrue(3)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_PrimesLessThan10_ReturnTrue(3)" methodname="IsPrime_PrimesLessThan10_ReturnTrue(3)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="5.2E-05" asserts="0" />
-              <test-case name="IsPrime_PrimesLessThan10_ReturnTrue(5)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_PrimesLessThan10_ReturnTrue(5)" methodname="IsPrime_PrimesLessThan10_ReturnTrue(5)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="2E-06" asserts="0" />
-              <test-case name="IsPrime_PrimesLessThan10_ReturnTrue(7)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_PrimesLessThan10_ReturnTrue(7)" methodname="IsPrime_PrimesLessThan10_ReturnTrue(7)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="1E-06" asserts="0" />
-              <test-case name="IsPrime_ValuesLessThan2_ReturnFalse(-1)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_ValuesLessThan2_ReturnFalse(-1)" methodname="IsPrime_ValuesLessThan2_ReturnFalse(-1)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="3.49E-05" asserts="0" />
-              <test-case name="IsPrime_ValuesLessThan2_ReturnFalse(0)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_ValuesLessThan2_ReturnFalse(0)" methodname="IsPrime_ValuesLessThan2_ReturnFalse(0)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="3.4E-05" asserts="0" />
-              <test-case name="IsPrime_ValuesLessThan2_ReturnFalse(1)" fullname="PrimeService.Tests.PrimeService.Tests.PrimeService_IsPrimeShould.IsPrime_ValuesLessThan2_ReturnFalse(1)" methodname="IsPrime_ValuesLessThan2_ReturnFalse(1)" classname="PrimeService_IsPrimeShould" result="Passed" start-time="2024-09-18T 21:41:07Z" end-time="2024-09-18T 21:41:07Z" duration="2E-06" asserts="0" />
-            </test-suite>
-          </test-suite>
-        </test-suite>
-      </test-suite>
-    </test-suite>
-    <errors />
-  </test-suite>
-</test-run>	
-            	'''
-            	, encoding: "UTF-8")
+                script {
+                    def xmlFileUrl = 'https://raw.githubusercontent.com/harness-community/test-jenkins-to-harness/refs/heads/main/nunit-test-result.xml' // Replace with the actual URL
+                    def outputFilePath = 'TestResult.xml'
+                    
+                    bat """
+                    powershell -Command "Invoke-WebRequest -Uri '${xmlFileUrl}' -OutFile '${outputFilePath}'"
+                    """
+                }
                 nunit testResultsPattern: 'TestResult.xml', failIfNoResults: true, skipJUnitArchiver: false, failedTestsFailBuild: true
             }
         }

--- a/convert/jenkinsjson/convertTestFiles/nunit/nunit.yaml
+++ b/convert/jenkinsjson/convertTestFiles/nunit/nunit.yaml
@@ -1,0 +1,11 @@
+- step:
+    identifier: nunit0d6d45
+    name: nunit
+    spec:
+      image: plugins/nunit
+      settings:
+        fail_if_no_results: 'true'
+        failed_tests_fail_build: 'true'
+        test_report_path: TestResult.xml
+    timeout: ''
+    type: Plugin

--- a/convert/jenkinsjson/convertTestFiles/nunit/nunit_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/nunit/nunit_snippet.json
@@ -1,0 +1,35 @@
+{
+    "spanId": "0d6d45a50c9f8dca",
+    "traceId": "717618b62f34567ed1c68e23f5e704c5",
+    "parent": "nunit",
+    "all-info": "span(name: nunit, spanId: 0d6d45a50c9f8dca, parentSpanId: 016f060e63807a96, traceId: 717618b62f34567ed1c68e23f5e704c5, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"delegate\" : {\n    \"symbol\" : \"nunit\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"failIfNoResults\" : true,\n      \"failedTestsFailBuild\" : true,\n      \"skipJUnitArchiver\" : false,\n      \"testResultsPattern\" : \"TestResult.xml\"\n    },\n    \"model\" : null\n  }\n};harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@3616fced:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@3616fced;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@74331ca3:org.jenkinsci.plugins.workflow.actions.TimingAction@74331ca3;harness-others:-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep;jenkins.pipeline.step.id:8;jenkins.pipeline.step.name:Publish NUnit test result report;jenkins.pipeline.step.plugin.name:nunit;jenkins.pipeline.step.plugin.version:485.ve8a_85357320d;jenkins.pipeline.step.type:nunit;)",
+    "name": "nunit #8",
+    "attributesMap": {
+        "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@74331ca3": "org.jenkinsci.plugins.workflow.actions.TimingAction@74331ca3",
+        "harness-others": "-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep",
+        "jenkins.pipeline.step.name": "Publish NUnit test result report",
+        "ci.pipeline.run.user": "SYSTEM",
+        "jenkins.pipeline.step.id": "8",
+        "jenkins.pipeline.step.type": "nunit",
+        "harness-attribute": "{\n  \"delegate\" : {\n    \"symbol\" : \"nunit\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"failIfNoResults\" : true,\n      \"failedTestsFailBuild\" : true,\n      \"skipJUnitArchiver\" : false,\n      \"testResultsPattern\" : \"TestResult.xml\"\n    },\n    \"model\" : null\n  }\n}",
+        "jenkins.pipeline.step.plugin.name": "nunit",
+        "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@3616fced": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@3616fced",
+        "jenkins.pipeline.step.plugin.version": "485.ve8a_85357320d"
+    },
+    "type": "Run Phase Span",
+    "parentSpanId": "016f060e63807a96",
+    "parameterMap": {
+        "delegate": {
+            "symbol": "nunit",
+            "klass": null,
+            "arguments": {
+                "skipJUnitArchiver": false,
+                "failIfNoResults": true,
+                "failedTestsFailBuild": true,
+                "testResultsPattern": "TestResult.xml"
+            },
+            "model": null
+        }
+    },
+    "spanName": "nunit"
+}

--- a/convert/jenkinsjson/json/nunit.go
+++ b/convert/jenkinsjson/json/nunit.go
@@ -1,0 +1,39 @@
+package json
+
+import (
+	"strings"
+
+	harness "github.com/drone/spec/dist/go"
+)
+
+// ConvertNunit creates a Harness step for nunit plugin.
+func ConvertNunit(node Node, arguments map[string]interface{}) *harness.Step {
+	testResultsPattern, _ := arguments["testResultsPattern"].(string)
+	failIfNoResults, _ := arguments["failIfNoResults"].(bool)
+	failedTestsFailBuild, _ := arguments["failedTestsFailBuild"].(bool)
+
+	resultArray := strings.Split(testResultsPattern, ",")
+
+	// Create a Report with the resultArray and type "junit"
+	report := harness.Report{
+		Type: "junit",
+		Path: resultArray,
+	}
+
+	convertNunit := &harness.Step{
+		Name: "nunit",
+		Type: "plugin",
+		Id:   SanitizeForId(node.SpanName, node.SpanId),
+		Spec: &harness.StepPlugin{
+			Image:   "plugins/nunit",
+			Reports: []*harness.Report{&report},
+			With: map[string]interface{}{
+				"test_report_path":        testResultsPattern,
+				"fail_if_no_results":      failIfNoResults,
+				"failed_tests_fail_build": failedTestsFailBuild,
+			},
+		},
+	}
+
+	return convertNunit
+}

--- a/convert/jenkinsjson/json/nunit_test.go
+++ b/convert/jenkinsjson/json/nunit_test.go
@@ -1,0 +1,55 @@
+package json
+
+import (
+	"fmt"
+	"testing"
+
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+)
+
+func extractArguments(currentNode Node) map[string]interface{} {
+	// Step 1: Extract the 'delegate' map from the 'parameterMap'
+	delegate, ok := currentNode.ParameterMap["delegate"].(map[string]interface{})
+	if !ok {
+		fmt.Println("Missing 'delegate' in parameterMap")
+	}
+
+	// Step 2: Extract the 'arguments' map from the 'delegate'
+	arguments, ok := delegate["arguments"].(map[string]interface{})
+	if !ok {
+		fmt.Println("Missing 'arguments' in delegate map")
+	}
+
+	return arguments
+}
+
+func TestConvertNunit(t *testing.T) {
+
+	var tests []runner
+	tests = append(tests, prepare(t, "/nunit/nunit_snippet", &harness.Step{
+		Id:   "nunit0d6d45",
+		Name: "nunit",
+		Type: "plugin",
+		Spec: &harness.StepPlugin{
+			Image:   "plugins/nunit",
+			Reports: []*harness.Report{{Path: harness.Stringorslice{"TestResult.xml"}, Type: "junit"}},
+			With: map[string]interface{}{
+				"test_report_path":        string("TestResult.xml"),
+				"fail_if_no_results":      bool(true),
+				"failed_tests_fail_build": bool(true),
+			},
+		},
+	}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			operation := extractArguments(tt.input)
+			got := ConvertNunit(tt.input, operation)
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("ConvertNunit() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -534,6 +534,21 @@ line3'''
                   , sourceFile: '*.md', uploadFromSlave: false]
                 ], profileName: 'default'
             }
+        }
+        //Nunit Stage
+        stage('Run NUnit') {
+            steps {
+                script {
+                    def xmlFileUrl = 'https://raw.githubusercontent.com/harness-community/test-jenkins-to-harness/refs/heads/main/nunit-test-result.xml'
+                    def outputFilePath = 'TestResult.xml'
+                    
+                    bat """
+                    powershell -Command "Invoke-WebRequest -Uri '${xmlFileUrl}' -OutFile '${outputFilePath}'"
+                    """
+                }
+                nunit testResultsPattern: 'TestResult.xml', failIfNoResults: true, skipJUnitArchiver: false, failedTestsFailBuild: true
+            }
         }	
     }
+    
 }


### PR DESCRIPTION
Nunit go-conversion:
Added "Nunit " support to go-convert specific to jenkins migration.

Nunit Jenkins Trace: [nunitTrace.json]

[nunitTrace.json](https://github.com/user-attachments/files/17381682/nunitTrace.json)

go run main.go jenkinsjson --downgrade ~/go/nunitTrace.json

Below is the resulted step in yaml:

```
- step:
    identifier: nunit0d6d45
    name: nunit
    spec:
      image: plugins/nunit
      settings:
        fail_if_no_results: 'true'
        failed_tests_fail_build: 'true'
        test_report_path: TestResult.xml
    timeout: ''
    type: Plugin
```