### PR TITLE
feat-notification: Notification conversion step for harness

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -724,6 +724,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 	case "javadoc":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertJavadoc(currentNode, variables), ID: id})
 
+	case "notifyEndpoints":
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertNotification(currentNode, currentNode.ParameterMap), ID: id})
+
 	default:
 		placeholderStr := fmt.Sprintf("echo %q", "This is a place holder for: "+currentNode.AttributesMap["jenkins.pipeline.step.type"])
 		b, err := json.MarshalIndent(currentNode.ParameterMap, "", "  ")

--- a/convert/jenkinsjson/convertTestFiles/Notification/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/Notification/Jenkinsfile
@@ -1,0 +1,35 @@
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            steps {
+                echo 'Simulating a build process...'
+                // Debug message for build stage
+                script {
+                    echo "Build stage is starting."
+                }
+            }
+        }
+        stage('Notify') {
+            steps {
+                script {
+                    // Prepare payload
+                    def payload = '{"status": "Build Successful", "job": "${env.JOB_NAME}", "buildNumber": "${env.BUILD_NUMBER}"}'
+
+                    // Debug: Print payload to verify its structure
+                    echo "Payload: ${payload}"
+
+                    // Debug: Check if the endpoint exists and can be accessed
+                    try {
+                        echo "Attempting to notify endpoint 'localEndpoint' with data"
+                        notifyEndpoints id: 'localEndpoint', data: payload
+                        echo "Notification sent successfully."
+                    } catch (Exception e) {
+                        // Catching any potential error during the notification
+                        echo "Failed to notify endpoint. Error: ${e.getMessage()}"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/Notification/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/Notification/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent any
 
     environment {
-        NOTIFICATION_ENDPOINT = "http://localhost:3000/api/data"
+        NOTIFICATION_ENDPOINT = "https://webhook.site/9ffae84b-a338-43ef-9283-319d70574bf4"
         NOTIFICATION_PROTOCOL = "HTTP"
         NOTIFICATION_FORMAT = "JSON"
         BUILD_NOTES = "Build metrics for analysis"
@@ -33,6 +33,19 @@ pipeline {
                         loglines: '1'
                     )
                 }
+            }
+        }
+    }
+        post {
+        always {
+            script {
+                notifyEndpoints(
+                    endpoint: env.NOTIFICATION_ENDPOINT,
+                  
+                    notes: env.BUILD_NOTES,
+                    phase: 'COMPLETED',
+                    loglines: '10'
+                )
             }
         }
     }

--- a/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
+++ b/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
@@ -5,17 +5,14 @@
       image: plugins/webhook
       settings:
         content-type: application/json
-        headers:
-          - "Authorization: abcd"
         method: POST
-        password: mypassword
-        template: "{\n  \t\t\"loglines\": \"10\",\n  \t\t\"phase\":
-          \"COMPLETED\",\n  \t\t\"status\": \"Success\",\n  \t\t\"notes\":
-          \"Build metrics for analysis\",\n  \t\t\"timestamp\": \"${time.now()}\"\n\t}"
-        token-type: Bearer
-        token-value: your-token-value
+        password: <+input>
+        template: "{\n  \t\t\"phase\": \"COMPLETED\",\n  \t\t\"notes\":
+          \"Build metrics for analysis\",\n\t}"
+        token-type: <+input>
+        token-value: <+input>
         urls:
           - https://httpbin.org/post
-        username: myusername
+        username: <+input>
     timeout: ""
     type: Plugin

--- a/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
+++ b/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
@@ -1,0 +1,16 @@
+- step:
+    identifier: notifyendpointsca9fc8
+    name: Notification
+    spec:
+      image: plugins/webhook
+      settings:
+        content_type: application/json
+        debug: "true"
+        method: <+input>
+        password: <+input>
+        template: '{"status": "Build Successful", "job": "${env.JOB_NAME}",
+                        "buildNumber": "${env.BUILD_NUMBER}"}'
+        urls: <+input>
+        username: <+input>
+    timeout: ""
+    type: Plugin

--- a/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
+++ b/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
@@ -1,18 +1,18 @@
 - step:
-    identifier: notifyendpoints2f61b6
+    identifier: notifyendpointsaa7206
     name: Notification
     spec:
       image: plugins/webhook
       settings:
         content-type: application/json
         method: POST
