### PR TITLE
feat: [CI-14710]: Javadoc Conversion Logic

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -667,6 +667,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 			*stepWithIDList = append(*stepWithIDList, StepWithID{Step: step, ID: id})
 		}
 
+	case "javadoc":
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertJavadoc(currentNode, variables), ID: id})
+
 	default:
 		placeholderStr := fmt.Sprintf("echo %q", "This is a place holder for: "+currentNode.AttributesMap["jenkins.pipeline.step.type"])
 		b, err := json.MarshalIndent(currentNode.ParameterMap, "", "  ")

--- a/convert/jenkinsjson/convertTestFiles/javadoc/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/javadoc/Jenkinsfile
@@ -1,0 +1,25 @@
+pipeline {
+    agent any
+    stages {
+        stage('Checkout') {
+            steps {
+                git url: 'https://github.com/spring-guides/gs-rest-service.git', branch: 'main'
+            }
+        }
+        stage('Build') {
+            steps {
+                sh 'cd complete && gradle clean build --info --stacktrace'
+            }
+        }
+        stage('Generate Javadoc') {
+            steps {
+                sh 'cd complete && gradle javadoc --info --stacktrace'
+            }
+        }
+        stage('Publish Javadoc') {
+            steps {
+                javadoc javadocDir: 'complete/build/docs/javadoc', keepAll: true
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/javadoc/javadoc.yml
+++ b/convert/jenkinsjson/convertTestFiles/javadoc/javadoc.yml
@@ -12,7 +12,7 @@
               aws_bucket: <+input>
               aws_secret_access_key: <+input>
               source: complete/build/docs/javadoc
-              target: <+pipeline.name>/<+pipeline.sequenceId>
+              target: <+pipeline.identifier>/<+pipeline.sequenceId>
           timeout: ""
           type: Plugin
     timeout: ""

--- a/convert/jenkinsjson/convertTestFiles/javadoc/javadoc.yml
+++ b/convert/jenkinsjson/convertTestFiles/javadoc/javadoc.yml
@@ -1,0 +1,18 @@
+- stepGroup:
+    identifier: Stage__nulld86474
+    name: Publish Javadoc
+    steps:
+      - step:
+          identifier: f14ddfd46ceb566c
+          name: Upload and Publish Javadoc
+          spec:
+            image: harnesscommunity/drone-s3-upload-publish
+            settings:
+              aws_access_key_id: <+input>
+              aws_bucket: <+input>
+              aws_secret_access_key: <+input>
+              source: complete/build/docs/javadoc
+              target: <+pipeline.name>/<+pipeline.sequenceId>
+          timeout: ""
+          type: Plugin
+    timeout: ""

--- a/convert/jenkinsjson/convertTestFiles/javadoc/javadocSnippet.json
+++ b/convert/jenkinsjson/convertTestFiles/javadoc/javadocSnippet.json
@@ -1,0 +1,34 @@
+{
+  "spanId": "ab0898fad8618719",
+  "traceId": "7af960212217ab39dfee129e39d04ced",
+  "parent": "op-javadoc",
+  "all-info": "span(name: javadoc, spanId: ab0898fad8618719, parentSpanId: 632277cd45ef3710, traceId: 7af960212217ab39dfee129e39d04ced, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"delegate\" : {\n    \"symbol\" : \"javadoc\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"javadocDir\" : \"build/docs/javadoc\",\n      \"keepAll\" : true\n    },\n    \"model\" : null\n  }\n};harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@19317f9f:com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@19317f9f;harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@37a5f855:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@37a5f855;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1c654d7c:org.jenkinsci.plugins.workflow.actions.TimingAction@1c654d7c;harness-others:-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep;jenkins.pipeline.step.id:32;jenkins.pipeline.step.name:Publish Javadoc;jenkins.pipeline.step.plugin.name:javadoc;jenkins.pipeline.step.plugin.version:280.v050b_5c849f69;jenkins.pipeline.step.type:javadoc;)",
+  "name": "op-javadoc #10",
+  "attributesMap": {
+    "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@19317f9f": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@19317f9f",
+    "harness-others": "-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep",
+    "jenkins.pipeline.step.name": "Publish Javadoc",
+    "ci.pipeline.run.user": "SYSTEM",
+    "jenkins.pipeline.step.id": "32",
+    "jenkins.pipeline.step.type": "javadoc",
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@37a5f855": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@37a5f855",
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1c654d7c": "org.jenkinsci.plugins.workflow.actions.TimingAction@1c654d7c",
+    "harness-attribute": "{\n  \"delegate\" : {\n    \"symbol\" : \"javadoc\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"javadocDir\" : \"build/docs/javadoc\",\n      \"keepAll\" : true\n    },\n    \"model\" : null\n  }\n}",
+    "jenkins.pipeline.step.plugin.name": "javadoc",
+    "jenkins.pipeline.step.plugin.version": "280.v050b_5c849f69"
+  },
+  "type": "Run Phase Span",
+  "parentSpanId": "632277cd45ef3710",
+  "parameterMap": {
+    "delegate": {
+      "symbol": "javadoc",
+      "klass": null,
+      "arguments": {
+        "javadocDir": "build/docs/javadoc",
+        "keepAll": true
+      },
+      "model": null
+    }
+  },
+  "spanName": "javadoc"
+}

--- a/convert/jenkinsjson/json/javadoc.go
+++ b/convert/jenkinsjson/json/javadoc.go
@@ -27,7 +27,7 @@ func ConvertJavadoc(node Node, variables map[string]string) *harness.Step {
                 "aws_secret_access_key": "<+input>",
                 "aws_bucket":            "<+input>",
                 "source":                javadocDir,
-                "target":                "<+pipeline.name>/<+pipeline.sequenceId>",
+                "target":                "<+pipeline.identifier>/<+pipeline.sequenceId>",
             },
         },
     }

--- a/convert/jenkinsjson/json/javadoc.go
+++ b/convert/jenkinsjson/json/javadoc.go
@@ -1,0 +1,49 @@
+package json
+
+import (
+	"fmt"
+
+	harness "github.com/drone/spec/dist/go"
+)
+
+// ConvertJavadoc converts a Jenkins Node to a Harness Step with the Javadoc plugin spec.
+func ConvertJavadoc(node Node, variables map[string]string) *harness.Step {
+    // Extract the Javadoc directory path
+    javadocDir := extractJavadocDir(node)
+    if javadocDir == "" {
+        fmt.Println("Warning: javadocDir not found, using default directory")
+        javadocDir = "build/docs/javadoc"
+    }
+
+    javadocStep := &harness.Step{
+        Id:   node.SpanId,
+        Name: "Upload and Publish Javadoc",
+        Type: "plugin",
+        Spec: &harness.StepPlugin{
+            Connector: "<+input>", // Placeholder for dynamic input
+            Image:     "harnesscommunity/drone-s3-upload-publish",
+            With: map[string]interface{}{
+                "aws_access_key_id":     "<+input>",
+                "aws_secret_access_key": "<+input>",
+                "aws_bucket":            "<+input>",
+                "source":                javadocDir,
+                "target":                "<+pipeline.name>/<+pipeline.sequenceId>",
+            },
+        },
+    }
+	if len(variables) > 0 {
+		javadocStep.Spec.(*harness.StepExec).Envs = variables
+	}
+    return javadocStep
+}
+
+func extractJavadocDir(node Node) string {
+    if delegate, ok := node.ParameterMap["delegate"].(map[string]interface{}); ok {
+        if arguments, ok := delegate["arguments"].(map[string]interface{}); ok {
+            if dir, ok := arguments["javadocDir"].(string); ok {
+                return dir
+            }
+        }
+    }
+    return ""
+}

--- a/convert/jenkinsjson/json/javadoc_test.go
+++ b/convert/jenkinsjson/json/javadoc_test.go
@@ -1,0 +1,57 @@
+package json
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+)
+
+// Test function for dynamically testing ConvertJavadoc
+func TestConvertJavadoc(t *testing.T) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	filePath := filepath.Join(workingDir, "../convertTestFiles/javadoc/javadocSnippet.json")
+	jsonData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read JSON file: %v", err)
+	}
+
+	var rawNode map[string]interface{}
+	if err := json.Unmarshal(jsonData, &rawNode); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+
+	node := Node{}
+	if err := mapToNodes(rawNode, &node); err != nil {
+		t.Fatalf("failed to convert raw node to Node: %v", err)
+	}
+
+	javadocStep := ConvertJavadoc(node, nil)
+	javadocStepPlugin, ok := javadocStep.Spec.(*harness.StepPlugin)
+	if !ok {
+		t.Fatalf("Expected Spec to be of type StepPlugin, but got %T", javadocStep.Spec)
+	}
+
+	expectedSource := extractJavadocDir(node)
+	expectedStepPlugin := &harness.StepPlugin{
+		With: map[string]interface{}{
+			"aws_access_key_id":     "<+input>",
+			"aws_secret_access_key": "<+input>",
+			"aws_bucket":            "<+input>",
+			"source":                expectedSource,
+			"target":                "<+pipeline.name>/<+pipeline.sequenceId>",
+		},
+	}
+
+	if diff := cmp.Diff(javadocStepPlugin.With, expectedStepPlugin.With); diff != "" {
+		t.Errorf("Javadoc step properties mismatch (-want +got): %s", diff)
+	}
+}

