### PR TITLE
feat-mailer: Added Mailer Plugin Conversion

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -699,6 +699,8 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 		}
 	case "withKubeConfig":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertKubeCtl(currentNode, currentNode.ParameterMap), ID: id})
+	case "mail":
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertMailer(currentNode, currentNode.ParameterMap), ID: id})
 
 	default:
 		placeholderStr := fmt.Sprintf("echo %q", "This is a place holder for: "+currentNode.AttributesMap["jenkins.pipeline.step.type"])

--- a/convert/jenkinsjson/convertTestFiles/mailer/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/mailer/Jenkinsfile
@@ -1,0 +1,25 @@
+pipeline {
+    agent any
+    stages {
+        stage('Test') {
+            steps {
+                script {
+                    // Set the build result to test email notifications
+                    currentBuild.result = 'FAILED' // Change to 'UNSTABLE' or 'SUCCESS' as needed
+                }
+            }
+        }
+    }
+    post {
+        always {
+            mail(
+                to: "test.uyser@testmail.com",
+                subject: "Jenkins Build - ${currentBuild.fullDisplayName}",
+                body: """
+                Build Status: ${currentBuild.currentResult}
+                Check console output at: ${env.BUILD_URL}console
+                """
+            )
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/mailer/mailer.yaml
+++ b/convert/jenkinsjson/convertTestFiles/mailer/mailer.yaml
@@ -1,0 +1,20 @@
+- step:
+    identifier: mail0fb620
+    name: Mailer
+    spec:
+      image: plugins/email
+      settings:
+        body:
+          "\n                    Build Status: FAILURE\n                    Check
+          console output at: http://localhost:8080/job/Mail_Pipeline/15/console\n
+          \                   "
+
+        from.address: <from_address>
+        host: smtp.gmail.com
+        password: <password>
+        port: "587"
+        recipients: test.user@testmail.com
+        subject: "Jenkins Build - Mail_Pipeline #15"
+        username: <username>
+    timeout: ""
+    type: Plugin

--- a/convert/jenkinsjson/convertTestFiles/mailer/mailer.yaml
+++ b/convert/jenkinsjson/convertTestFiles/mailer/mailer.yaml
@@ -9,12 +9,12 @@
           console output at: http://localhost:8080/job/Mail_Pipeline/15/console\n
           \                   "
 
-        from.address: <from_address>
-        host: smtp.gmail.com
-        password: <password>
-        port: "587"
+        from.address: <+input>
+        host: <+input>
+        password: <+input>
+        port: <+input>
         recipients: test.user@testmail.com
         subject: "Jenkins Build - Mail_Pipeline #15"
-        username: <username>
+        username: <+input>
     timeout: ""
     type: Plugin

--- a/convert/jenkinsjson/convertTestFiles/mailer/mailer_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/mailer/mailer_snippet.json
@@ -1,0 +1,27 @@
+{
+  "spanId": "0fb62047be44794e",
+  "traceId": "68619222e565647b7daf28be798bdb26",
+  "parent": "Mail_Pipeline",
+  "all-info": "span(name: mail, spanId: 0fb62047be44794e, parentSpanId: 7ccf4ab5dd4035e3, traceId: 68619222e565647b7daf28be798bdb26, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"body\" : \"\\n                    Build Status: FAILURE\\n                    Check console output at: http://localhost:8080/job/Mail_Pipeline/15/console\\n                    \",\n  \"subject\" : \"Jenkins Build - Mail_Pipeline #15\",\n  \"to\" : \"test.user@testmail.com\"\n};harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@2b82c7b7:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@2b82c7b7;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@2d96420d:org.jenkinsci.plugins.workflow.actions.TimingAction@2d96420d;harness-others:-subject-field org.jenkinsci.plugins.workflow.steps.MailStep subject-org.jenkinsci.plugins.workflow.steps.MailStep.subject-class java.lang.String-body-field org.jenkinsci.plugins.workflow.steps.MailStep body-org.jenkinsci.plugins.workflow.steps.MailStep.body-class java.lang.String-from-field org.jenkinsci.plugins.workflow.steps.MailStep from-org.jenkinsci.plugins.workflow.steps.MailStep.from-class java.lang.String-to-field org.jenkinsci.plugins.workflow.steps.MailStep to-org.jenkinsci.plugins.workflow.steps.MailStep.to-class java.lang.String-cc-field org.jenkinsci.plugins.workflow.steps.MailStep cc-org.jenkinsci.plugins.workflow.steps.MailStep.cc-class java.lang.String-bcc-field org.jenkinsci.plugins.workflow.steps.MailStep bcc-org.jenkinsci.plugins.workflow.steps.MailStep.bcc-class java.lang.String-replyTo-field org.jenkinsci.plugins.workflow.steps.MailStep replyTo-org.jenkinsci.plugins.workflow.steps.MailStep.replyTo-class java.lang.String;jenkins.pipeline.step.id:11;jenkins.pipeline.step.name:Mail;jenkins.pipeline.step.plugin.name:workflow-basic-steps;jenkins.pipeline.step.plugin.version:1058.vcb_fc1e3a_21a_9;jenkins.pipeline.step.type:mail;)",
+  "name": "Mail_Pipeline #15",
+  "attributesMap": {
+    "harness-others": "-subject-field org.jenkinsci.plugins.workflow.steps.MailStep subject-org.jenkinsci.plugins.workflow.steps.MailStep.subject-class java.lang.String-body-field org.jenkinsci.plugins.workflow.steps.MailStep body-org.jenkinsci.plugins.workflow.steps.MailStep.body-class java.lang.String-from-field org.jenkinsci.plugins.workflow.steps.MailStep from-org.jenkinsci.plugins.workflow.steps.MailStep.from-class java.lang.String-to-field org.jenkinsci.plugins.workflow.steps.MailStep to-org.jenkinsci.plugins.workflow.steps.MailStep.to-class java.lang.String-cc-field org.jenkinsci.plugins.workflow.steps.MailStep cc-org.jenkinsci.plugins.workflow.steps.MailStep.cc-class java.lang.String-bcc-field org.jenkinsci.plugins.workflow.steps.MailStep bcc-org.jenkinsci.plugins.workflow.steps.MailStep.bcc-class java.lang.String-replyTo-field org.jenkinsci.plugins.workflow.steps.MailStep replyTo-org.jenkinsci.plugins.workflow.steps.MailStep.replyTo-class java.lang.String",
+    "jenkins.pipeline.step.name": "Mail",
+    "ci.pipeline.run.user": "SYSTEM",
+    "jenkins.pipeline.step.id": "11",
+    "jenkins.pipeline.step.type": "mail",
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@2b82c7b7": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@2b82c7b7",
+    "harness-attribute": "{\n  \"body\" : \"\\n                    Build Status: FAILURE\\n                    Check console output at: http://localhost:8080/job/Mail_Pipeline/15/console\\n                    \",\n  \"subject\" : \"Jenkins Build - Mail_Pipeline #15\",\n  \"to\" : \"test.user@testmail.com\"\n}",
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@2d96420d": "org.jenkinsci.plugins.workflow.actions.TimingAction@2d96420d",
+    "jenkins.pipeline.step.plugin.name": "workflow-basic-steps",
+    "jenkins.pipeline.step.plugin.version": "1058.vcb_fc1e3a_21a_9"
+  },
+  "type": "Run Phase Span",
+  "parentSpanId": "7ccf4ab5dd4035e3",
+  "parameterMap": {
+    "subject": "Jenkins Build - Mail_Pipeline #15",
+    "to": "test.user@testmail.com",
+    "body": "\n                    Build Status: FAILURE\n                    Check console output at: http://localhost:8080/job/Mail_Pipeline/15/console\n                    "
+  },
+  "spanName": "mail"
+}

--- a/convert/jenkinsjson/json/mailer.go
+++ b/convert/jenkinsjson/json/mailer.go
@@ -1,0 +1,33 @@
+package json
+
+import (
+	harness "github.com/drone/spec/dist/go"
+)
+
+// ConvertMailer creates a Harness step for nunit plugin.
+func ConvertMailer(node Node, arguments map[string]interface{}) *harness.Step {
+	subject, _ := arguments["subject"].(string)
+	to, _ := arguments["to"].(string)
+	body, _ := arguments["body"].(string)
+
+	convertMailer := &harness.Step{
+		Id:   SanitizeForId(node.SpanName, node.SpanId),
+		Name: "Mailer",
+		Type: "plugin",
+		Spec: &harness.StepPlugin{
+			Image: "plugins/email",
+			With: map[string]interface{}{
+				"host":         "smtp.gmail.com",
+				"port":         "587",
+				"username":     "<username>",
+				"password":     "<password>",
+				"subject":      subject,
+				"body":         body,
+				"recipients":   to,
+				"from.address": "<from_address>",
+			},
+		},
+	}
+
+	return convertMailer
+}

--- a/convert/jenkinsjson/json/mailer.go
+++ b/convert/jenkinsjson/json/mailer.go
@@ -17,14 +17,14 @@ func ConvertMailer(node Node, arguments map[string]interface{}) *harness.Step {
 		Spec: &harness.StepPlugin{
 			Image: "plugins/email",
 			With: map[string]interface{}{
-				"host":         "smtp.gmail.com",
-				"port":         "587",
-				"username":     "<username>",
-				"password":     "<password>",
+				"host":         "<+input>",
+				"port":         "<+input>",
+				"username":     "<+input>",
+				"password":     "<+input>",
 				"subject":      subject,
 				"body":         body,
 				"recipients":   to,
-				"from.address": "<from_address>",
+				"from.address": "<+input>",
 			},
 		},
 	}

--- a/convert/jenkinsjson/json/mailer_test.go
+++ b/convert/jenkinsjson/json/mailer_test.go
@@ -18,13 +18,13 @@ func TestConvertMailer(t *testing.T) {
 			Image: "plugins/email",
 			With: map[string]interface{}{
 				"body":         string("\n                    Build Status: FAILURE\n                    Check console output at: http://localhost:8080/job/Mail_Pipeline/15/console\n                    "),
-				"from.address": string("<from_address>"),
-				"host":         string("smtp.gmail.com"),
-				"password":     string("<password>"),
-				"port":         string("587"),
+				"from.address": string("<+input>"),
+				"host":         string("<+input>"),
+				"password":     string("<+input>"),
+				"port":         string("<+input>"),
 				"recipients":   string("test.user@testmail.com"),
 				"subject":      string("Jenkins Build - Mail_Pipeline #15"),
-				"username":     string("<username>"),
+				"username":     string("<+input>"),
 			},
 		},
 	}))