-        password: <+input>
-        template: "{\n  \t\t\"phase\": \"COMPLETED\",\n  \t\t\"notes\":
-          \"Build metrics for analysis\",\n\t}"
-        token-type: <+input>
+        template: |-
+          {
+              "status": "SUCCESSFUL",
+              "notes": "Build metrics for analysis"
+          }
         token-value: <+input>
         urls:
           - https://webhook.site/9ffae84b-a338-43ef-9283-319d70574bf4
-        username: <+input>
     timeout: ""
     type: Plugin

--- a/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
+++ b/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
@@ -12,7 +12,7 @@
         token-type: <+input>
         token-value: <+input>
         urls:
-          - https://httpbin.org/post
+          - https://webhook.site/9ffae84b-a338-43ef-9283-319d70574bf4
         username: <+input>
     timeout: ""
     type: Plugin

--- a/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
+++ b/convert/jenkinsjson/convertTestFiles/Notification/notification.yaml
@@ -1,16 +1,21 @@
 - step:
-    identifier: notifyendpointsca9fc8
+    identifier: notifyendpoints2f61b6
     name: Notification
     spec:
       image: plugins/webhook
       settings:
-        content_type: application/json
-        debug: "true"
-        method: <+input>
-        password: <+input>
-        template: '{"status": "Build Successful", "job": "${env.JOB_NAME}",
-                        "buildNumber": "${env.BUILD_NUMBER}"}'
-        urls: <+input>
-        username: <+input>
+        content-type: application/json
+        headers:
+          - "Authorization: abcd"
+        method: POST
+        password: mypassword
+        template: "{\n  \t\t\"loglines\": \"10\",\n  \t\t\"phase\":
+          \"COMPLETED\",\n  \t\t\"status\": \"Success\",\n  \t\t\"notes\":
+          \"Build metrics for analysis\",\n  \t\t\"timestamp\": \"${time.now()}\"\n\t}"
+        token-type: Bearer
+        token-value: your-token-value
+        urls:
+          - https://httpbin.org/post
+        username: myusername
     timeout: ""
     type: Plugin

