### PR TITLE
fix: [CI-14984]: Fixed mergeRunStep issue.

### DIFF
--- a/command/jenkinsjson.go
+++ b/command/jenkinsjson.go
@@ -28,14 +28,15 @@ import (
 )
 
 type JenkinsJson struct {
-	name       string
-	proj       string
-	org        string
-	repoName   string
-	repoConn   string
-	kubeName   string
-	kubeConn   string
-	dockerConn string
+	name         string
+	proj         string
+	org          string
+	repoName     string
+	repoConn     string
+	kubeName     string
+	kubeConn     string
+	dockerConn   string
+	defaultImage string
 
 	downgrade   bool
 	beforeAfter bool
@@ -60,6 +61,7 @@ func (c *JenkinsJson) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&c.kubeConn, "kube-connector", "", "kubernetes connector")
 	f.StringVar(&c.kubeName, "kube-namespace", "", "kubernets namespace")
 	f.StringVar(&c.dockerConn, "docker-connector", "", "dockerhub connector")
+	f.StringVar(&c.defaultImage, "default-image", "alpine", "default image for run step")
 }
 
 func (c *JenkinsJson) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
@@ -83,6 +85,7 @@ func (c *JenkinsJson) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	converter := jenkinsjson.New(
 		jenkinsjson.WithDockerhub(c.dockerConn),
 		jenkinsjson.WithKubernetes(c.kubeName, c.kubeConn),
+		jenkinsjson.WithDefaultImage(c.defaultImage),
 	)
 	after, err := converter.ConvertBytes(before)
 	if err != nil {

--- a/convert/jenkinsjson/option.go
+++ b/convert/jenkinsjson/option.go
@@ -33,3 +33,11 @@ func WithKubernetes(namespace, connector string) Option {
 		d.kubeConnector = connector
 	}
 }
+
+// WithDefaultImage returns an option to set the default
+// image to run step.
+func WithDefaultImage(image string) Option {
+	return func(d *Converter) {
+		d.defaultImage = image
+	}
+}


### PR DESCRIPTION
Removed the pushed flag:
The pushed flag was unnecessary and potentially confusing
The logic now handles all cases without needing to track whether something was pushed

Simplified the loop logic:
Removed the conditional check if i != len(*steps)-1
Made the merge/no-merge decision more straightforward

Fixed the last step handling:
Always append the final cursor state after the loop
This ensures we don't lose any steps regardless of whether the last step was merged or not (which was the main issue).


Also added a function which checks that if image is non-default then it will not merge.



Jenkins pipeline which I mentioned in the ticket in now returning correct output.
```
pipeline:
  identifier: default
  name: default
  orgIdentifier: default
  projectIdentifier: default
  properties:
    ci:
      codebase:
        build: <+input>
  stages:
  - stage:
      identifier: build
      name: build
      spec:
        cloneCodebase: true
        execution:
          steps:
          - stepGroup:
              identifier: Stage__null645b44
              name: Checkout
              timeout: ""
          - stepGroup:
              identifier: Stage__null959e75
              name: Plugin Build
              steps:
              - step:
                  identifier: stagenull30d2ac
                  name: maven
                  spec:
                    command: mvn clean install                        package
                    envVariables:
                      ANT_HOME: /var/jenkins_home/tools/hudson.tasks.Ant_AntInstallation/ant1
                      M2_HOME: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1
                      MAVEN_HOME: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1
                      PATH+ANT: /var/jenkins_home/tools/hudson.tasks.Ant_AntInstallation/ant1/bin
                      PATH+GRADLE: /var/jenkins_home/tools/hudson.plugins.gradle.GradleInstallation/gradle1/bin
                      PATH+MAVEN: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1/bin
                    image: maven:latest
                    shell: Sh
                  timeout: ""
                  type: Run
              - step:
                  identifier: stagenull51182d
                  name: ant
                  spec:
                    command: ant build
                    envVariables:
                      ANT_HOME: /var/jenkins_home/tools/hudson.tasks.Ant_AntInstallation/ant1
                      M2_HOME: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1
                      MAVEN_HOME: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1
                      PATH+ANT: /var/jenkins_home/tools/hudson.tasks.Ant_AntInstallation/ant1/bin
                      PATH+GRADLE: /var/jenkins_home/tools/hudson.plugins.gradle.GradleInstallation/gradle1/bin
                      PATH+MAVEN: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1/bin
                    image: frekele/ant:latest
                    shell: Sh
                  timeout: ""
                  type: Run
              - step:
                  identifier: stagenulld802a5
                  name: gradle
                  spec:
                    command: gradle build
                    envVariables:
                      ANT_HOME: /var/jenkins_home/tools/hudson.tasks.Ant_AntInstallation/ant1
                      M2_HOME: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1
                      MAVEN_HOME: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1
                      PATH+ANT: /var/jenkins_home/tools/hudson.tasks.Ant_AntInstallation/ant1/bin
                      PATH+GRADLE: /var/jenkins_home/tools/hudson.plugins.gradle.GradleInstallation/gradle1/bin
                      PATH+MAVEN: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1/bin
                    image: gradle:latest
                    shell: Sh
                  timeout: ""
                  type: Run
              timeout: ""
          - stepGroup:
              identifier: Stage__null847254
              name: Code Analysis
              steps:
              - step:
                  identifier: stagenull7d2a33
                  name: sonarCube
                  spec:
                    envVariables:
                      ANT_HOME: /var/jenkins_home/tools/hudson.tasks.Ant_AntInstallation/ant1
                      M2_HOME: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1
                      MAVEN_HOME: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1
                      PATH+ANT: /var/jenkins_home/tools/hudson.tasks.Ant_AntInstallation/ant1/bin
                      PATH+GRADLE: /var/jenkins_home/tools/hudson.plugins.gradle.GradleInstallation/gradle1/bin
                      PATH+MAVEN: /var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/maven1/bin
                      scannerHome: /var/jenkins_home/tools/hudson.plugins.sonar.SonarRunnerInstallation/sonar1
                    image: aosapps/drone-sonar-plugin
                    settings:
                      sonar_host: <+input>
                      sonar_token: <+input>
                  timeout: ""
                  type: Plugin
              timeout: ""
        platform:
          arch: Amd64
          os: Linux
        runtime:
          spec: {}
          type: Cloud
      type: CI
```