### PR TITLE
adding jacoco conversion step

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -627,6 +627,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 	case "httpRequest":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertHttpRequest(currentNode, variables), ID: id})
 
+	case "jacoco":
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertJacoco(currentNode, variables), ID: id})
+
 	case "readMavenPom":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertReadMavenPom(currentNode), ID: id})
 

--- a/convert/jenkinsjson/convertTestFiles/jacoco/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/jacoco/Jenkinsfile
@@ -1,0 +1,42 @@
+pipeline {
+	// Defined the maven docker image for maven build.
+	agent any
+	tools {
+        maven 'M3'
+        jdk 'jdk8'
+    }
+	stages {
+	stage('checkout scm') {
+		steps {
+        checkout([$class: 'GitSCM',
+		branches: [[name: "*/master"]],
+		doGenerateSubmoduleConfigurations: false,
+		extensions: [[$class: 'CleanCheckout']],
+		submoduleCfg: [],
+		userRemoteConfigs: [[ url: 'https://github.com/syamv/game-of-life.git']]])
+		}
+    }
+
+	// using the maven docker image for build
+    stage('maven build') {
+		steps {
+		sh 'mvn clean verify org.jacoco:jacoco-maven-plugin:prepare-agent package jacoco:report'
+		}
+
+    }
+	stage('Junit Testing') {
+		steps {
+		junit allowEmptyResults: true, skipPublishingChecks: true, testResults: '**/target/surefire-reports/TEST-*.xml'
+		}
+	}
+
+	stage('Jacoco reports') {
+		steps {
+		jacoco classPattern: '**/target/classes', execPattern: '**/**.exec', sourcePattern: '**/src/main'
+		//jacoco exclusionPattern: '**/*Test*.class', execPattern: '**/**.exec,**/target/*.exec', runAlways: true
+
+		}
+	}
+
+	}
+}

--- a/convert/jenkinsjson/convertTestFiles/jacoco/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/jacoco/Jenkinsfile
@@ -1,42 +1,55 @@
 pipeline {
-	// Defined the maven docker image for maven build.
-	agent any
-	tools {
-        maven 'M3'
-        jdk 'jdk8'
-    }
-	stages {
-	stage('checkout scm') {
-		steps {
+
+  agent any
+	
+  tools {
+    maven 'M3'
+    jdk 'jdk8'
+  }
+	
+  stages {
+    stage('checkout scm') {
+      steps {
         checkout([$class: 'GitSCM',
-		branches: [[name: "*/master"]],
-		doGenerateSubmoduleConfigurations: false,
-		extensions: [[$class: 'CleanCheckout']],
-		submoduleCfg: [],
-		userRemoteConfigs: [[ url: 'https://github.com/syamv/game-of-life.git']]])
-		}
+          branches: [
+            [name: "*/master"]
+          ],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'CleanCheckout']
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: [
+            [url: 'https://github.com/syamv/game-of-life.git']
+          ]
+        ])
+      }
     }
 
-	// using the maven docker image for build
     stage('maven build') {
-		steps {
-		sh 'mvn clean verify org.jacoco:jacoco-maven-plugin:prepare-agent package jacoco:report'
-		}
+      steps {
+        sh 'mvn clean verify org.jacoco:jacoco-maven-plugin:prepare-agent package jacoco:report'
+      }
 
     }
-	stage('Junit Testing') {
-		steps {
-		junit allowEmptyResults: true, skipPublishingChecks: true, testResults: '**/target/surefire-reports/TEST-*.xml'
-		}
-	}
 
-	stage('Jacoco reports') {
-		steps {
-		jacoco classPattern: '**/target/classes', execPattern: '**/**.exec', sourcePattern: '**/src/main'
-		//jacoco exclusionPattern: '**/*Test*.class', execPattern: '**/**.exec,**/target/*.exec', runAlways: true
+    stage('Jacoco reports') {
+      steps {
+        jacoco(
+          classPattern: '**/target/classes, **/WEB-INF/classes',
+          exclusionPattern: '**/controllers/*.class',
+          inclusionPattern: '**/*.class',
+          sourceInclusionPattern: '**/*.java',
+          sourceExclusionPattern: '**/controllers/*.java',
+          maximumBranchCoverage: '81',
+          maximumClassCoverage: '85',
+          maximumComplexityCoverage: '10',
+          maximumInstructionCoverage: '80',
+          maximumLineCoverage: '83',
+          maximumMethodCoverage: '84'
+        )
+      }
+    }
 
-		}
-	}
-
-	}
+  }
 }