--- a/convert/jenkinsjson/convertTestFiles/Notification/notification_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/Notification/notification_snippet.json
@@ -1,27 +1,36 @@
 {
-  "spanId": "ca9fc8eff41d4f92",
-  "traceId": "f1adc1d1a45c1dedbd53784e7fca2814",
-  "parent": "vani_notification",
-  "all-info": "span(name: notifyEndpoints, spanId: ca9fc8eff41d4f92, parentSpanId: acee98a0cf6aa892, traceId: f1adc1d1a45c1dedbd53784e7fca2814, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"data\" : \"{\\\"status\\\": \\\"Build Successful\\\", \\\"job\\\": \\\"${env.JOB_NAME}\\\", \\\"buildNumber\\\": \\\"${env.BUILD_NUMBER}\\\"}\",\n  \"id\" : \"localEndpoint\"\n};harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@31117cf1:com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@31117cf1;harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ac86a35:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ac86a35;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@3de2c204:org.jenkinsci.plugins.workflow.actions.TimingAction@3de2c204;harness-others:;jenkins.pipeline.step.id:21;jenkins.pipeline.step.name:Notify configured endpoints;jenkins.pipeline.step.plugin.name:notification;jenkins.pipeline.step.plugin.version:1.17;jenkins.pipeline.step.type:notifyEndpoints;)",
-  "name": "vani_notification #18",
+  "spanId": "2f61b68e9e0048e2",
+  "traceId": "2b0e53934eda3036265588832b32296a",
+  "parent": "notification",
+  "all-info": "span(name: notifyEndpoints, spanId: 2f61b68e9e0048e2, parentSpanId: 527ceb23f807b770, traceId: 2b0e53934eda3036265588832b32296a, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"phase\" : \"COMPLETED\",\n  \"endpoints\" : [ {\n    \"url\" : \"https://httpbin.org/post\",\n    \"protocol\" : \"HTTP\",\n    \"format\" : \"JSON\",\n    \"headers\" : {\n      \"Authorization\" : \"abcd\"\n    }\n  } ],\n  \"loglines\" : \"10\",\n  \"notes\" : \"Build metrics for analysis\"\n};harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@3b2b0b5d:com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@3b2b0b5d;harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@10e3eda8:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@10e3eda8;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1659c9c:org.jenkinsci.plugins.workflow.actions.TimingAction@1659c9c;harness-others:;jenkins.pipeline.step.id:32;jenkins.pipeline.step.name:Notify configured endpoints;jenkins.pipeline.step.plugin.name:notification;jenkins.pipeline.step.plugin.version:1.18;jenkins.pipeline.step.type:notifyEndpoints;)",
+  "name": "notification #28",
   "attributesMap": {
-    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@3de2c204": "org.jenkinsci.plugins.workflow.actions.TimingAction@3de2c204",
     "harness-others": "",
     "jenkins.pipeline.step.name": "Notify configured endpoints",
     "ci.pipeline.run.user": "SYSTEM",
-    "jenkins.pipeline.step.id": "21",
+    "jenkins.pipeline.step.id": "32",
     "jenkins.pipeline.step.type": "notifyEndpoints",
-    "harness-attribute": "{\n  \"data\" : \"{\\\"status\\\": \\\"Build Successful\\\", \\\"job\\\": \\\"${env.JOB_NAME}\\\", \\\"buildNumber\\\": \\\"${env.BUILD_NUMBER}\\\"}\",\n  \"id\" : \"localEndpoint\"\n}",
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@10e3eda8": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@10e3eda8",
+    "harness-attribute": "{\n  \"phase\" : \"COMPLETED\",\n  \"endpoints\" : [ {\n    \"url\" : \"https://httpbin.org/post\",\n    \"protocol\" : \"HTTP\",\n    \"format\" : \"JSON\",\n    \"headers\" : {\n      \"Authorization\" : \"abcd\"\n    }\n  } ],\n  \"loglines\" : \"10\",\n  \"notes\" : \"Build metrics for analysis\"\n}",
     "jenkins.pipeline.step.plugin.name": "notification",
-    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ac86a35": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ac86a35",
-    "jenkins.pipeline.step.plugin.version": "1.17",
-    "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@31117cf1": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@31117cf1"
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1659c9c": "org.jenkinsci.plugins.workflow.actions.TimingAction@1659c9c",
+    "jenkins.pipeline.step.plugin.version": "1.18",
+    "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@3b2b0b5d": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@3b2b0b5d"
   },
   "type": "Run Phase Span",
-  "parentSpanId": "acee98a0cf6aa892",
+  "parentSpanId": "527ceb23f807b770",
   "parameterMap": {
-    "data": "{\"status\": \"Build Successful\", \"job\": \"${env.JOB_NAME}\", \"buildNumber\": \"${env.BUILD_NUMBER}\"}",
-    "id": "localEndpoint"
+    "phase": "COMPLETED",
+    "endpoints": [
+      {
+        "headers": { "Authorization": "abcd" },
+        "protocol": "HTTP",
+        "format": "JSON",
+        "url": "https://httpbin.org/post"
+      }
+    ],
+    "loglines": "10",
+    "notes": "Build metrics for analysis"
   },
   "spanName": "notifyEndpoints"
 }

--- a/convert/jenkinsjson/convertTestFiles/Notification/notification_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/Notification/notification_snippet.json
@@ -1,0 +1,27 @@
+{
+  "spanId": "ca9fc8eff41d4f92",
+  "traceId": "f1adc1d1a45c1dedbd53784e7fca2814",
+  "parent": "vani_notification",
+  "all-info": "span(name: notifyEndpoints, spanId: ca9fc8eff41d4f92, parentSpanId: acee98a0cf6aa892, traceId: f1adc1d1a45c1dedbd53784e7fca2814, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"data\" : \"{\\\"status\\\": \\\"Build Successful\\\", \\\"job\\\": \\\"${env.JOB_NAME}\\\", \\\"buildNumber\\\": \\\"${env.BUILD_NUMBER}\\\"}\",\n  \"id\" : \"localEndpoint\"\n};harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@31117cf1:com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@31117cf1;harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ac86a35:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ac86a35;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@3de2c204:org.jenkinsci.plugins.workflow.actions.TimingAction@3de2c204;harness-others:;jenkins.pipeline.step.id:21;jenkins.pipeline.step.name:Notify configured endpoints;jenkins.pipeline.step.plugin.name:notification;jenkins.pipeline.step.plugin.version:1.17;jenkins.pipeline.step.type:notifyEndpoints;)",
+  "name": "vani_notification #18",
+  "attributesMap": {
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@3de2c204": "org.jenkinsci.plugins.workflow.actions.TimingAction@3de2c204",
+    "harness-others": "",
+    "jenkins.pipeline.step.name": "Notify configured endpoints",
+    "ci.pipeline.run.user": "SYSTEM",
+    "jenkins.pipeline.step.id": "21",
+    "jenkins.pipeline.step.type": "notifyEndpoints",
+    "harness-attribute": "{\n  \"data\" : \"{\\\"status\\\": \\\"Build Successful\\\", \\\"job\\\": \\\"${env.JOB_NAME}\\\", \\\"buildNumber\\\": \\\"${env.BUILD_NUMBER}\\\"}\",\n  \"id\" : \"localEndpoint\"\n}",
+    "jenkins.pipeline.step.plugin.name": "notification",
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ac86a35": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ac86a35",
+    "jenkins.pipeline.step.plugin.version": "1.17",
+    "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@31117cf1": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@31117cf1"
+  },
+  "type": "Run Phase Span",
+  "parentSpanId": "acee98a0cf6aa892",
+  "parameterMap": {
+    "data": "{\"status\": \"Build Successful\", \"job\": \"${env.JOB_NAME}\", \"buildNumber\": \"${env.BUILD_NUMBER}\"}",
+    "id": "localEndpoint"
+  },
+  "spanName": "notifyEndpoints"
+}

