### PR TITLE
fix: [CI-15388]: recurse into chilren for ws, dir and withCred steps

### DIFF
--- a/convert/harness/downgrader/downgrade.go
+++ b/convert/harness/downgrader/downgrade.go
@@ -161,6 +161,9 @@ func (d *Downgrader) downgrade(src []*v1.Config) ([]byte, error) {
 		if config.Pipeline.Name == harness.DefaultName && p.Name != "" {
 			config.Pipeline.Name = p.Name
 		}
+		if config.Pipeline.ID == harness.DefaultName && p.Name != "" {
+			config.Pipeline.ID = slug.Create(p.Name)
+		}
 
 		config.Pipeline.Org = d.pipelineOrg
 		config.Pipeline.Project = d.pipelineProj

--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -188,11 +188,6 @@ func collectStagesWithID(jsonNode *jenkinsjson.Node, processedTools *ProcessedTo
 			stepsInStage := make([]*harness.Step, 0)
 			recursiveParseJsonToSteps(childNode, &stepsInStage, processedTools, variables, dockerImage)
 
-			// skip empty step groups
-			if len(stepsInStage) == 0 {
-				continue
-			}
-
 			// Create the stepGroup for the new stage
 			dstStep := &harness.Step{
 				Name: jenkinsjson.SanitizeForName(stageName),

--- a/convert/jenkinsjson/json/deletedir.go
+++ b/convert/jenkinsjson/json/deletedir.go
@@ -22,8 +22,11 @@ func ConvertDeleteDir(node Node, variables map[string]string) *harness.Step {
 	return step
 }
 
-func ConvertDir(node Node, variables map[string]string) *harness.Step {
-	dirPath := node.ParameterMap["path"].(string)
+func ConvertDir(node Node, variables map[string]string) (*harness.Step, bool) {
+	dirPath, ok := node.ParameterMap["path"].(string)
+	if !ok {
+		return nil, false
+	}
 	step := &harness.Step{
 		Name: "Dir",
 		Id:   SanitizeForId(node.SpanName, node.SpanId),
@@ -36,5 +39,5 @@ func ConvertDir(node Node, variables map[string]string) *harness.Step {
 	if len(variables) > 0 {
 		step.Spec.(*harness.StepExec).Envs = variables
 	}
-	return step
+	return step, true
 }

--- a/convert/jenkinsjson/json/util.go
+++ b/convert/jenkinsjson/json/util.go
@@ -22,7 +22,7 @@ import (
 
 func SanitizeForId(spanName string, spanId string) string {
 	// Replace invalid characters with underscores
-	invalidCharRegex := regexp.MustCompile(`[^a-zA-Z0-9.\-_]+`)
+	invalidCharRegex := regexp.MustCompile(`[^a-zA-Z0-9_]+`)
 	sanitized := invalidCharRegex.ReplaceAllString(spanName, "_")
 
 	// Trim leading and trailing underscores

--- a/convert/jenkinsjson/json/util_test.go
+++ b/convert/jenkinsjson/json/util_test.go
@@ -35,7 +35,7 @@ func TestSanitizeForId(t *testing.T) {
 			name:       "RealSample",
 			spanId:     "a2e5df",
 			spanName:   "Deploy to DEV-CT",
-			expectedId: "Deploy_to_DEV-CTa2e5df",
+			expectedId: "Deploy_to_DEV_CTa2e5df",
 		},
 		{
 			name:       "TruncateLongName",

--- a/convert/jenkinsjson/json/withCredentials.go
+++ b/convert/jenkinsjson/json/withCredentials.go
@@ -1,0 +1,39 @@
+package json
+
+import (
+	"fmt"
+	"log"
+)
+
+func ConvertWithCredentials(node Node) map[string]string {
+	envVars := make(map[string]string)
+
+	if bindings, ok := node.ParameterMap["bindings"].([]interface{}); ok {
+		for _, binding := range bindings {
+			bindingMap, okBind := binding.(map[string]interface{})
+			symbol, okSym := bindingMap["symbol"].(string)
+			arguments, okArgs := bindingMap["arguments"].(map[string]interface{})
+			if !okBind || !okSym || !okArgs {
+				continue
+			}
+
+			switch symbol {
+			case "usernamePassword":
+				addVariable("usernameVariable", arguments, envVars)
+				addVariable("passwordVariable", arguments, envVars)
+			case "string":
+				addVariable("variable", arguments, envVars)
+			default:
+				log.Printf("withCredentials unsupported symbol: %s", symbol)
+			}
+		}
+	}
+
+	return envVars
+}
+
+func addVariable(key string, arguments map[string]interface{}, envVars map[string]string) {
+	if passwordVariable, ok := arguments[key].(string); ok {
+		envVars[passwordVariable] = fmt.Sprintf("<+pipeline.variables.%s>", passwordVariable)
+	}
+}

--- a/convert/jenkinsjson/json/withCredentials_test.go
+++ b/convert/jenkinsjson/json/withCredentials_test.go
@@ -1,0 +1,233 @@
+// Copyright 2023 Harness, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestConvertWithCredentials(t *testing.T) {
+	tests := []struct {
+		name      string
+		symbol    string
+		arguments map[string]interface{}
+		want      map[string]string
+	}{
+		{
+			name:      "ReturnsStringVariable",
+			symbol:    "string",
+			arguments: map[string]interface{}{"variable": "ABC"},
+			want:      map[string]string{"ABC": "<+pipeline.variables.ABC>"},
+		},
+		{
+			name:      "ReturnsUserPassVariables",
+			symbol:    "usernamePassword",
+			arguments: map[string]interface{}{"usernameVariable": "USER", "passwordVariable": "PASS"},
+			want:      map[string]string{"USER": "<+pipeline.variables.USER>", "PASS": "<+pipeline.variables.PASS>"},
+		},
+		{
+			name:      "LogsErrorWhenUnknownSymbol",
+			symbol:    "not_real",
+			arguments: map[string]interface{}{"variable": "XYZ"},
+			want:      map[string]string{},
+		},
+		{
+			name:      "ReturnsEmptyWhenArgumentsIsNull",
+			symbol:    "string",
+			arguments: nil,
+			want:      map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := Node{
+				ParameterMap: map[string]any{
+					"bindings": []any{
+						map[string]any{
+							"symbol":    tc.symbol,
+							"arguments": tc.arguments,
+						},
+					},
+				},
+			}
+			got := ConvertWithCredentials(node)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ConvertWithCredentials mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}
+
+func TestConvertWithCredentialsArray(t *testing.T) {
+	tests := []struct {
+		name string
+		want map[string]string
+	}{
+		{
+			name: "ReturnsMultipleVariables",
+			want: map[string]string{"A": "<+pipeline.variables.A>", "C": "<+pipeline.variables.C>", "D": "<+pipeline.variables.D>", "B": "<+pipeline.variables.B>"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := Node{
+				ParameterMap: map[string]any{
+					"bindings": []any{
+						map[string]any{
+							"symbol":    "string",
+							"arguments": map[string]interface{}{"variable": "A"},
+						},
+						map[string]any{
+							"symbol":    "usernamePassword",
+							"arguments": map[string]interface{}{"usernameVariable": "C", "passwordVariable": "D"},
+						},
+						map[string]any{
+							"symbol":    "string",
+							"arguments": map[string]interface{}{"variable": "B"},
+						},
+					},
+				},
+			}
+			got := ConvertWithCredentials(node)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ConvertWithCredentials mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}
+
+func TestConvertWithCredentialsErrorCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		parameterMap map[string]any
+		want         map[string]string
+	}{
+		{
+			name:         "HandlesNullParameterMap",
+			parameterMap: nil,
+			want:         map[string]string{},
+		},
+		{
+			name:         "HandlesMissingBindings",
+			parameterMap: map[string]any{},
+			want:         map[string]string{},
+		},
+		{
+			name: "HandlesBindingsAsNull",
+			parameterMap: map[string]any{
+				"bindings": nil,
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "HandlesNullBindings",
+			parameterMap: map[string]any{
+				"bindings": []any{nil},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "HandlesMissingSymbol",
+			parameterMap: map[string]any{
+				"bindings": []any{
+					map[string]any{
+						"arguments": map[string]interface{}{"variable": "ABC"},
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "HandlesSymbolAsNull",
+			parameterMap: map[string]any{
+				"bindings": []any{
+					map[string]any{
+						"symbol":    nil,
+						"arguments": map[string]interface{}{"variable": "ABC"},
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "HandlesSymbolAsWrongType",
+			parameterMap: map[string]any{
+				"bindings": []any{
+					map[string]any{
+						"symbol":    1,
+						"arguments": map[string]interface{}{"variable": "ABC"},
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "HandlesMissingArguments",
+			parameterMap: map[string]any{
+				"bindings": []any{
+					map[string]any{
+						"symbol": "string",
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "HandlesArgumentsAsNull",
+			parameterMap: map[string]any{
+				"bindings": []any{
+					map[string]any{
+						"symbol":    "string",
+						"arguments": nil,
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "HandlesArgumentsAsWrongType",
+			parameterMap: map[string]any{
+				"bindings": []any{
+					map[string]any{
+						"symbol":    "string",
+						"arguments": "bad",
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := Node{
+				ParameterMap: tc.parameterMap,
+			}
+			got := ConvertWithCredentials(node)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ConvertWithCredentials mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This PR includes a few changes,
1. Recurse into children for ws, dir and withCred step types
2. Add default child recurse for other unknown types
3. Derive pipeline ID from name
4. Ignore ansiColor plugin steps
