### PR TITLE
feat-unacrchive: Added a unarchive conversion step

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -724,6 +724,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 	case "javadoc":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertJavadoc(currentNode, variables), ID: id})
 
+	case "unarchive":
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertUnarchive(currentNode, currentNode.ParameterMap), ID: id})
+
 	default:
 		placeholderStr := fmt.Sprintf("echo %q", "This is a place holder for: "+currentNode.AttributesMap["jenkins.pipeline.step.type"])
 		b, err := json.MarshalIndent(currentNode.ParameterMap, "", "  ")

--- a/convert/jenkinsjson/convertTestFiles/unarchive/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/unarchive/Jenkinsfile
@@ -1,0 +1,59 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Prepare Archive Files') {
+            steps {
+                script {
+                    // Create dummy files for archiving
+                    sh '''
+                        echo "File 1 content" > file1.txt
+                        echo "File 2 content" > file2.txt
+
+                        # Create zip archive
+                        zip archive.zip file1.txt file2.txt
+                    '''
+
+                    // Archive files using Jenkins Archive Plugin
+                    archiveArtifacts artifacts: 'archive.zip', fingerprint: true
+                }
+            }
+        }
+
+        stage('Unarchive Files') {
+            steps {
+                script {
+                    // Directory to store unarchived files
+                    def extractDir = 'unarchived_files'
+
+                    // Ensure the directory exists
+                    sh "mkdir -p ${extractDir}"
+
+                    // Define the mapping for unarchiving files
+                    def mappings = [
+                        'archive.zip': "${extractDir}/zip/",
+                    ]
+
+                    // Loop through the mappings and unarchive files
+                    for (archive in mappings.keySet()) {
+                        def targetDir = mappings[archive]
+                        echo "Unarchiving: ${archive} into ${targetDir}"
+                        unarchive mapping: ["${archive}": targetDir]
+                    }
+
+                    // Verify the unarchived files
+                    sh "ls -l ${extractDir}"
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                // Clean up workspace
+                sh "rm -rf file1.txt file2.txt archive.zip archive.tar archive.tar.gz unarchived_files"
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/unarchive/unarchive.yaml
+++ b/convert/jenkinsjson/convertTestFiles/unarchive/unarchive.yaml
@@ -1,8 +1,13 @@
 - step:
     identifier: unarchive4bf5e3
-    name: UnArchive
+    name: Unarchive
     spec:
-      command: mkdir -p unarchived_files/zip/ && unzip -o archive.zip -d unarchived_files/zip/
-      shell: Sh
-    timeout: ''
-    type: Run
+      image: plugins/archive
+      settings:
+        action: extract
+        exclude: ''
+        format: zip
+        glob: '**/*'
+        overwrite: 'true'
+        source: archive.zip
+        target: unarchived_files/zip/

--- a/convert/jenkinsjson/convertTestFiles/unarchive/unarchive.yaml
+++ b/convert/jenkinsjson/convertTestFiles/unarchive/unarchive.yaml
@@ -1,0 +1,8 @@
+- step:
+    identifier: unarchive4bf5e3
+    name: UnArchive
+    spec:
+      command: mkdir -p unarchived_files/zip/ && unzip -o archive.zip -d unarchived_files/zip/
+      shell: Sh
+    timeout: ''
+    type: Run

--- a/convert/jenkinsjson/convertTestFiles/unarchive/unarchive_snippet.json
+++ b/convert/jenkinsjson/convertTestFiles/unarchive/unarchive_snippet.json
@@ -1,0 +1,24 @@
+{
+  "spanId": "4bf5e3ac44876208",
+  "traceId": "0f4444ef5d1887d2a917f8e9a3b9cb76",
+  "parent": "Vani_Unarchive",
+  "all-info": "span(name: unarchive, spanId: 4bf5e3ac44876208, parentSpanId: e8795c91c5afd84e, traceId: 0f4444ef5d1887d2a917f8e9a3b9cb76, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"mapping\" : {\n    \"archive.zip\" : \"unarchived_files/zip/\"\n  }\n};harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@59b01d93:com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@59b01d93;harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@4f03b5d7:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@4f03b5d7;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@27163664:org.jenkinsci.plugins.workflow.actions.TimingAction@27163664;harness-others:-mapping-field org.jenkinsci.plugins.workflow.steps.ArtifactUnarchiverStep mapping-org.jenkinsci.plugins.workflow.steps.ArtifactUnarchiverStep.mapping-interface java.util.Map;jenkins.pipeline.step.id:21;jenkins.pipeline.step.name:Copy archived artifacts into the workspace;jenkins.pipeline.step.plugin.name:workflow-basic-steps;jenkins.pipeline.step.plugin.version:1058.vcb_fc1e3a_21a_9;jenkins.pipeline.step.type:unarchive;)",
+  "name": "Vani_Unarchive #2",
+  "attributesMap": {
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@27163664": "org.jenkinsci.plugins.workflow.actions.TimingAction@27163664",
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@4f03b5d7": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@4f03b5d7",
+    "harness-attribute-extra-pip: com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@59b01d93": "com.cloudbees.workflow.rest.endpoints.FlowNodeAPI@59b01d93",
+    "harness-others": "-mapping-field org.jenkinsci.plugins.workflow.steps.ArtifactUnarchiverStep mapping-org.jenkinsci.plugins.workflow.steps.ArtifactUnarchiverStep.mapping-interface java.util.Map",
+    "jenkins.pipeline.step.name": "Copy archived artifacts into the workspace",
+    "ci.pipeline.run.user": "SYSTEM",
+    "jenkins.pipeline.step.id": "21",
+    "jenkins.pipeline.step.type": "unarchive",
+    "harness-attribute": "{\n  \"mapping\" : {\n    \"archive.zip\" : \"unarchived_files/zip/\"\n  }\n}",
+    "jenkins.pipeline.step.plugin.name": "workflow-basic-steps",
+    "jenkins.pipeline.step.plugin.version": "1058.vcb_fc1e3a_21a_9"
+  },
+  "type": "Run Phase Span",
+  "parentSpanId": "e8795c91c5afd84e",
+  "parameterMap": {"mapping": {"archive.zip": "unarchived_files/zip/"}},
+  "spanName": "unarchive"
+}

--- a/convert/jenkinsjson/json/unarchive.go
+++ b/convert/jenkinsjson/json/unarchive.go
@@ -26,8 +26,8 @@ func ConvertUnarchive(node Node, paramMap map[string]interface{}) *harness.Step 
 		format = "zip"
 	case strings.HasSuffix(source, ".tar"):
 		format = "tar"
-	case strings.HasSuffix(source, ".tar.gz"):
-		format = "tar.gz"
+	case strings.HasSuffix(source, ".gz"):
+		format = "tar"
 	}
 
 	// Create a Harness plugin step for unarchiving

--- a/convert/jenkinsjson/json/unarchive.go
+++ b/convert/jenkinsjson/json/unarchive.go
@@ -1,0 +1,53 @@
+package json
+
+import (
+	"fmt"
+	"strings"
+
+	harness "github.com/drone/spec/dist/go"
+)
+
+// ConvertUnarchive creates a Harness step for nunit plugin.
+func ConvertUnarchive(node Node, paramMap map[string]interface{}) *harness.Step {
+
+	// Extract the mapping from the parameterMap
+	mapping := paramMap["mapping"].(map[string]interface{})
+
+	// Initialize the script
+	var scriptBuilder strings.Builder
+
+	// Loop through each entry in the mapping
+	for source, target := range mapping {
+		// Determine the unarchiving command based on the file extension
+		switch {
+		case strings.HasSuffix(source, ".zip"):
+			// Unzip command
+			scriptBuilder.WriteString(fmt.Sprintf("mkdir -p %s && unzip -o %s -d %s\n", target, source, target))
+		case strings.HasSuffix(source, ".tar"):
+			// Tar extraction command
+			scriptBuilder.WriteString(fmt.Sprintf("mkdir -p %s && tar -xvf %s -C %s\n", target, source, target))
+		case strings.HasSuffix(source, ".tar.gz"):
+			// Tar.gz extraction command
+			scriptBuilder.WriteString(fmt.Sprintf("mkdir -p %s && tar -xzvf %s -C %s\n", target, source, target))
+		default:
+			// Unsupported format
+			scriptBuilder.WriteString(fmt.Sprintf("echo 'Unsupported archive format for %s'\n", source))
+		}
+	}
+
+	// Trim the trailing newline
+	script := strings.TrimSuffix(scriptBuilder.String(), "\n")
+
+	// Create the Harness step with the generated script
+	convertUnArchive := &harness.Step{
+		Name: "UnArchive",
+		Type: "script",
+		Id:   SanitizeForId(node.SpanName, node.SpanId),
+		Spec: &harness.StepExec{
+			Shell: "sh",
+			Run:   script,
+		},
+	}
+
+	return convertUnArchive
+}

--- a/convert/jenkinsjson/json/unarchive_test.go
+++ b/convert/jenkinsjson/json/unarchive_test.go
@@ -1,0 +1,37 @@
+package json
+
+import (
+	"fmt"
+	"testing"
+
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertUnarchive(t *testing.T) {
+
+	targetStr := string("unarchived_files/zip/")
+	source := string("archive.zip")
+	// Initialize the script
+	expectedScript := fmt.Sprintf("mkdir -p %s && unzip -o %s -d %s", targetStr, source, targetStr)
+	var tests []runner
+	tests = append(tests, prepare(t, "/unarchive/unarchive_snippet", &harness.Step{
+		Id:   "unarchive4bf5e3",
+		Name: "UnArchive",
+		Type: "script",
+		Spec: &harness.StepExec{
+			Shell: "sh",
+			Run:   expectedScript,
+		},
+	}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertUnarchive(tt.input, tt.input.ParameterMap)
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("ConvertUnarchive() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/convert/jenkinsjson/json/unarchive_test.go
+++ b/convert/jenkinsjson/json/unarchive_test.go
@@ -1,7 +1,6 @@
 package json
 
 import (
-	"fmt"
 	"testing"
 
 	harness "github.com/drone/spec/dist/go"
@@ -12,16 +11,22 @@ func TestConvertUnarchive(t *testing.T) {
 
 	targetStr := string("unarchived_files/zip/")
 	source := string("archive.zip")
-	// Initialize the script
-	expectedScript := fmt.Sprintf("mkdir -p %s && unzip -o %s -d %s", targetStr, source, targetStr)
 	var tests []runner
 	tests = append(tests, prepare(t, "/unarchive/unarchive_snippet", &harness.Step{
 		Id:   "unarchive4bf5e3",
-		Name: "UnArchive",
-		Type: "script",
-		Spec: &harness.StepExec{
-			Shell: "sh",
-			Run:   expectedScript,
+		Name: "Unarchive",
+		Type: "plugin",
+		Spec: &harness.StepPlugin{
+			Image: "plugins/archive",
+			With: map[string]interface{}{
+				"source":    source,
+				"target":    targetStr,
+				"format":    "zip",
+				"action":    "extract",
+				"glob":      "**/*",
+				"overwrite": "true",
+				"exclude":   "",
+			},
 		},
 	}))
 

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -749,5 +749,33 @@ line3'''
                 version: '1.12'
             }
         }
+
+        //Unarchive Stage
+        stage('Unarchive Files') {
+            steps {
+                script {
+                    // Directory to store unarchived files
+                    def extractDir = 'unarchived_files'
+
+                    // Ensure the directory exists
+                    sh "mkdir -p ${extractDir}"
+
+                    // Define the mapping for unarchiving files
+                    def mappings = [
+                        'archive.zip': "${extractDir}/zip/",
+                    ]
+
+                    // Loop through the mappings and unarchive files
+                    for (archive in mappings.keySet()) {
+                        def targetDir = mappings[archive]
+                        echo "Unarchiving: ${archive} into ${targetDir}"
+                        unarchive mapping: ["${archive}": targetDir]
+                    }
+
+                    // Verify the unarchived files
+                    sh "ls -l ${extractDir}"
+                }
+            }
+        }
     }
 }

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -605,7 +605,7 @@ line3'''
             steps {
                 javadoc javadocDir: 'complete/build/docs/javadoc', keepAll: true
             }
-        }	
+        }    
         //Kube-ctl
         stage('Check Docker') {
             steps {


### PR DESCRIPTION
Unarchive go-conversion:
Added "Unarchive" support to go-convert specific to jenkins migration.

Unarchive Jenkins Trace:
[Vani_Unarchive.json](https://github.com/user-attachments/files/17896508/Vani_Unarchive.json)

go run main.go jenkinsjson --downgrade ~/go/Vani_Unarchive.json

Unarchive harness pipeline step:
```
- step:
    identifier: unarchive4bf5e3
    name: Unarchive
    spec:
      image: plugins/archive
      settings:
        action: extract
        exclude: ''
        format: zip
        glob: '**/*'
        overwrite: 'true'
        source: archive.zip
        target: unarchived_files/zip/
```

Unarchive Harness Pipeline [here](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/default/projects/jenkinstoharness/pipelines/Vani_Unarchive_Pipeline/deployments/gmEez38qT1SQjBauDCS_6A/pipeline?storeType=INLINE)

