### PR TITLE
fix: [CI-13903]: fix parallel steps for Consilio brutal pipeline

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -353,6 +353,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 		// this is technically a step group, we treat it as just steps for now
 		if len(currentNode.Children) > 1 {
 			// handle parallel from parent
+			if currentNode.Children[0].AttributesMap["jenkins.pipeline.step.type"] == "getContext" {
+				currentNode.Children = currentNode.Children[1:]
+			}
 			if currentNode.Children[0].AttributesMap["jenkins.pipeline.step.type"] == "parallel" {
 				parallelStepItemsWithID := make([]StepWithID, 0)
 				for _, child := range currentNode.Children {
@@ -378,6 +381,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 				*stepWithIDList = append(*stepWithIDList, StepWithID{Step: parallelStep, ID: id})
 			} else {
 				for _, child := range currentNode.Children {
+					if child.SpanName == "getContext" {
+						child.SpanName = currentNode.AttributesMap["jenkins.pipeline.step.name"]
+					}
 					clone, repo = collectStepsWithID(child, stepWithIDList, processedTools, variables, timeout, dockerImage)
 				}
 			}


### PR DESCRIPTION
This change adds handling for a `getContext` node we are seeing in a trace. There was two issues that this node was causing.

1. It broke parallel rendering for parallel step groups.
2. It caused all parallel steps to be produced with the same "getContext" name.

I'm not really sure what the `getContext` node is so as a result I'm not very confident that this is the best way to handle it.
Here is the getContext description from the trace file
> Get contextual object from internal APIs

My assumption is that the getContext node is added to the trace when Jenkins checks the conditional execution for a step which results in the step not running. Since the step never runs we don't get the step execution in the trace leaving only these mostly useless getContext nodes.

Jenkins stage
```
stage('Deployment') {
    when {
        beforeAgent true
        allOf {
            expression { mode == "Deploy" }
        }
    }
    steps {
        buildDescription "Deploying to env"
        // run deployment
    }
}
```
getContext node from trace
```
  {
    "spanId": "123",
    "traceId": "123",
    "parent": "dev",
    "all-info": "...",
    "name": "Pipeline » workflows » name » branch #1",
    "attributesMap": {
      "harness-others": "-type-field org.jenkinsci.plugins.workflow.steps.GetContextStep type-org.jenkinsci.plugins.workflow.steps.GetContextStep.type-class java.lang.Class",
      "jenkins.pipeline.step.name": "Get contextual object from internal APIs",
      "ci.pipeline.run.user": "SYSTEM",
      "jenkins.pipeline.step.id": "1",
      "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@5ddf7cc1": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@5ddf7cc1",
      "jenkins.pipeline.step.type": "getContext",
      "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@7fc12d65": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@7fc12d65",
      "harness-attribute-extra-pip: io.jenkins.blueocean.service.embedded.BlueOceanUrlAction@43b49c84": "io.jenkins.blueocean.service.embedded.BlueOceanUrlAction@43b49c84",
      "harness-attribute": "{\n  \"type\" : \"UNSERIALIZABLE\"\n}",
      "jenkins.pipeline.step.plugin.name": "workflow-basic-steps",
      "jenkins.pipeline.step.plugin.version": "1058.vcb_fc1e3a_21a_9",
      "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@29bb31ce": "org.jenkinsci.plugins.workflow.actions.TimingAction@29bb31ce"
    },
    "type": "Run Phase Span",
    "parentSpanId": "123",
    "parameterMap": {"type": "UNSERIALIZABLE"},
    "spanName": "getContext"
  },

```