### PR TITLE
fix: [CI-15419]: enable bulk conversion of traces with dir

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -201,7 +201,7 @@ func collectStagesWithID(jsonNode *jenkinsjson.Node, processedTools *ProcessedTo
 			// Convert stageID to integer and store it with the stage
 			id, err := strconv.Atoi(stageID)
 			if err != nil {
-				fmt.Println("Error converting stage ID to integer:", err)
+				fmt.Printf("Error converting stage ID to integer, spanId=%s: %v\n", jsonNode.SpanId, err)
 				id = 0
 			}
 


### PR DESCRIPTION
This PR adds "bulk" or directory based conversion of Jenkins trace files.

By providing a directory as the input rather than a file the tool will walk the filesystem from that root converting all JSON files it finds.

Also added an --output-dir option so that converted yaml files can be saved to disc rather than printing all to STDOUT