### PR TITLE
Feat nodejs: Added Nodejs Conversion

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -290,6 +290,27 @@ func recursiveParseJsonToSteps(currentNode jenkinsjson.Node, steps *[]*harness.S
 	return nil, nil
 }
 
+func processNodejsScript(currentNode jenkinsjson.Node, result *string) {
+	for _, child := range currentNode.Children {
+		processNode(child, result)
+	}
+}
+
+func processNode(node jenkinsjson.Node, result *string) {
+	if stepType, exists := node.AttributesMap["jenkins.pipeline.step.type"]; exists {
+		switch stepType {
+		case "wrap":
+			for _, child := range node.Children {
+				processNode(child, result)
+			}
+		case "bat", "sh":
+			if script, ok := node.ParameterMap["script"].(string); ok {
+				*result += script + "\n"
+			}
+		}
+	}
+}
+
 func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWithID, processedTools *ProcessedTools, variables map[string]string, timeout string, dockerImage string) (*harness.CloneStage, *harness.Repository) {
 	var clone *harness.CloneStage
 	var repo *harness.Repository
@@ -527,6 +548,13 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 		}
 		if processedTools.AntPresent {
 			clone, repo = recursiveHandleWithTool(currentNode, stepWithIDList, processedTools, "ant", "ant", "frekele/ant:latest", variables, timeout)
+		}
+		if symbol, ok := currentNode.ParameterMap["delegate"].(map[string]interface{})["symbol"]; ok && symbol == "nodejs" {
+			// Recursively process children
+			var result string
+			processNodejsScript(currentNode, &result)
+			fmt.Println(result)
+			// *stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertPowerShell(currentNode, variables, timeout), ID: id})
 		}
 	case "powershell":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertPowerShell(currentNode, variables, timeout), ID: id})