--- a/convert/jenkinsjson/convertTestFiles/jacoco/jacoco.json
+++ b/convert/jenkinsjson/convertTestFiles/jacoco/jacoco.json
@@ -1,0 +1,34 @@
+{
+  "Name": "jacoco #26",
+  "Parent": "jacoco",
+  "SpanName": "jacoco",
+  "SpanId": "66be31db38207c76",
+  "ParentSpanId": "c236b1a66f1d20a0",
+  "TraceId": "d7e2308fed543055fbe737e417e6b092",
+  "Children": null,
+  "Type": "Run Phase Span",
+  "ParameterMap": {
+    "delegate": {
+      "arguments": {
+        "classPattern": "**/target/classes",
+        "execPattern": "**/**.exec",
+        "sourcePattern": "**/src/main"
+      },
+      "klass": null,
+      "model": null,
+      "symbol": "jacoco"
+    }
+  },
+  "AttributesMap": {
+    "ci.pipeline.run.user": "SYSTEM",
+    "harness-attribute": "{\n  \"delegate\" : {\n    \"symbol\" : \"jacoco\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"classPattern\" : \"**/target/classes\",\n      \"execPattern\" : \"**/**.exec\",\n      \"sourcePattern\" : \"**/src/main\"\n    },\n    \"model\" : null\n  }\n}",
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1fa030d3": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1fa030d3",
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@2573b66a": "org.jenkinsci.plugins.workflow.actions.TimingAction@2573b66a",
+    "harness-others": "-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep",
+    "jenkins.pipeline.step.id": "62",
+    "jenkins.pipeline.step.name": "Record JaCoCo coverage report",
+    "jenkins.pipeline.step.plugin.name": "jacoco",
+    "jenkins.pipeline.step.plugin.version": "3.3.6",
+    "jenkins.pipeline.step.type": "jacoco"
+  }
+}

--- a/convert/jenkinsjson/convertTestFiles/jacoco/jacoco.yaml
+++ b/convert/jenkinsjson/convertTestFiles/jacoco/jacoco.yaml
@@ -1,0 +1,23 @@
+- step:
+    identifier: jacoco66be31
+    name: jacoco
+    spec:
+      envVariables:
+        JAVA_HOME:
+          /Users/franciscojunior/.jenkins/tools/hudson.model.JDK/jdk8/zulu8.80.0.17-ca-jdk8.0.422-macosx_aarch64
+        M2_HOME:
+          /Users/franciscojunior/.jenkins/tools/hudson.tasks.Maven_MavenInstallation/M3
+        MAVEN_HOME:
+          /Users/franciscojunior/.jenkins/tools/hudson.tasks.Maven_MavenInstallation/M3
+        PATH+JDK:
+          /Users/franciscojunior/.jenkins/tools/hudson.model.JDK/jdk8/zulu8.80.0.17-ca-jdk8.0.422-macosx_aarch64/bin
+        PATH+MAVEN:
+          /Users/franciscojunior/.jenkins/tools/hudson.tasks.Maven_MavenInstallation/M3/bin
+      image: plugins/coverage-report
+      settings:
+        class_directories: '**/target/classes'
+        reports_path_pattern: '**/**.exec'
+        source_directories: '**/src/main'
+        tool: jacoco
+    timeout: ''
+    type: Plugin

--- a/convert/jenkinsjson/json/jacoco.go
+++ b/convert/jenkinsjson/json/jacoco.go
@@ -1,0 +1,41 @@
+package json
+
+import (
+	harness "github.com/drone/spec/dist/go"
+)
+
+var JacocoJenkinsToDroneParamMapperList = []JenkinsToDroneParamMapper{
+	{"changeBuildStatus", "fail_on_threshold", BoolType, nil},
+	{"classPattern", "class_directories", StringType, nil},
+	{"exclusionPattern", "class_exclusion_pattern", StringType, nil},
+	{"inclusionPattern", "class_inclusion_pattern", StringType, nil},
+	{"execPattern", "reports_path_pattern", StringType, nil},
+	{"skipCopyOfSrcFiles", "skip_source_copy", BoolType, nil},
+	{"sourcePattern", "source_directories", StringType, nil},
+	{"sourceExclusionPattern", "source_exclusion_pattern", StringType, nil},
+	{"sourceInclusionPattern", "source_inclusion_pattern", StringType, nil},
+	{"minimumBranchCoverage", "threshold_branch", Float64Type, nil},
+	{"minimumClassCoverage", "threshold_class", Float64Type, nil},
+	{"minimumComplexityCoverage", "threshold_complexity", Float64Type, nil},
+	{"minimumInstructionCoverage", "threshold_instruction", Float64Type, nil},
+	{"minimumLineCoverage", "threshold_line", Float64Type, nil},
+	{"minimumMethodCoverage", "threshold_method", Float64Type, nil},
+	// {"runAlways", "run_always", BoolType, nil},
+	{"tool", "tool", StringType, SetJacocoTool},
+}
+
+func ConvertJacoco(node Node, variables map[string]string) *harness.Step {
+
+	step := ConvertToStepUsingParameterMapDelegate(&node, variables, JacocoJenkinsToDroneParamMapperList,
+		CoverageReportImage)
+
+	return step
+}
+
+func SetJacocoTool(node *Node, attrMap map[string]interface{}, jenkinsKey string) (interface{}, error) {
+	return "jacoco", nil
+}
+
+const (
+	CoverageReportImage = "plugins/coverage-report"
+)