--- a/convert/jenkinsjson/convertTestFiles/Notification/notification_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/Notification/notification_snippet.json
@@ -1,35 +1,28 @@
 {
-  "spanId": "2f61b68e9e0048e2",
-  "traceId": "2b0e53934eda3036265588832b32296a",
-  "parent": "notification",
-  "all-info": "span(name: notifyEndpoints, spanId: 2f61b68e9e0048e2, parentSpanId: 527ceb23f807b770, traceId: 2b0e53934eda3036265588832b32296a, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"phase\" : \"COMPLETED\",\n  \"endpoints\" : [ {\n    \"url\" : \"https://httpbin.org/post\",\n    \"protocol\" : \"HTTP\",\n    \"format\" : \"JSON\",\n    \"headers\" : {\n      \"Authorization\" : \"abcd\"\n    }\n  } ],\n  \"loglines\" : \"10\",\n  \"notes\" : \"Build metrics for analysis\"\n};harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@3b2b0b5d:com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@3b2b0b5d;harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@10e3eda8:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@10e3eda8;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1659c9c:org.jenkinsci.plugins.workflow.actions.TimingAction@1659c9c;harness-others:;jenkins.pipeline.step.id:32;jenkins.pipeline.step.name:Notify configured endpoints;jenkins.pipeline.step.plugin.name:notification;jenkins.pipeline.step.plugin.version:1.18;jenkins.pipeline.step.type:notifyEndpoints;)",
-  "name": "notification #28",
+  "spanId": "c1ca8f942d508a7d",
+  "traceId": "1e73c5bfc71b34177b49c7217d9c875e",
+  "parent": "notification_1",
+  "all-info": "span(name: notifyEndpoints, spanId: c1ca8f942d508a7d, parentSpanId: f02f5e6730d53d10, traceId: 1e73c5bfc71b34177b49c7217d9c875e, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"phase\" : \"COMPLETED\",\n  \"endpoint\" : \"http://localhost:3000/api/data\",\n  \"loglines\" : \"1\",\n  \"notes\" : \"Build metrics for analysis\"\n};harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@6f7b23be:com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@6f7b23be;harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ccdf733:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ccdf733;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@377af433:org.jenkinsci.plugins.workflow.actions.TimingAction@377af433;harness-others:;jenkins.pipeline.step.id:23;jenkins.pipeline.step.name:Notify configured endpoints;jenkins.pipeline.step.plugin.name:notification;jenkins.pipeline.step.plugin.version:1.18;jenkins.pipeline.step.type:notifyEndpoints;)",
+  "name": "notification_1 #44",
   "attributesMap": {
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@377af433": "org.jenkinsci.plugins.workflow.actions.TimingAction@377af433",
     "harness-others": "",
     "jenkins.pipeline.step.name": "Notify configured endpoints",
     "ci.pipeline.run.user": "SYSTEM",
-    "jenkins.pipeline.step.id": "32",
+    "jenkins.pipeline.step.id": "23",
     "jenkins.pipeline.step.type": "notifyEndpoints",
-    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@10e3eda8": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@10e3eda8",
-    "harness-attribute": "{\n  \"phase\" : \"COMPLETED\",\n  \"endpoints\" : [ {\n    \"url\" : \"https://httpbin.org/post\",\n    \"protocol\" : \"HTTP\",\n    \"format\" : \"JSON\",\n    \"headers\" : {\n      \"Authorization\" : \"abcd\"\n    }\n  } ],\n  \"loglines\" : \"10\",\n  \"notes\" : \"Build metrics for analysis\"\n}",
+    "harness-attribute": "{\n  \"phase\" : \"COMPLETED\",\n  \"endpoint\" : \"http://localhost:3000/api/data\",\n  \"loglines\" : \"1\",\n  \"notes\" : \"Build metrics for analysis\"\n}",
+    "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@6f7b23be": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@6f7b23be",
     "jenkins.pipeline.step.plugin.name": "notification",
-    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@1659c9c": "org.jenkinsci.plugins.workflow.actions.TimingAction@1659c9c",
-    "jenkins.pipeline.step.plugin.version": "1.18",
-    "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@3b2b0b5d": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@3b2b0b5d"
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ccdf733": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@1ccdf733",
+    "jenkins.pipeline.step.plugin.version": "1.18"
   },
   "type": "Run Phase Span",
-  "parentSpanId": "527ceb23f807b770",
+  "parentSpanId": "f02f5e6730d53d10",
   "parameterMap": {
     "phase": "COMPLETED",
-    "endpoints": [
-      {
-        "headers": { "Authorization": "abcd" },
-        "protocol": "HTTP",
-        "format": "JSON",
-        "url": "https://httpbin.org/post"
-      }
-    ],
-    "loglines": "10",
+    "endpoint": "https://webhook.site/9ffae84b-a338-43ef-9283-319d70574bf4",
+    "loglines": "1",
     "notes": "Build metrics for analysis"
   },
   "spanName": "notifyEndpoints"

--- a/convert/jenkinsjson/json/notification.go
+++ b/convert/jenkinsjson/json/notification.go
@@ -22,11 +22,17 @@ func ConvertNotification(node Node, parameterMap map[string]interface{}) *harnes
 	phase, _ := parameterMap["phase"].(string)
 	notes, _ := parameterMap["notes"].(string)
 
+	// Determine the status based on phase
+	status := ""
+	if phase == "COMPLETED" {
+		status = "SUCCESSFUL"
+	}
+
 	// Create the template
 	template := fmt.Sprintf(`{
-  		"phase": "%s",
-  		"notes": "%s",
-	}`, phase, notes)
+    "status": "%s",
+    "notes": "%s"
+}`, status, notes)
 
 	convertNotification := &harness.Step{
 		Name: "Notification",
@@ -37,10 +43,7 @@ func ConvertNotification(node Node, parameterMap map[string]interface{}) *harnes
 			With: map[string]interface{}{
 				"urls":         urls,
 				"method":       "POST",
-				"username":     "<+input>",
-				"password":     "<+input>",
 				"token-value":  "<+input>",
-				"token-type":   "<+input>",
 				"content-type": "application/json",
 				"template":     template,
 			},

--- a/convert/jenkinsjson/json/notification.go
+++ b/convert/jenkinsjson/json/notification.go
@@ -1,12 +1,20 @@
 package json
 
 import (
+	"encoding/json"
+
 	harness "github.com/drone/spec/dist/go"
 )
 
 // ConvertNotification creates a Harness step for nunit plugin.
 func ConvertNotification(node Node, arguments map[string]interface{}) *harness.Step {
 	data, _ := arguments["data"].(string)
+
+	// Remove line breaks and format as compact JSON
+	var compactData map[string]interface{}
+	_ = json.Unmarshal([]byte(data), &compactData) // Parse JSON
+	compactBytes, _ := json.Marshal(compactData)   // Convert to compact JSON
+	compactString := string(compactBytes)          // Convert bytes to string
 
 	convertNotification := &harness.Step{
 		Name: "Notification",
@@ -22,7 +30,7 @@ func ConvertNotification(node Node, arguments map[string]interface{}) *harness.S
 				"method":       "<+input>",
 				"content_type": "application/json",
 				"debug":        "true",
-				"template":     data,
+				"template":     compactString,
 			},
 		},
 	}

--- a/convert/jenkinsjson/json/notification.go
+++ b/convert/jenkinsjson/json/notification.go
@@ -1,0 +1,31 @@
+package json
+
+import (
+	harness "github.com/drone/spec/dist/go"
+)
+
+// ConvertNotification creates a Harness step for nunit plugin.
+func ConvertNotification(node Node, arguments map[string]interface{}) *harness.Step {
+	data, _ := arguments["data"].(string)
+
+	convertNotification := &harness.Step{
+		Name: "Notification",
+		Type: "plugin",
+		Id:   SanitizeForId(node.SpanName, node.SpanId),
+		Spec: &harness.StepPlugin{
+			Connector: "<+input>",
+			Image:     "plugins/webhook",
+			With: map[string]interface{}{
+				"urls":         "<+input>",
+				"username":     "<+input>",
+				"password":     "<+input>",
+				"method":       "<+input>",
+				"content_type": "application/json",
+				"debug":        "true",
+				"template":     data,
+			},
+		},
+	}
+
+	return convertNotification
+}

--- a/convert/jenkinsjson/json/notification.go
+++ b/convert/jenkinsjson/json/notification.go
@@ -10,32 +10,12 @@ import (
 func ConvertNotification(node Node, parameterMap map[string]interface{}) *harness.Step {
 
 	// Extract values from parameterMap
-	endpoints, ok := parameterMap["endpoints"].([]interface{})
+	url, urlOk := parameterMap["endpoint"].(string)
 	urls := []string{}
-	contentType := "application/json" // Default content type
 
-	if ok && len(endpoints) > 0 {
-		// Assuming only one endpoint in the array for simplicity
-		if endpoint, ok := endpoints[0].(map[string]interface{}); ok {
-			if url, ok := endpoint["url"].(string); ok {
-				urls = append(urls, url)
-			}
-
-			if format, ok := endpoint["format"].(string); ok {
-				switch format {
-				case "JSON":
-					contentType = "application/json"
-				case "XML":
-					contentType = "application/xml"
-				default:
-					contentType = "application/json" // Fallback
-				}
-			}
-		}
-	}
-
-	// If no URLs were found, use <+input>
-	if len(urls) == 0 {
+	if urlOk {
+		urls = append(urls, url)
+	} else {
 		urls = append(urls, "<+input>")
 	}
 
@@ -61,7 +41,7 @@ func ConvertNotification(node Node, parameterMap map[string]interface{}) *harnes
 				"password":     "<+input>",
 				"token-value":  "<+input>",
 				"token-type":   "<+input>",
-				"content-type": contentType,
+				"content-type": "application/json",
 				"template":     template,
 			},
 		},

--- a/convert/jenkinsjson/json/notification_test.go
+++ b/convert/jenkinsjson/json/notification_test.go
@@ -11,13 +11,13 @@ func TestConvertNotification(t *testing.T) { // Convert bytes to string
 
 	var tests []runner
 	tests = append(tests, prepare(t, "/notification/notification_snippet", &harness.Step{
-		Id:   "notifyEndpoints2f61b6",
+		Id:   "notifyEndpointsc1ca8f",
 		Name: "Notification",
 		Type: "plugin",
 		Spec: &harness.StepPlugin{
 			Image: "plugins/webhook",
 			With: map[string]interface{}{
-				"urls":         []string{"https://httpbin.org/post"},
+				"urls":         []string{"https://webhook.site/9ffae84b-a338-43ef-9283-319d70574bf4"},
 				"method":       "POST",
 				"username":     "<+input>",
 				"password":     "<+input>",

--- a/convert/jenkinsjson/json/notification_test.go
+++ b/convert/jenkinsjson/json/notification_test.go
@@ -1,20 +1,13 @@
 package json
 
 import (
-	"encoding/json"
 	"testing"
 
 	harness "github.com/drone/spec/dist/go"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestConvertNotification(t *testing.T) {
-
-	// Remove line breaks and format as compact JSON
-	var compactData map[string]interface{}
-	_ = json.Unmarshal([]byte("{\"status\": \"Build Successful\", \"job\": \"${env.JOB_NAME}\", \"buildNumber\": \"${env.BUILD_NUMBER}\"}"), &compactData) // Parse JSON
-	compactBytes, _ := json.Marshal(compactData)                                                                                                           // Convert to compact JSON
-	compactString := string(compactBytes)                                                                                                                  // Convert bytes to string
+func TestConvertNotification(t *testing.T) { // Convert bytes to string
 
 	var tests []runner
 	tests = append(tests, prepare(t, "/notification/notification_snippet", &harness.Step{
@@ -25,13 +18,21 @@ func TestConvertNotification(t *testing.T) {
 			Connector: "<+input>",
 			Image:     "plugins/webhook",
 			With: map[string]interface{}{
-				"urls":         "<+input>",
+				"urls":         []string{"https://httpbin.org/post"},
+				"method":       "POST",
 				"username":     "<+input>",
 				"password":     "<+input>",
-				"method":       "<+input>",
-				"content_type": "application/json",
-				"debug":        "true",
-				"template":     compactString,
+				"token-value":  "<+input>",
+				"token-type":   "<+input>",
+				"content-type": "application/json",
+				"headers":      "Authorization=abcd",
+				"template": `{
+  		"loglines": "10",
+  		"phase": "COMPLETED",
+  		"status": "Success",
+  		"notes": "Build metrics for analysis",
+  		"timestamp": "${time.now()}"
+	}`,
 			},
 		},
 	}))

--- a/convert/jenkinsjson/json/notification_test.go
+++ b/convert/jenkinsjson/json/notification_test.go
@@ -19,15 +19,12 @@ func TestConvertNotification(t *testing.T) { // Convert bytes to string
 			With: map[string]interface{}{
 				"urls":         []string{"https://webhook.site/9ffae84b-a338-43ef-9283-319d70574bf4"},
 				"method":       "POST",
-				"username":     "<+input>",
-				"password":     "<+input>",
 				"token-value":  "<+input>",
-				"token-type":   "<+input>",
 				"content-type": "application/json",
 				"template": `{
-  		"phase": "COMPLETED",
-  		"notes": "Build metrics for analysis",
-	}`,
+    "status": "SUCCESSFUL",
+    "notes": "Build metrics for analysis"
+}`,
 			},
 		},
 	}))