--- a/convert/jenkinsjson/convertTestFiles/nodejs/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/nodejs/Jenkinsfile
@@ -1,0 +1,48 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Generate package.json') {
+            steps {
+                script {
+                    // Create a valid JSON package.json file without comments
+                    def packageJson = '''{
+                      "name": "test-nodejs-plugin",
+                      "version": "1.0.0",
+                      "description": "Sample project to test NodeJS plugin in Jenkins",
+                      "scripts": {
+                        "test": "echo \\"Running tests...\\" && exit 0"
+                      },
+                      "dependencies": {
+                        "lodash": "^4.17.21"
+                      }
+                    }'''
+                    writeFile(file: 'package.json', text: packageJson)
+                }
+
+            }
+        }
+
+        stage('Install Packages') {
+            steps {
+                // Set up the NodeJS environment
+                nodejs(nodeJSInstallationName: 'node') {
+                    sh '''
+                        # Ensure npm uses the public registry
+                        echo "registry=https://registry.npmjs.org/" > .npmrc
+                        npm install
+                    '''
+                }
+            }
+        }
+
+        stage('Run Tests') {
+            steps {
+                nodejs(nodeJSInstallationName: 'node') {
+                    // Run npm test to execute the "test" script in package.json
+                    sh 'npm test'
+                }
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/nodejs/nodejs.yaml
+++ b/convert/jenkinsjson/convertTestFiles/nodejs/nodejs.yaml
@@ -1,0 +1,11 @@
+- step:
+    identifier: stagenull99086b
+    name: Nodejs
+    spec:
+      command: |
+        npm --version
+        npm install
+      image: node:latest
+      shell: Sh
+    timeout: ""
+    type: Run

--- a/convert/jenkinsjson/convertTestFiles/nodejs/nodejs_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/nodejs/nodejs_snippet.json
@@ -1,0 +1,126 @@
+{
+  "spanId": "99086bc578544ba9",
+  "traceId": "8a85a96d5009b0838f1074cd9bd5984c",
+  "parent": "Test_Nodejs_plugin",
+  "all-info": "span(name: Stage: null, spanId: 99086bc578544ba9, parentSpanId: b726fb59b015ad7b, traceId: 8a85a96d5009b0838f1074cd9bd5984c, attr: harness-attribute:{\r\n  \"delegate\" : {\r\n    \"symbol\" : \"nodejs\",\r\n    \"klass\" : null,\r\n    \"arguments\" : {\r\n      \"nodeJSInstallationName\" : \"Node 22\"\r\n    },\r\n    \"model\" : null\r\n  }\r\n};harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@52416506:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@52416506;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@4f5adbd4:org.jenkinsci.plugins.workflow.actions.TimingAction@4f5adbd4;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@146b406d:org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@146b406d;harness-others:;jenkins.pipeline.step.type:wrap;)",
+  "children": [
+    {
+      "spanId": "4dad6bcc1544f9b9",
+      "traceId": "8a85a96d5009b0838f1074cd9bd5984c",
+      "parent": "Test_Nodejs_plugin",
+      "all-info": "span(name: Stage: null, spanId: 4dad6bcc1544f9b9, parentSpanId: 99086bc578544ba9, traceId: 8a85a96d5009b0838f1074cd9bd5984c, attr: harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@3bc1da4e:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@3bc1da4e;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@2904a805:org.jenkinsci.plugins.workflow.actions.TimingAction@2904a805;harness-others:;jenkins.pipeline.step.type:wrap;)",
+      "name": "Test_Nodejs_plugin #4",
+      "attributesMap": {
+        "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@3bc1da4e": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@3bc1da4e",
+        "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@2904a805": "org.jenkinsci.plugins.workflow.actions.TimingAction@2904a805",
+        "harness-others": "",
+        "jenkins.pipeline.step.type": "wrap"
+      },
+      "type": "Run Phase Span",
+      "parentSpanId": "99086bc578544ba9",
+      "spanName": "Stage: null"
+    },
+    {
+      "spanId": "6020c253b602c693",
+      "traceId": "8a85a96d5009b0838f1074cd9bd5984c",
+      "parent": "Test_Nodejs_plugin",
+      "all-info": "span(name: Stage: null, spanId: 6020c253b602c693, parentSpanId: 99086bc578544ba9, traceId: 8a85a96d5009b0838f1074cd9bd5984c, attr: harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@17036922:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@17036922;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@41cef527:org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@41cef527;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@325b7831:org.jenkinsci.plugins.workflow.actions.TimingAction@325b7831;harness-others:;jenkins.pipeline.step.type:wrap;)",
+      "children": [
+        {
+          "spanId": "470bd0cfec6f43ac",
+          "traceId": "8a85a96d5009b0838f1074cd9bd5984c",
+          "parent": "Test_Nodejs_plugin",
+          "all-info": "span(name: bat, spanId: 470bd0cfec6f43ac, parentSpanId: 6020c253b602c693, traceId: 8a85a96d5009b0838f1074cd9bd5984c, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\r\n  \"script\" : \"npm --version\"\r\n};harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@6fa85e2a:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@6fa85e2a;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@637dbca1:org.jenkinsci.plugins.workflow.actions.TimingAction@637dbca1;harness-others:-WATCHING_RECURRENCE_PERIOD-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep WATCHING_RECURRENCE_PERIOD-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.WATCHING_RECURRENCE_PERIOD-long-USE_WATCHING-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep USE_WATCHING-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING-boolean-REMOTE_TIMEOUT-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep REMOTE_TIMEOUT-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT-long;jenkins.pipeline.step.id:18;jenkins.pipeline.step.name:Windows Batch Script;jenkins.pipeline.step.plugin.name:workflow-durable-task-step;jenkins.pipeline.step.plugin.version:1371.vb_7cec8f3b_95e;jenkins.pipeline.step.type:bat;)",
+          "name": "Test_Nodejs_plugin #4",
+          "attributesMap": {
+            "harness-others": "-WATCHING_RECURRENCE_PERIOD-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep WATCHING_RECURRENCE_PERIOD-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.WATCHING_RECURRENCE_PERIOD-long-USE_WATCHING-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep USE_WATCHING-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING-boolean-REMOTE_TIMEOUT-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep REMOTE_TIMEOUT-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT-long",
+            "jenkins.pipeline.step.name": "Windows Batch Script",
+            "ci.pipeline.run.user": "SYSTEM",
+            "jenkins.pipeline.step.id": "18",
+            "jenkins.pipeline.step.type": "bat",
+            "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@637dbca1": "org.jenkinsci.plugins.workflow.actions.TimingAction@637dbca1",
+            "harness-attribute": "{\r\n  \"script\" : \"npm --version\"\r\n}",
+            "jenkins.pipeline.step.plugin.name": "workflow-durable-task-step",
+            "jenkins.pipeline.step.plugin.version": "1371.vb_7cec8f3b_95e",
+            "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@6fa85e2a": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@6fa85e2a"
+          },
+          "type": "Run Phase Span",
+          "parentSpanId": "6020c253b602c693",
+          "parameterMap": { "script": "npm --version" },
+          "spanName": "bat"
+        },
+        {
+          "spanId": "4a9bac16c68a1993",
+          "traceId": "8a85a96d5009b0838f1074cd9bd5984c",
+          "parent": "Test_Nodejs_plugin",
+          "all-info": "span(name: Stage: null, spanId: 4a9bac16c68a1993, parentSpanId: 6020c253b602c693, traceId: 8a85a96d5009b0838f1074cd9bd5984c, attr: harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@c8a17fe:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@c8a17fe;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@30e0409c:org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@30e0409c;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@47cf545e:org.jenkinsci.plugins.workflow.actions.TimingAction@47cf545e;harness-others:;jenkins.pipeline.step.type:wrap;)",
+          "name": "Test_Nodejs_plugin #4",
+          "attributesMap": {
+            "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@47cf545e": "org.jenkinsci.plugins.workflow.actions.TimingAction@47cf545e",
+            "harness-others": "",
+            "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@c8a17fe": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@c8a17fe",
+            "jenkins.pipeline.step.type": "wrap",
+            "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@30e0409c": "org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@30e0409c"
+          },
+          "type": "Run Phase Span",
+          "parentSpanId": "6020c253b602c693",
+          "spanName": "Stage: null"
+        },
+        {
+          "spanId": "eb13aeb24d05fbb1",
+          "traceId": "8a85a96d5009b0838f1074cd9bd5984c",
+          "parent": "Test_Nodejs_plugin",
+          "all-info": "span(name: bat, spanId: eb13aeb24d05fbb1, parentSpanId: 6020c253b602c693, traceId: 8a85a96d5009b0838f1074cd9bd5984c, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\r\n  \"script\" : \"npm install\"\r\n};harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@5a73f798:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@5a73f798;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@5fe91849:org.jenkinsci.plugins.workflow.actions.TimingAction@5fe91849;harness-others:-WATCHING_RECURRENCE_PERIOD-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep WATCHING_RECURRENCE_PERIOD-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.WATCHING_RECURRENCE_PERIOD-long-USE_WATCHING-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep USE_WATCHING-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING-boolean-REMOTE_TIMEOUT-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep REMOTE_TIMEOUT-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT-long;jenkins.pipeline.step.id:19;jenkins.pipeline.step.name:Windows Batch Script;jenkins.pipeline.step.plugin.name:workflow-durable-task-step;jenkins.pipeline.step.plugin.version:1371.vb_7cec8f3b_95e;jenkins.pipeline.step.type:bat;)",
+          "name": "Test_Nodejs_plugin #4",
+          "attributesMap": {
+            "harness-others": "-WATCHING_RECURRENCE_PERIOD-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep WATCHING_RECURRENCE_PERIOD-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.WATCHING_RECURRENCE_PERIOD-long-USE_WATCHING-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep USE_WATCHING-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING-boolean-REMOTE_TIMEOUT-staticField org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep REMOTE_TIMEOUT-org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.REMOTE_TIMEOUT-long",
+            "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@5a73f798": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@5a73f798",
+            "jenkins.pipeline.step.name": "Windows Batch Script",
+            "ci.pipeline.run.user": "SYSTEM",
+            "jenkins.pipeline.step.id": "19",
+            "jenkins.pipeline.step.type": "bat",
+            "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@5fe91849": "org.jenkinsci.plugins.workflow.actions.TimingAction@5fe91849",
+            "harness-attribute": "{\r\n  \"script\" : \"npm install\"\r\n}",
+            "jenkins.pipeline.step.plugin.name": "workflow-durable-task-step",
+            "jenkins.pipeline.step.plugin.version": "1371.vb_7cec8f3b_95e"
+          },
+          "type": "Run Phase Span",
+          "parentSpanId": "6020c253b602c693",
+          "parameterMap": { "script": "npm install" },
+          "spanName": "bat"
+        }
+      ],
+      "name": "Test_Nodejs_plugin #4",
+      "attributesMap": {
+        "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@17036922": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@17036922",
+        "harness-others": "",
+        "jenkins.pipeline.step.type": "wrap",
+        "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@41cef527": "org.jenkinsci.plugins.workflow.actions.BodyInvocationAction@41cef527",
+        "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@325b7831": "org.jenkinsci.plugins.workflow.actions.TimingAction@325b7831"
+      },
+      "type": "Run Phase Span",
+      "parentSpanId": "99086bc578544ba9",
+      "spanName": "Stage: null"
+    }
+  ],
+  "name": "Test_Nodejs_plugin #4",
+  "attributesMap": {
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@146b406d": "org.jenkinsci.plugins.workflow.support.actions.LogStorageAction@146b406d",
+    "harness-others": "",
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@52416506": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@52416506",
+    "jenkins.pipeline.step.type": "wrap",
+    "harness-attribute": "{\r\n  \"delegate\" : {\r\n    \"symbol\" : \"nodejs\",\r\n    \"klass\" : null,\r\n    \"arguments\" : {\r\n      \"nodeJSInstallationName\" : \"Node 22\"\r\n    },\r\n    \"model\" : null\r\n  }\r\n}",
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@4f5adbd4": "org.jenkinsci.plugins.workflow.actions.TimingAction@4f5adbd4"
+  },
+  "type": "Run Phase Span",
+  "parentSpanId": "b726fb59b015ad7b",
+  "parameterMap": {
+    "delegate": {
+      "symbol": "nodejs",
+      "klass": null,
+      "arguments": { "nodeJSInstallationName": "Node 22" },
+      "model": null
+    }
+  },
+  "spanName": "Stage: null"
+}

--- a/convert/jenkinsjson/json/nodejs.go
+++ b/convert/jenkinsjson/json/nodejs.go
@@ -1,0 +1,46 @@
+package json
+
+import (
+	harness "github.com/drone/spec/dist/go"
+)
+
+// ConvertNodejs creates a Harness step for nunit plugin.
+func ConvertNodejs(node Node) *harness.Step {
+	// Recursively process children
+	var script string
+	processNodejsScript(node, &script)
+	convertNodeJs := &harness.Step{
+		Name: "Nodejs",
+		Type: "script",
+		Id:   SanitizeForId(node.SpanName, node.SpanId),
+		Spec: &harness.StepExec{
+			Connector: "<+input_docker_hub_connector>",
+			Image:     "node:latest",
+			Shell:     "sh",
+			Run:       script,
+		},
+	}
+
+	return convertNodeJs
+}
+
+func processNodejsScript(currentNode Node, result *string) {
+	for _, child := range currentNode.Children {
+		processNode(child, result)
+	}
+}
+
+func processNode(node Node, result *string) {
+	if stepType, exists := node.AttributesMap["jenkins.pipeline.step.type"]; exists {
+		switch stepType {
+		case "wrap":
+			for _, child := range node.Children {
+				processNode(child, result)
+			}
+		case "bat", "sh":
+			if script, ok := node.ParameterMap["script"].(string); ok {
+				*result += script + "\n"
+			}
+		}
+	}
+}

--- a/convert/jenkinsjson/json/nodejs_test.go
+++ b/convert/jenkinsjson/json/nodejs_test.go
@@ -1,0 +1,34 @@
+package json
+
+import (
+	"testing"
+
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertNodejs(t *testing.T) {
+
+	var tests []runner
+	tests = append(tests, prepare(t, "/nodejs/nodejs_snippet", &harness.Step{
+		Id:   "Stage_null99086b",
+		Name: "Nodejs",
+		Type: "script",
+		Spec: &harness.StepExec{
+			Connector: "<+input_docker_hub_connector>",
+			Image:     "node:latest",
+			Shell:     "sh",
+			Run:       "npm --version\nnpm install\n",
+		},
+	}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertNodejs(tt.input)
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("ConvertNodejs() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -685,5 +685,28 @@ line3'''
                 ])
             }
         }
+
+        //Nodejs pipeline stage
+        stage('Install Packages') {
+            steps {
+                // Set up the NodeJS environment
+                nodejs(nodeJSInstallationName: 'node') {
+                    sh '''
+                        # Ensure npm uses the public registry
+                        echo "registry=https://registry.npmjs.org/" > .npmrc
+                        npm install
+                    '''
+                }
+            }
+        }
+
+        stage('Run Tests') {
+            steps {
+                nodejs(nodeJSInstallationName: 'node') {
+                    // Run npm test to execute the "test" script in package.json
+                    sh 'npm test'
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Nodejs go-conversion:
Added "Nodejs" support to go-convert specific to jenkins migration.

Nodejs Jenkins Trace:
[Test_Nodejs_plugin__4.json](https://github.com/user-attachments/files/17822886/Test_Nodejs_plugin__4.json)

go run main.go jenkinsjson --downgrade ~/go/Test_Nodejs_plugin__4.json

Harness Nodejs test pipeline [here](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/default/projects/jenkinstoharness/pipelines/Vani_Nodejs/deployments/7xFIHcf4Qnqo266DMu44kQ/pipeline?storeType=INLINE).
Nodejs harness pipeline step:

```
- step:
    identifier: stagenull99086b
    name: Nodejs
    spec:
      command: |
        npm --version
        npm install
      image: node:latest
      shell: Sh
    timeout: ""
    type: Run
```