--- a/convert/jenkinsjson/json/mailer_test.go
+++ b/convert/jenkinsjson/json/mailer_test.go
@@ -1,0 +1,41 @@
+package json
+
+import (
+	"testing"
+
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertMailer(t *testing.T) {
+
+	var tests []runner
+	tests = append(tests, prepare(t, "/mailer/mailer_snippet", &harness.Step{
+		Id:   "mail0fb620",
+		Name: "Mailer",
+		Type: "plugin",
+		Spec: &harness.StepPlugin{
+			Image: "plugins/email",
+			With: map[string]interface{}{
+				"body":         string("\n                    Build Status: FAILURE\n                    Check console output at: http://localhost:8080/job/Mail_Pipeline/15/console\n                    "),
+				"from.address": string("<from_address>"),
+				"host":         string("smtp.gmail.com"),
+				"password":     string("<password>"),
+				"port":         string("587"),
+				"recipients":   string("test.user@testmail.com"),
+				"subject":      string("Jenkins Build - Mail_Pipeline #15"),
+				"username":     string("<username>"),
+			},
+		},
+	}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertMailer(tt.input, tt.input.ParameterMap)
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("ConvertMailer() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -685,5 +685,26 @@ line3'''
                 ])
             }
         }
+        //mailer
+        stage('Test') {
+            steps {
+                script {
+                    // Set the build result to test email notifications
+                    currentBuild.result = 'FAILED' // Change to 'UNSTABLE' or 'SUCCESS' as needed
+                }
+            }
+        }
+        post {
+        always {
+            mail(
+                to: "test.uyser@testmail.com",
+                subject: "Jenkins Build - ${currentBuild.fullDisplayName}",
+                body: """
+                Build Status: ${currentBuild.currentResult}
+                Check console output at: ${env.BUILD_URL}console
+                """
+            )
+        }
+        }
     }
 }

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -694,17 +694,17 @@ line3'''
                 }
             }
         }
-        post {
-        always {
-            mail(
-                to: "test.uyser@testmail.com",
-                subject: "Jenkins Build - ${currentBuild.fullDisplayName}",
-                body: """
-                Build Status: ${currentBuild.currentResult}
-                Check console output at: ${env.BUILD_URL}console
-                """
-            )
-        }
+         post {
+            always {
+                mail(
+                    to: "test.uyser@testmail.com",
+                    subject: "Jenkins Build - ${currentBuild.fullDisplayName}",
+                    body: """
+                    Build Status: ${currentBuild.currentResult}
+                    Check console output at: ${env.BUILD_URL}console
+                    """
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Mailer go-conversion:
Added "Mailer" support to go-convert specific to jenkins migration.

Mailer Jenkins Trace:
[Mailer_Trace.json](https://github.com/user-attachments/files/17787751/Mailer_Trace.json)

go run main.go jenkinsjson --downgrade ~/go/Mailer_Trace.json

Mailer harness pipeline step:
```
- step:
    identifier: mail0fb620
    name: Mailer
    spec:
      image: plugins/email
      settings:
        body:
          "\n                    Build Status: FAILURE\n                    Check
          console output at: http://localhost:8080/job/Mail_Pipeline/15/console\n
          \                   "

        from.address: <from_address>
        host: smtp.gmail.com
        password: <password>
        port: "587"
        recipients: test.user@testmail.com
        subject: "Jenkins Build - Mail_Pipeline #15"
        username: <username>
    timeout: ""
    type: Plugin
```