--- a/convert/jenkinsjson/json/notification_test.go
+++ b/convert/jenkinsjson/json/notification_test.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"encoding/json"
 	"testing"
 
 	harness "github.com/drone/spec/dist/go"
@@ -8,6 +9,12 @@ import (
 )
 
 func TestConvertNotification(t *testing.T) {
+
+	// Remove line breaks and format as compact JSON
+	var compactData map[string]interface{}
+	_ = json.Unmarshal([]byte("{\"status\": \"Build Successful\", \"job\": \"${env.JOB_NAME}\", \"buildNumber\": \"${env.BUILD_NUMBER}\"}"), &compactData) // Parse JSON
+	compactBytes, _ := json.Marshal(compactData)                                                                                                           // Convert to compact JSON
+	compactString := string(compactBytes)                                                                                                                  // Convert bytes to string
 
 	var tests []runner
 	tests = append(tests, prepare(t, "/notification/notification_snippet", &harness.Step{
@@ -24,7 +31,7 @@ func TestConvertNotification(t *testing.T) {
 				"method":       "<+input>",
 				"content_type": "application/json",
 				"debug":        "true",
-				"template":     "{\"status\": \"Build Successful\", \"job\": \"${env.JOB_NAME}\", \"buildNumber\": \"${env.BUILD_NUMBER}\"}",
+				"template":     compactString,
 			},
 		},
 	}))

