### PR TITLE
fix: [CI-13903]: move default image logic to downgrader

### DIFF
--- a/command/jenkinsjson.go
+++ b/command/jenkinsjson.go
@@ -85,7 +85,6 @@ func (c *JenkinsJson) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	converter := jenkinsjson.New(
 		jenkinsjson.WithDockerhub(c.dockerConn),
 		jenkinsjson.WithKubernetes(c.kubeName, c.kubeConn),
-		jenkinsjson.WithDefaultImage(c.defaultImage),
 	)
 	after, err := converter.ConvertBytes(before)
 	if err != nil {
@@ -104,6 +103,7 @@ func (c *JenkinsJson) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 			downgrader.WithName(c.name),
 			downgrader.WithOrganization(c.org),
 			downgrader.WithProject(c.proj),
+			downgrader.WithDefaultImage(c.defaultImage),
 		)
 		after, err = d.Downgrade(after)
 		if err != nil {

--- a/convert/harness/downgrader/downgrade.go
+++ b/convert/harness/downgrader/downgrade.go
@@ -44,6 +44,7 @@ type Downgrader struct {
 	pipelineName  string
 	pipelineOrg   string
 	pipelineProj  string
+	defaultImage  string
 	identifiers   *store.Identifiers
 }
 
@@ -461,7 +462,7 @@ func (d *Downgrader) convertStepRun(src *v1.Step) *v0.Step {
 			Env:             spec_.Envs,
 			Command:         spec_.Run,
 			ConnRef:         d.dockerhubConn,
-			Image:           spec_.Image,
+			Image:           convertImage(spec_.Image, d.defaultImage),
 			ImagePullPolicy: convertImagePull(spec_.Pull),
 			Outputs:         outputs, // Add this line
 			Privileged:      spec_.Privileged,
@@ -583,6 +584,7 @@ func (d *Downgrader) convertStepPlugin(src *v1.Step) *v0.Step {
 			Spec: &v0.StepArtifactoryUpload{
 				Target:     setting["target"].(string),
 				SourcePath: setting["source"].(string),
+				ConnRef:    "<+input>",
 			},
 			When: convertStepWhen(src.When, id),
 		}
@@ -789,6 +791,14 @@ func convertTimeout(s string) v0.Duration {
 	return v0.Duration{
 		Duration: d,
 	}
+}
+
+func convertImage(s string, defaultImage string) string {
+	image := s
+	if image == "" {
+		image = defaultImage
+	}
+	return image
 }
 
 func convertImagePull(v string) (s string) {

--- a/convert/harness/downgrader/option.go
+++ b/convert/harness/downgrader/option.go
@@ -72,3 +72,10 @@ func WithProject(project string) Option {
 		d.pipelineProj = project
 	}
 }
+
+// WithDefaultImage returns an option to set the default Run step image
+func WithDefaultImage(image string) Option {
+	return func(d *Downgrader) {
+		d.defaultImage = image
+	}
+}

--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -981,10 +981,6 @@ func canMergeSteps(step1, step2 *harness.Step) bool {
 		return false
 	}
 
-	if !hasNoImage(exec1) || !hasNoImage(exec2) {
-		return false
-	}
-
 	return exec1.Image == exec2.Image &&
 		exec1.Connector == exec2.Connector &&
 		exec1.Shell == exec2.Shell &&
@@ -993,10 +989,6 @@ func canMergeSteps(step1, step2 *harness.Step) bool {
 		ARGSslicesEqual(exec1.Args, exec2.Args) &&
 		exec1.Privileged == exec2.Privileged &&
 		exec1.Network == exec2.Network
-}
-
-func hasNoImage(exec *harness.StepExec) bool {
-	return strings.TrimSpace(exec.Image) == ""
 }
 
 func ENVmapsEqual(m1, m2 map[string]string) bool {

--- a/convert/jenkinsjson/convert_test.go
+++ b/convert/jenkinsjson/convert_test.go
@@ -645,29 +645,6 @@ func TestCanMergeSteps(t *testing.T) {
 	})
 }
 
-func TestHasDefaultOrNoImage(t *testing.T) {
-	t.Run("No image", func(t *testing.T) {
-		exec := &harness.StepExec{Image: ""}
-		if !hasNoImage(exec) {
-			t.Error("expected empty image to return true")
-		}
-	})
-
-	t.Run("No image with spaces", func(t *testing.T) {
-		exec := &harness.StepExec{Image: "   "}
-		if !hasNoImage(exec) {
-			t.Error("expected no image with spaces to return true")
-		}
-	})
-
-	t.Run("Non-default image", func(t *testing.T) {
-		exec := &harness.StepExec{Image: "ubuntu:latest"}
-		if hasNoImage(exec) {
-			t.Error("expected non-default image to return false")
-		}
-	})
-}
-
 func TestENVmapsEqual(t *testing.T) {
 	t.Run("Empty maps", func(t *testing.T) {
 		if !ENVmapsEqual(nil, nil) {

--- a/convert/jenkinsjson/convert_test.go
+++ b/convert/jenkinsjson/convert_test.go
@@ -648,21 +648,21 @@ func TestCanMergeSteps(t *testing.T) {
 func TestHasDefaultOrNoImage(t *testing.T) {
 	t.Run("No image", func(t *testing.T) {
 		exec := &harness.StepExec{Image: ""}
-		if !hasDefaultOrNoImage(exec) {
+		if !hasNoImage(exec) {
 			t.Error("expected empty image to return true")
 		}
 	})
 
-	t.Run("Default image with different casing", func(t *testing.T) {
-		exec := &harness.StepExec{Image: "Alpine"}
-		if !hasDefaultOrNoImage(exec) {
-			t.Error("expected default image with different casing to return true")
+	t.Run("No image with spaces", func(t *testing.T) {
+		exec := &harness.StepExec{Image: "   "}
+		if !hasNoImage(exec) {
+			t.Error("expected no image with spaces to return true")
 		}
 	})
 
 	t.Run("Non-default image", func(t *testing.T) {
 		exec := &harness.StepExec{Image: "ubuntu:latest"}
-		if hasDefaultOrNoImage(exec) {
+		if hasNoImage(exec) {
 			t.Error("expected non-default image to return false")
 		}
 	})

--- a/convert/jenkinsjson/json/bat.go
+++ b/convert/jenkinsjson/json/bat.go
@@ -6,7 +6,7 @@ import (
 	harness "github.com/drone/spec/dist/go"
 )
 
-func ConvertBat(node Node, variables map[string]string, timeout string) *harness.Step {
+func ConvertBat(node Node, variables map[string]string, timeout string, dockerImage string) *harness.Step {
 	script := fmt.Sprintf("%v", node.ParameterMap["script"])
 	stepId := SanitizeForId(node.SpanName, node.SpanId)
 	cmd := getFileCreateCommand(stepId, script)
@@ -16,6 +16,7 @@ func ConvertBat(node Node, variables map[string]string, timeout string) *harness
 		Id:      stepId,
 		Type:    "script",
 		Spec: &harness.StepExec{
+			Image: dockerImage,
 			Shell: "pwsh",
 			Run:   cmd,
 		},

--- a/convert/jenkinsjson/json/bat_test.go
+++ b/convert/jenkinsjson/json/bat_test.go
@@ -45,6 +45,7 @@ func TestBat(t *testing.T) {
 				Id:      "bat3b5f74",
 				Type:    "script",
 				Spec: &harness.StepExec{
+					Image: "abc.example.com/image:tag",
 					Shell: "pwsh",
 					Run:   "echo @\"\necho hello world\n\"@ > bat3b5f74.bat\n ./bat3b5f74.bat",
 				},
@@ -63,6 +64,7 @@ func TestBat(t *testing.T) {
 				Id:      "bat3b5f74",
 				Type:    "script",
 				Spec: &harness.StepExec{
+					Image: "abc.example.com/image:tag",
 					Shell: "pwsh",
 					Run:   "echo @\"\necho hello world\n\"@ > bat3b5f74.bat\n ./bat3b5f74.bat",
 					Envs: map[string]string{
@@ -76,7 +78,7 @@ func TestBat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ConvertBat(tt.input, tt.variables, "10m")
+			got := ConvertBat(tt.input, tt.variables, "10m", "abc.example.com/image:tag")
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("ConvertBat() mismatch (-want +got):\n%s", diff)
 			}

--- a/convert/jenkinsjson/json/powershell.go
+++ b/convert/jenkinsjson/json/powershell.go
@@ -6,13 +6,14 @@ import (
 	harness "github.com/drone/spec/dist/go"
 )
 
-func ConvertPowerShell(node Node, variables map[string]string, timeout string) *harness.Step {
+func ConvertPowerShell(node Node, variables map[string]string, timeout string, dockerImage string) *harness.Step {
 	powerShellStep := &harness.Step{
 		Name:    node.SpanName,
 		Timeout: timeout,
 		Id:      SanitizeForId(node.SpanName, node.SpanId),
 		Type:    "script",
 		Spec: &harness.StepExec{
+			Image: dockerImage,
 			Shell: "Powershell",
 			Run:   fmt.Sprintf("%v", node.ParameterMap["script"]),
 		},

--- a/convert/jenkinsjson/json/powershell_test.go
+++ b/convert/jenkinsjson/json/powershell_test.go
@@ -45,6 +45,7 @@ func TestConvertPowerShell(t *testing.T) {
 				Id:      "powershell1d3281",
 				Type:    "script",
 				Spec: &harness.StepExec{
+					Image: "abc.example.com/image:tag",
 					Shell: "Powershell",
 					Run:   "\n                Write-Output \"Running a PowerShell command\"\n                ",
 				},
@@ -63,6 +64,7 @@ func TestConvertPowerShell(t *testing.T) {
 				Id:      "powershell1d3281",
 				Type:    "script",
 				Spec: &harness.StepExec{
+					Image: "abc.example.com/image:tag",
 					Shell: "Powershell",
 					Run:   "\n                Write-Output \"Running a PowerShell command\"\n                ",
 					Envs: map[string]string{
@@ -76,7 +78,7 @@ func TestConvertPowerShell(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ConvertPowerShell(tt.input, tt.variables, "10m")
+			got := ConvertPowerShell(tt.input, tt.variables, "10m", "abc.example.com/image:tag")
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("ConvertPowerShell() mismatch (-want +got):\n%s", diff)
 			}

--- a/convert/jenkinsjson/option.go
+++ b/convert/jenkinsjson/option.go
@@ -33,11 +33,3 @@ func WithKubernetes(namespace, connector string) Option {
 		d.kubeConnector = connector
 	}
 }
-
-// WithDefaultImage returns an option to set the default
-// image to run step.
-func WithDefaultImage(image string) Option {
-	return func(d *Converter) {
-		d.defaultImage = image
-	}
-}


### PR DESCRIPTION
I'm not confident that this is the best solution here so please let me know if you disagree with this change.

The issue I am trying to solve here is that most steps in the jenkinsjson converter do not provide a default image. This breaks the import into Harness when using Kubernetes infra as it requires a step image. 

I started this change by tracking down each place where my trace was outputting a step with no image and adding the default image logic into the step conversion. After doing 2 or 3 of these I realised that I would need to add the default image logic to every step creation, of which there is many. Which brought me to this conclusion, why not default the image in the downgrader is none was specified during the conversion. Simple right?

As I am typing this, I realise I could probably add similar logic into the converter in a generic fashion, by adding a deferred function call or something? Anyway, this is here, please give me your thoughts, thanks for reading!