--- a/convert/jenkinsjson/json/jacoco_test.go
+++ b/convert/jenkinsjson/json/jacoco_test.go
@@ -1,0 +1,67 @@
+package json
+
+import (
+	"encoding/json"
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestJacocoCoverage(t *testing.T) {
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	filePath := filepath.Join(workingDir, "../convertTestFiles/jacoco/jacoco.json")
+
+	jsonData, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read JSON file: %v", err)
+	}
+
+	var node Node
+	if err := json.Unmarshal(jsonData, &node); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	variables := make(map[string]string)
+
+	tmpTestStep := ConvertToStepUsingParameterMapDelegate(&node, variables, JacocoJenkinsToDroneParamMapperList,
+		CoverageReportImage)
+
+	wantStep, err := ToStructFromJsonString[harness.Step](expectedJacocoStepJSON)
+	if err != nil {
+		t.Fatalf("want step : %v", err)
+	}
+
+	diffs := cmp.Diff(wantStep, *tmpTestStep)
+
+	if len(diffs) != 0 {
+		t.Fatalf("failed to convert JSON to struct: %v", diffs)
+	}
+
+}
+
+var expectedJacocoStepJSON = `{
+    "id": "jacoco66be31",
+    "name": "jacoco",
+    "type": "plugin",
+    "spec": {
+        "image": "plugins/coverage-report",
+        "with": {
+            "class_directories": "**/target/classes",
+            "reports_path_pattern": "**/**.exec",
+            "source_directories": "**/src/main",
+            "tool": "jacoco"
+        },
+        "inputs": {
+            "class_directories": "**/target/classes",
+            "reports_path_pattern": "**/**.exec",
+            "source_directories": "**/src/main",
+            "tool": "jacoco"
+        }
+    }
+}`

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -534,6 +534,23 @@ line3'''
                   , sourceFile: '*.md', uploadFromSlave: false]
                 ], profileName: 'default'
             }
-        }	
+        }
+        stage('Jacoco reports') {
+          steps {
+            jacoco(
+              classPattern: '**/target/classes, **/WEB-INF/classes',
+              exclusionPattern: '**/controllers/*.class',
+              inclusionPattern: '**/*.class',
+              sourceInclusionPattern: '**/*.java',
+              sourceExclusionPattern: '**/controllers/*.java',
+              maximumBranchCoverage: '81',
+              maximumClassCoverage: '85',
+              maximumComplexityCoverage: '10',
+              maximumInstructionCoverage: '80',
+              maximumLineCoverage: '83',
+              maximumMethodCoverage: '84'
+            )
+          }
+        }
     }
 }


### PR DESCRIPTION
Jaoco Conversion:
Added "jacoco" support to go-convert specific to Jenkins migration

Jacoco Jenkins Trace file:

[jacoco_jenkins_trace.json](https://github.com/user-attachments/files/17523136/jacoco_jenkins_trace.json)

Conversion command used:
go run main.go   jenkinsjson --downgrade <path_prefix>/Jacoco-JenkinsFile

Generated step as YAML

```yaml
- step:
    identifier: jacoco66be31
    name: jacoco
    spec:
      envVariables:
        JAVA_HOME:
          /Users/franciscojunior/.jenkins/tools/hudson.model.JDK/jdk8/zulu8.80.0.17-ca-jdk8.0.422-macosx_aarch64
        M2_HOME:
          /Users/franciscojunior/.jenkins/tools/hudson.tasks.Maven_MavenInstallation/M3
        MAVEN_HOME:
          /Users/franciscojunior/.jenkins/tools/hudson.tasks.Maven_MavenInstallation/M3
        PATH+JDK:
          /Users/franciscojunior/.jenkins/tools/hudson.model.JDK/jdk8/zulu8.80.0.17-ca-jdk8.0.422-macosx_aarch64/bin
        PATH+MAVEN:
          /Users/franciscojunior/.jenkins/tools/hudson.tasks.Maven_MavenInstallation/M3/bin
      image: plugins/coverage-report
      settings:
        class_directories: '**/target/classes'
        reports_path_pattern: '**/**.exec'
        source_directories: '**/src/main'
        tool: jacoco
    timeout: ''
    type: Plugin`
```