--- a/convert/jenkinsjson/json/notification_test.go
+++ b/convert/jenkinsjson/json/notification_test.go
@@ -11,12 +11,11 @@ func TestConvertNotification(t *testing.T) { // Convert bytes to string
 
 	var tests []runner
 	tests = append(tests, prepare(t, "/notification/notification_snippet", &harness.Step{
-		Id:   "notifyEndpointsca9fc8",
+		Id:   "notifyEndpoints2f61b6",
 		Name: "Notification",
 		Type: "plugin",
 		Spec: &harness.StepPlugin{
-			Connector: "<+input>",
-			Image:     "plugins/webhook",
+			Image: "plugins/webhook",
 			With: map[string]interface{}{
 				"urls":         []string{"https://httpbin.org/post"},
 				"method":       "POST",
@@ -25,13 +24,9 @@ func TestConvertNotification(t *testing.T) { // Convert bytes to string
 				"token-value":  "<+input>",
 				"token-type":   "<+input>",
 				"content-type": "application/json",
-				"headers":      "Authorization=abcd",
 				"template": `{
-  		"loglines": "10",
   		"phase": "COMPLETED",
-  		"status": "Success",
   		"notes": "Build metrics for analysis",
-  		"timestamp": "${time.now()}"
 	}`,
 			},
 		},

--- a/convert/jenkinsjson/json/notification_test.go
+++ b/convert/jenkinsjson/json/notification_test.go
@@ -1,0 +1,41 @@
+package json
+
+import (
+	"testing"
+
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertNotification(t *testing.T) {
+
+	var tests []runner
+	tests = append(tests, prepare(t, "/notification/notification_snippet", &harness.Step{
+		Id:   "notifyEndpointsca9fc8",
+		Name: "Notification",
+		Type: "plugin",
+		Spec: &harness.StepPlugin{
+			Connector: "<+input>",
+			Image:     "plugins/webhook",
+			With: map[string]interface{}{
+				"urls":         "<+input>",
+				"username":     "<+input>",
+				"password":     "<+input>",
+				"method":       "<+input>",
+				"content_type": "application/json",
+				"debug":        "true",
+				"template":     "{\"status\": \"Build Successful\", \"job\": \"${env.JOB_NAME}\", \"buildNumber\": \"${env.BUILD_NUMBER}\"}",
+			},
+		},
+	}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertNotification(tt.input, tt.input.ParameterMap)
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("ConvertNotification() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/convert/jenkinsjson/json/notification_test.go
+++ b/convert/jenkinsjson/json/notification_test.go
@@ -10,7 +10,7 @@ import (
 func TestConvertNotification(t *testing.T) { // Convert bytes to string
 
 	var tests []runner
-	tests = append(tests, prepare(t, "/notification/notification_snippet", &harness.Step{
+	tests = append(tests, prepare(t, "/Notification/notification_snippet", &harness.Step{
 		Id:   "notifyEndpointsc1ca8f",
 		Name: "Notification",
 		Type: "plugin",

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -749,5 +749,29 @@ line3'''
                 version: '1.12'
             }
         }
+
+        //Notification Conversion step
+        stage('Notify') {
+            steps {
+                script {
+                    // Prepare payload
+                    def payload = '{"status": "Build Successful", "job": "${env.JOB_NAME}", "buildNumber": "${env.BUILD_NUMBER}"}'
+
+                    // Debug: Print payload to verify its structure
+                    echo "Payload: ${payload}"
+
+                    // Debug: Check if the endpoint exists and can be accessed
+                    try {
+                        echo "Attempting to notify endpoint 'localEndpoint' with data"
+                        notifyEndpoints id: 'localEndpoint', data: payload
+                        echo "Notification sent successfully."
+                    } catch (Exception e) {
+                        // Catching any potential error during the notification
+                        echo "Failed to notify endpoint. Error: ${e.getMessage()}"
+                    }
+                }
+            }
+        }
+
     }
 }

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -914,17 +914,19 @@ line3'''
             }
         }
 
-        stage('Notify') {
-            steps {
-                script {
-                    notifyEndpoints(
-                        endpoint: env.NOTIFICATION_ENDPOINT,
-                        notes: env.BUILD_NOTES,
-                        phase: 'COMPLETED',
-                        loglines: '1'
-                    )
-                }
+        //Notify Endpoints
+        post {
+        always {
+            script {
+                notifyEndpoints(
+                    endpoint: env.NOTIFICATION_ENDPOINT,
+                  
+                    notes: env.BUILD_NOTES,
+                    phase: 'COMPLETED',
+                    loglines: '10'
+                )
             }
+        }
         }
     }
 }


### PR DESCRIPTION
Notification go-conversion:
Added "Notification" support to go-convert specific to jenkins migration.

Norification Jenkins Trace:
[notification_28.json](https://github.com/user-attachments/files/18118924/notification_28.json)

go run main.go jenkinsjson --downgrade ~/go/notification_28.json

Harness Notification Pipeline is [here](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/default/projects/jenkinstoharness/pipelines/Vani_Notification/executions/bFVDXNsrQXmpeYWMwmdAuQ/pipeline).

Notification harness pipeline step:
```
- step:
    identifier: notifyendpointsaa7206
    name: Notification
    spec:
      image: plugins/webhook
      settings:
        content-type: application/json
        method: POST
        template: |-
          {
              "status": "SUCCESSFUL",
              "notes": "Build metrics for analysis"
          }
        token-value: <+input>
        urls:
          - https://webhook.site/9ffae84b-a338-43ef-9283-319d70574bf4
    timeout: ""
    type: Plugin
```