--- a/convert/jenkinsjson/json/javadoc_test.go
+++ b/convert/jenkinsjson/json/javadoc_test.go
@@ -47,7 +47,7 @@ func TestConvertJavadoc(t *testing.T) {
 			"aws_secret_access_key": "<+input>",
 			"aws_bucket":            "<+input>",
 			"source":                expectedSource,
-			"target":                "<+pipeline.name>/<+pipeline.sequenceId>",
+			"target":                "<+pipeline.identifier>/<+pipeline.sequenceId>",
 		},
 	}
 

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -556,6 +556,27 @@ line3'''
                     results: [[path: 'build/allure-results']]
                 ])
             }
+        }
+        // Javadoc Steps
+        stage('Checkout') {
+            steps {
+                git url: 'https://github.com/spring-guides/gs-rest-service.git', branch: 'main'
+            }
+        }
+        stage('Build') {
+            steps {
+                sh 'cd complete && gradle clean build --info --stacktrace'
+            }
+        }
+        stage('Generate Javadoc') {
+            steps {
+                sh 'cd complete && gradle javadoc --info --stacktrace'
+            }
+        }
+        stage('Publish Javadoc') {
+            steps {
+                javadoc javadocDir: 'complete/build/docs/javadoc', keepAll: true
+            }
         }	
     }
 }


### PR DESCRIPTION
Added "Javadoc" support to go-convert specific to jenkins migration.

[op-javadoc.json](https://github.com/user-attachments/files/17545293/op-javadoc-without-dir__1.json)

```bash
go run main.go jenkinsjson -downgrade ~/Downloads/op-javadoc.json 
```

<details>
  <summary>Example Harness v0 YAML</summary>

```yaml
pipeline:
  identifier: default
  name: default
  orgIdentifier: default
  projectIdentifier: default
  properties:
    ci:
      codebase:
        build: <+input>
  stages:
  - stage:
      identifier: build
      name: build
      spec:
        cloneCodebase: true
        execution:
          steps:
          - stepGroup:
              identifier: Stage__nullb5a696
              name: Checkout
              timeout: ""
          - stepGroup:
              identifier: Stage__nullcbb8ae
              name: Build
              steps:
              - step:
                  identifier: sh574fb7
                  name: sh
                  spec:
                    command: cd complete && gradle clean build --info --stacktrace
                    image: alpine
                    shell: Sh
                  timeout: ""
                  type: Run
              timeout: ""
          - stepGroup:
              identifier: Stage__nullc2abc0
              name: Generate Javadoc
              steps:
              - step:
                  identifier: sh34c17c
                  name: sh
                  spec:
                    command: cd complete && gradle javadoc --info --stacktrace
                    image: alpine
                    shell: Sh
                  timeout: ""
                  type: Run
              timeout: ""
          - stepGroup:
              identifier: Stage__nulld86474
              name: Publish Javadoc
              steps:
              - step:
                  identifier: f14ddfd46ceb566c
                  name: Upload and Publish Javadoc
                  spec:
                    image: harnesscommunity/drone-s3-upload-publish
                    settings:
                      aws_access_key_id: <+input>
                      aws_bucket: <+input>
                      aws_secret_access_key: <+input>
                      source: complete/build/docs/javadoc
                      target: <+pipeline.name>/<+pipeline.sequenceId>
                  timeout: ""
                  type: Plugin
              timeout: ""
        platform:
          arch: Amd64
          os: Linux
        runtime:
          spec: {}
          type: Cloud
      type: CI
```
</details>