### PR TITLE
feat-kubectl: Added the conversion for kube-ctl

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -685,6 +685,8 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 		for _, step := range steps {
 			*stepWithIDList = append(*stepWithIDList, StepWithID{Step: step, ID: id})
 		}
+	case "withKubeConfig":
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertKubeCtl(currentNode, currentNode.ParameterMap), ID: id})
 
 	default:
 		placeholderStr := fmt.Sprintf("echo %q", "This is a place holder for: "+currentNode.AttributesMap["jenkins.pipeline.step.type"])

--- a/convert/jenkinsjson/convertTestFiles/kubeCtl/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/kubeCtl/Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+    agent any
+    environment {
+        PATH = "/usr/local/bin:$PATH" // Ensure the PATH includes the directory for kubectl
+    }
+    stages {
+        stage('Check Docker') {
+            steps {
+                sh '''
+                    echo "Current PATH: $PATH"
+                    which docker || echo "Docker not found"
+                '''
+            }
+        }
+        stage('Run Kubectl') {
+            steps {
+                withKubeConfig([
+                    credentialsId: 'credentialsId', // Replace with your actual credentials ID
+                    serverUrl: 'https://127.0.0.1:56227' // Replace with your actual server URL
+
+                ]) {
+                    sh 'kubectl get pods' // Run your kubectl command here
+                }
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/kubeCtl/kubeCtl.yaml
+++ b/convert/jenkinsjson/convertTestFiles/kubeCtl/kubeCtl.yaml
@@ -1,0 +1,16 @@
+- step:
+    identifier: stagenulled0166
+    name: Apply Kubernetes Files
+    spec:
+      command: kubectl get pods
+      envVariables:
+        KUBE_CA_CERTIFICATE: ''
+        KUBE_CLUSTER: cluster-name
+        KUBE_CONTEXT: context-name
+        KUBE_CREDENTIALS_ID: credentialsId
+        KUBE_NAMESPACE: default
+        KUBE_SERVER: 'https://127.0.0.1:56227'
+        KUBE_TOKEN: <+secrets.getValue("kube_token")>
+      image: bitnami/kubectl
+      shell: Sh
+    timeout: null

--- a/convert/jenkinsjson/convertTestFiles/kubeCtl/kubeCtl_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/kubeCtl/kubeCtl_snippet.json
@@ -1,0 +1,103 @@
+{
+    "spanId": "ed0166b86044d93b",
+    "traceId": "0d1c6615b37ed3e4ab4a441419c417b3",
+    "parent": "kube",
+    "all-info": "span(name: Stage: null, spanId: ed0166b86044d93b, parentSpanId: 0ed2afd54f64053f, traceId: 0d1c6615b37ed3e4ab4a441419c417b3, attr: harness-attribute:{\n  \"namespace\" : \"default\",\n  \"contextName\" : \"context-name\",\n  \"credentialsId\" : \"credentialsId\",\n  \"caCertificate\" : \"\",\n  \"serverUrl\" : \"https://127.0.0.1:56227\",\n  \"clusterName\" : \"cluster-name\"\n};harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1e824cae:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1e824cae;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@36d14716:org.jenkinsci.plugins.workflow.actions.TimingAction@36d14716;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@2fa91a3d:org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@2fa91a3d;harness-others:-serverUrl-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep serverUrl-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.serverUrl-class java.lang.String-credentialsId-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep credentialsId-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.credentialsId-class java.lang.String-caCertificate-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep caCertificate-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.caCertificate-class java.lang.String-contextName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep contextName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.contextName-class java.lang.String-clusterName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep clusterName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.clusterName-class java.lang.String-namespace-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep namespace-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.namespace-class java.lang.String-restrictKubeConfigAccess-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep restrictKubeConfigAccess-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.restrictKubeConfigAccess-class java.lang.Boolean;jenkins.pipeline.step.type:withKubeConfig;)",
+    "children": [
+      {
+        "spanId": "12f0157a79d67dc9",
+        "traceId": "0d1c6615b37ed3e4ab4a441419c417b3",
+        "parent": "kube",
+        "all-info": "span(name: Stage: null, spanId: 12f0157a79d67dc9, parentSpanId: ed0166b86044d93b, traceId: 0d1c6615b37ed3e4ab4a441419c417b3, attr: harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@49a6a117:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@49a6a117;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@127dcd39:org.jenkinsci.plugins.workflow.actions.TimingAction@127dcd39;harness-others:-serverUrl-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep serverUrl-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.serverUrl-class java.lang.String-credentialsId-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep credentialsId-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.credentialsId-class java.lang.String-caCertificate-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep caCertificate-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.caCertificate-class java.lang.String-contextName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep contextName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.contextName-class java.lang.String-clusterName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep clusterName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.clusterName-class java.lang.String-namespace-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep namespace-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.namespace-class java.lang.String-restrictKubeConfigAccess-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep restrictKubeConfigAccess-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.restrictKubeConfigAccess-class java.lang.Boolean;jenkins.pipeline.step.type:withKubeConfig;)",
+        "name": "kube #34",
+        "attributesMap": {
+          "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@127dcd39": "org.jenkinsci.plugins.workflow.actions.TimingAction@127dcd39",
+          "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@49a6a117": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@49a6a117",
+          "harness-others": "-serverUrl-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep serverUrl-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.serverUrl-class java.lang.String-credentialsId-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep credentialsId-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.credentialsId-class java.lang.String-caCertificate-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep caCertificate-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.caCertificate-class java.lang.String-contextName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep contextName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.contextName-class java.lang.String-clusterName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep clusterName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.clusterName-class java.lang.String-namespace-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep namespace-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.namespace-class java.lang.String-restrictKubeConfigAccess-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep restrictKubeConfigAccess-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.restrictKubeConfigAccess-class java.lang.Boolean",
+          "jenkins.pipeline.step.type": "withKubeConfig"
+        },
+        "type": "Run Phase Span",
+        "parentSpanId": "ed0166b86044d93b",
+        "spanName": "Stage: null"
+      },
+      {
+        "spanId": "e382a52ee792e976",
+        "traceId": "0d1c6615b37ed3e4ab4a441419c417b3",
+        "parent": "kube",
+        "all-info": "span(name: Stage: null, spanId: e382a52ee792e976, parentSpanId: ed0166b86044d93b, traceId: 0d1c6615b37ed3e4ab4a441419c417b3, attr: harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@4f7d72e2:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@4f7d72e2;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@52b8f1de:org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@52b8f1de;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@5f20a1d3:org.jenkinsci.plugins.workflow.actions.TimingAction@5f20a1d3;harness-others:-serverUrl-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep serverUrl-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.serverUrl-class java.lang.String-credentialsId-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep credentialsId-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.credentialsId-class java.lang.String-caCertificate-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep caCertificate-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.caCertificate-class java.lang.String-contextName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep contextName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.contextName-class java.lang.String-clusterName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep clusterName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.clusterName-class java.lang.String-namespace-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep namespace-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.namespace-class java.lang.String-restrictKubeConfigAccess-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep restrictKubeConfigAccess-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.restrictKubeConfigAccess-class java.lang.Boolean;jenkins.pipeline.step.type:withKubeConfig;)",
+        "children": [
+          {
+            "spanId": "4f244ccb56e3311d",
+            "traceId": "0d1c6615b37ed3e4ab4a441419c417b3",
+            "parent": "kube",
+            "all-info": "span(name: Stage: null, spanId: 4f244ccb56e3311d, parentSpanId: e382a52ee792e976, traceId: 0d1c6615b37ed3e4ab4a441419c417b3, attr: harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@7b086020:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@7b086020;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@14e40a96:org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@14e40a96;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@2d79fca1:org.jenkinsci.plugins.workflow.actions.TimingAction@2d79fca1;harness-others:-serverUrl-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep serverUrl-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.serverUrl-class java.lang.String-credentialsId-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep credentialsId-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.credentialsId-class java.lang.String-caCertificate-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep caCertificate-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.caCertificate-class java.lang.String-contextName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep contextName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.contextName-class java.lang.String-clusterName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep clusterName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.clusterName-class java.lang.String-namespace-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep namespace-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.namespace-class java.lang.String-restrictKubeConfigAccess-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep restrictKubeConfigAccess-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.restrictKubeConfigAccess-class java.lang.Boolean;jenkins.pipeline.step.type:withKubeConfig;)",
+            "name": "kube #34",
+            "attributesMap": {
+              "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@2d79fca1": "org.jenkinsci.plugins.workflow.actions.TimingAction@2d79fca1",
+              "harness-others": "-serverUrl-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep serverUrl-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.serverUrl-class java.lang.String-credentialsId-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep credentialsId-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.credentialsId-class java.lang.String-caCertificate-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep caCertificate-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.caCertificate-class java.lang.String-contextName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep contextName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.contextName-class java.lang.String-clusterName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep clusterName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.clusterName-class java.lang.String-namespace-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep namespace-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.namespace-class java.lang.String-restrictKubeConfigAccess-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep restrictKubeConfigAccess-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.restrictKubeConfigAccess-class java.lang.Boolean",
+              "jenkins.pipeline.step.type": "withKubeConfig",
+              "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@14e40a96": "org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@14e40a96",
+              "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@7b086020": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@7b086020"
+            },
+            "type": "Run Phase Span",
+            "parentSpanId": "e382a52ee792e976",
+            "spanName": "Stage: null"
+          },
+          {
+            "spanId": "4b20fb7157119cf7",
+            "traceId": "0d1c6615b37ed3e4ab4a441419c417b3",
+            "parent": "kube",
+            "all-info": "span(name: sh, spanId: 4b20fb7157119cf7, parentSpanId: e382a52ee792e976, traceId: 0d1c6615b37ed3e4ab4a441419c417b3, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"script\" : \"kubectl get pods\"\n};harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@2441dbed:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@2441dbed;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1d587a6:org.jenkinsci.plugins.workflow.actions.TimingAction@1d587a6;harness-others:-WATCHING_RECURRENCE_PERIOD-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep WATCHING_RECURRENCE_PERIOD-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.WATCHING_RECURRENCE_PERIOD-long-USE_WATCHING-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep USE_WATCHING-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING-boolean-REMOTE_TIMEOUT-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep REMOTE_TIMEOUT-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT-long;jenkins.pipeline.step.id:16;jenkins.pipeline.step.name:Shell Script;jenkins.pipeline.step.plugin.name:workflow-durable-task-step;jenkins.pipeline.step.plugin.version:1371.vb_7cec8f3b_95e;jenkins.pipeline.step.type:sh;)",
+            "name": "kube #34",
+            "attributesMap": {
+              "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@2441dbed": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@2441dbed",
+              "harness-others": "-WATCHING_RECURRENCE_PERIOD-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep WATCHING_RECURRENCE_PERIOD-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.WATCHING_RECURRENCE_PERIOD-long-USE_WATCHING-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep USE_WATCHING-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING-boolean-REMOTE_TIMEOUT-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep REMOTE_TIMEOUT-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT-long",
+              "jenkins.pipeline.step.name": "Shell Script",
+              "ci.pipeline.run.user": "SYSTEM",
+              "jenkins.pipeline.step.id": "16",
+              "jenkins.pipeline.step.type": "sh",
+              "harness-attribute": "{\n  \"script\" : \"kubectl get pods\"\n}",
+              "jenkins.pipeline.step.plugin.name": "workflow-durable-task-step",
+              "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1d587a6": "org.jenkinsci.plugins.workflow.actions.TimingAction@1d587a6",
+              "jenkins.pipeline.step.plugin.version": "1371.vb_7cec8f3b_95e"
+            },
+            "type": "Run Phase Span",
+            "parentSpanId": "e382a52ee792e976",
+            "parameterMap": {"script": "kubectl get pods"},
+            "spanName": "sh"
+          }
+        ],
+        "name": "kube #34",
+        "attributesMap": {
+          "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@52b8f1de": "org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@52b8f1de",
+          "harness-others": "-serverUrl-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep serverUrl-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.serverUrl-class java.lang.String-credentialsId-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep credentialsId-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.credentialsId-class java.lang.String-caCertificate-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep caCertificate-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.caCertificate-class java.lang.String-contextName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep contextName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.contextName-class java.lang.String-clusterName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep clusterName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.clusterName-class java.lang.String-namespace-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep namespace-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.namespace-class java.lang.String-restrictKubeConfigAccess-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep restrictKubeConfigAccess-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.restrictKubeConfigAccess-class java.lang.Boolean",
+          "jenkins.pipeline.step.type": "withKubeConfig",
+          "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@5f20a1d3": "org.jenkinsci.plugins.workflow.actions.TimingAction@5f20a1d3",
+          "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@4f7d72e2": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@4f7d72e2"
+        },
+        "type": "Run Phase Span",
+        "parentSpanId": "ed0166b86044d93b",
+        "spanName": "Stage: null"
+      }
+    ],
+    "name": "kube #34",
+    "attributesMap": {
+      "harness-others": "-serverUrl-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep serverUrl-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.serverUrl-class java.lang.String-credentialsId-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep credentialsId-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.credentialsId-class java.lang.String-caCertificate-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep caCertificate-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.caCertificate-class java.lang.String-contextName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep contextName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.contextName-class java.lang.String-clusterName-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep clusterName-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.clusterName-class java.lang.String-namespace-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep namespace-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.namespace-class java.lang.String-restrictKubeConfigAccess-field org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep restrictKubeConfigAccess-org.jenkinsci.plugins.kubernetes.cli.KubectlBuildStep.restrictKubeConfigAccess-class java.lang.Boolean",
+      "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@36d14716": "org.jenkinsci.plugins.workflow.actions.TimingAction@36d14716",
+      "jenkins.pipeline.step.type": "withKubeConfig",
+      "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@2fa91a3d": "org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@2fa91a3d",
+      "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1e824cae": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1e824cae",
+      "harness-attribute": "{\n  \"namespace\" : \"default\",\n  \"contextName\" : \"context-name\",\n  \"credentialsId\" : \"credentialsId\",\n  \"caCertificate\" : \"\",\n  \"serverUrl\" : \"https://127.0.0.1:56227\",\n  \"clusterName\" : \"cluster-name\"\n}"
+    },
+    "type": "Run Phase Span",
+    "parentSpanId": "0ed2afd54f64053f",
+    "parameterMap": {
+      "contextName": "context-name",
+      "serverUrl": "https://127.0.0.1:56227",
+      "clusterName": "cluster-name",
+      "namespace": "default",
+      "credentialsId": "credentialsId",
+      "caCertificate": ""
+    },
+    "spanName": "null"
+  }

--- a/convert/jenkinsjson/json/kubeCtl.go
+++ b/convert/jenkinsjson/json/kubeCtl.go
@@ -1,0 +1,88 @@
+package json
+
+import (
+	harness "github.com/drone/spec/dist/go"
+)
+
+// ConvertNunit creates a Harness step for nunit plugin.
+func ConvertKubeCtl(node Node, paramMap map[string]interface{}) *harness.Step {
+	var contextName string = ""
+	var serverUrl string = ""
+	var clusterName string = ""
+	var namespace string = ""
+	var credentialsId string = ""
+	var caCertificate string = ""
+
+	script := findScript(node)
+
+	if contextNameValue, ok := node.ParameterMap["contextName"]; ok {
+		contextName = contextNameValue.(string)
+	}
+
+	if serverUrlValue, ok := node.ParameterMap["serverUrl"]; ok {
+		serverUrl = serverUrlValue.(string)
+	}
+
+	if clusterNameValue, ok := node.ParameterMap["clusterName"]; ok {
+		clusterName = clusterNameValue.(string)
+	}
+
+	if namespaceValue, ok := node.ParameterMap["namespace"]; ok {
+		namespace = namespaceValue.(string)
+	}
+
+	if credentialsIdValue, ok := node.ParameterMap["credentialsId"]; ok {
+		credentialsId = credentialsIdValue.(string)
+	}
+
+	if caCertificateValue, ok := node.ParameterMap["caCertificate"]; ok {
+		caCertificate = caCertificateValue.(string)
+	}
+
+	convertNunit := &harness.Step{
+		Name: "Apply Kubernetes Files",
+		Type: "script",
+		Id:   SanitizeForId(node.SpanName, node.SpanId),
+		Spec: &harness.StepExec{
+			Connector: "docker_hub_connector",
+			Image:     "bitnami/kubectl",
+			Shell:     "sh",
+			Envs: map[string]string{
+				"KUBE_SERVER":         serverUrl,
+				"KUBE_CONTEXT":        contextName,
+				"KUBE_CLUSTER":        clusterName,
+				"KUBE_TOKEN":          "<+secrets.getValue(\"kube_token\")>",
+				"KUBE_NAMESPACE":      namespace,
+				"KUBE_CA_CERTIFICATE": caCertificate,
+				"KUBE_CREDENTIALS_ID": credentialsId,
+			},
+			Run: script,
+		},
+	}
+
+	return convertNunit
+}
+
+// Function to recursively search for "script" in a specific child node
+func findScript(node Node) string {
+	// Check if "jenkins.pipeline.step.type" is "withKubeConfig"
+	if node.AttributesMap["jenkins.pipeline.step.type"] == "withKubeConfig" {
+		// Traverse through children
+		for _, child := range node.Children {
+			// Check if "jenkins.pipeline.step.type" in the child is "sh"
+			if child.AttributesMap["jenkins.pipeline.step.type"] == "sh" {
+				// Check if "script" exists in ParameterMap and return it
+				if scriptValue, ok := child.ParameterMap["script"]; ok {
+					return scriptValue.(string)
+				}
+			} else {
+				// Recursively check in case the child has further descendants
+				if result := findScript(child); result != "" {
+					return result
+				}
+			}
+		}
+	}
+	// Return empty string if no valid "script" found
+	return ""
+}

--- a/convert/jenkinsjson/json/kubeCtl_test.go
+++ b/convert/jenkinsjson/json/kubeCtl_test.go
@@ -1,0 +1,43 @@
+package json
+
+import (
+	"testing"
+
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertKubeCtl(t *testing.T) {
+
+	var tests []runner
+	tests = append(tests, prepare(t, "/kubeCtl/kubeCtl_snippet", &harness.Step{
+		Id:   "nulled0166",
+		Name: "Apply Kubernetes Files",
+		Type: "script",
+		Spec: &harness.StepExec{
+			Connector: "docker_hub_connector",
+			Image:     "bitnami/kubectl",
+			Shell:     "sh",
+			Run:       "kubectl get pods",
+			Envs: map[string]string{
+				"KUBE_SERVER":         "https://127.0.0.1:56227",
+				"KUBE_CONTEXT":        "context-name",
+				"KUBE_CLUSTER":        "cluster-name",
+				"KUBE_TOKEN":          "<+secrets.getValue(\"kube_token\")>",
+				"KUBE_NAMESPACE":      "default",
+				"KUBE_CA_CERTIFICATE": "",
+				"KUBE_CREDENTIALS_ID": "credentialsId",
+			},
+		},
+	}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertKubeCtl(tt.input, tt.input.ParameterMap)
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("ConvertNunit() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -586,5 +586,25 @@ line3'''
                 nunit testResultsPattern: 'TestResult.xml', failIfNoResults: true, skipJUnitArchiver: false, failedTestsFailBuild: true
             }
         }
+        //Kube-ctl
+        stage('Check Docker') {
+            steps {
+                sh '''
+                    echo "Current PATH: $PATH"
+                    which docker || echo "Docker not found"
+                '''
+            }
+        }
+        stage('Run Kubectl') {
+            steps {
+                withKubeConfig([
+                    credentialsId: 'credentialsId', // Replace with your actual credentials ID
+                    serverUrl: 'https://127.0.0.1:56227' // Replace with your actual server URL
+
+                ]) {
+                    sh 'kubectl get pods' // Run your kubectl command here
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
feat-kubectl: added the conversion for kube ctl

Trace File:
======
[kube__latest_with_all_fields.json](https://github.com/user-attachments/files/17595232/kube__latest_with_all_fields.json)

go run main.go jenkinsjson --downgrade "~/go/kube__latest_with_all_fields.json"

```
- step:
    identifier: stagenulled0166
    name: Apply Kubernetes Files
    spec:
      command: kubectl get pods
      envVariables:
        KUBE_CA_CERTIFICATE: ''
        KUBE_CLUSTER: cluster-name
        KUBE_CONTEXT: context-name
        KUBE_CREDENTIALS_ID: credentialsId
        KUBE_NAMESPACE: default
        KUBE_SERVER: 'https://127.0.0.1:56227'
        KUBE_TOKEN: <+secrets.getValue("kube_token")>
      image: bitnami/kubectl
      shell: Sh
    timeout: null

```