### PR TITLE
CI-15185 Use `parameterMap` for `artifactoryUpload` and `tools` 

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -298,8 +298,8 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 	var repo *harness.Repository
 
 	// parameterMap and harness-attribute are now aligned in recent trace files and always contain identical data.
-	// However, keep this for backwards compatibility with older traces that might
-	// only contain harness-attribute.
+	// However, if older traces can only contain harness-attribute, let's update parameterMap manually as we
+	// use it exclusively for lookups below.
 	if len(currentNode.ParameterMap) == 0 {
 		if harnessAttr, ok := currentNode.AttributesMap["harness-attribute"]; ok {
 			var paramMap map[string]interface{}
@@ -519,7 +519,6 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 	case "verifySha256":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertVerifySha256(currentNode, variables, dockerImage), ID: id})
 	case "artifactoryUpload":
-		// Updated artifactoryUpload handling using ParameterMap
 		specStr, ok := currentNode.ParameterMap["spec"].(string)
 		if !ok {
 			fmt.Println("Invalid or missing 'spec' in ParameterMap for artifactoryUpload")

--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -909,8 +909,8 @@ func handleTool(currentNode jenkinsjson.Node, processedTools *ProcessedTools) {
 	// Check if this node is a "tool" node
 	if stepType, ok := currentNode.AttributesMap["jenkins.pipeline.step.type"]; ok && stepType == "tool" {
 		typeVal, typeExists := currentNode.ParameterMap["type"].(string)
-		toolType := ""
 		if typeExists {
+			toolType := ""
 			// Determine the tool type from 'typeVal'
 			if parts := strings.Split(typeVal, "$"); len(parts) > 1 {
 				toolType = parts[1]

--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -297,6 +297,9 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 	var clone *harness.CloneStage
 	var repo *harness.Repository
 
+	// parameterMap and harness-attribute are now aligned in recent trace files and always contain identical data.
+	// However, keep this for backwards compatibility with older traces that might
+	// only contain harness-attribute.
 	if len(currentNode.ParameterMap) == 0 {
 		if harnessAttr, ok := currentNode.AttributesMap["harness-attribute"]; ok {
 			var paramMap map[string]interface{}
@@ -516,21 +519,37 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepWithIDList *[]StepWith
 	case "verifySha256":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertVerifySha256(currentNode, variables, dockerImage), ID: id})
 	case "artifactoryUpload":
-		attr, ok := currentNode.AttributesMap["harness-attribute"]
+		// Updated artifactoryUpload handling using ParameterMap
+		specStr, ok := currentNode.ParameterMap["spec"].(string)
 		if !ok {
+			fmt.Println("Invalid or missing 'spec' in ParameterMap for artifactoryUpload")
 			return nil, nil
 		}
-		fileSpecs, err := jenkinsjson.ParseHarnessAttribute(attr)
+
+		var spec jenkinsjson.Spec
+		err := json.Unmarshal([]byte(specStr), &spec)
 		if err != nil {
+			fmt.Println("Error unmarshalling 'spec' for artifactoryUpload:", err)
 			return nil, nil
 		}
-		for _, fileSpec := range fileSpecs {
+
+		// Iterate over each file specification
+		for _, fileSpec := range spec.Files {
+			// Create a new node with 'pattern' and 'target' in ParameterMap
 			newNode := currentNode
-			newNode.AttributesMap = map[string]string{
-				"pattern": fileSpec.Pattern,
-				"target":  fileSpec.Target,
+			newNode.ParameterMap["pattern"] = fileSpec.Pattern
+			newNode.ParameterMap["target"] = fileSpec.Target
+
+			// Convert and append the Artifactory Upload step
+			convertedStep := jenkinsjson.ConvertArtifactUploadJfrog(newNode, variables, timeout)
+			if convertedStep != nil {
+				*stepWithIDList = append(*stepWithIDList, StepWithID{
+					Step: convertedStep,
+					ID:   id,
+				})
+			} else {
+				fmt.Println("Failed to convert artifactoryUpload step")
 			}
-			*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertArtifactUploadJfrog(newNode, variables, timeout), ID: id})
 		}
 
 	case "anchore":

--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -909,27 +909,25 @@ func recursiveHandleWithTool(currentNode jenkinsjson.Node, stepWithIDList *[]Ste
 func handleTool(currentNode jenkinsjson.Node, processedTools *ProcessedTools) {
 	// Check if this node is a "tool" node
 	if stepType, ok := currentNode.AttributesMap["jenkins.pipeline.step.type"]; ok && stepType == "tool" {
-		if attr, ok := currentNode.AttributesMap["harness-attribute"]; ok {
-			toolAttributes := make(map[string]string)
-			if err := json.Unmarshal([]byte(attr), &toolAttributes); err == nil {
-				fullToolType := toolAttributes["type"]
-				toolType := ""
-				if parts := strings.Split(fullToolType, "$"); len(parts) > 1 {
-					toolType = parts[1]
-				} else {
-					toolType = extractToolType(fullToolType)
-				}
+		typeVal, typeExists := currentNode.ParameterMap["type"].(string)
+		toolType := ""
+		if typeExists {
+			// Determine the tool type from 'typeVal'
+			if parts := strings.Split(typeVal, "$"); len(parts) > 1 {
+				toolType = parts[1]
+			} else {
+				toolType = extractToolType(typeVal)
+			}
 
-				switch toolType {
-				case "MavenInstallation":
-					processedTools.MavenPresent = true
-				case "GradleInstallation":
-					processedTools.GradlePresent = true
-				case "AntInstallation":
-					processedTools.AntPresent = true
-				default:
-					processedTools.ToolProcessed = true
-				}
+			switch toolType {
+			case "MavenInstallation":
+				processedTools.MavenPresent = true
+			case "GradleInstallation":
+				processedTools.GradlePresent = true
+			case "AntInstallation":
+				processedTools.AntPresent = true
+			default:
+				processedTools.ToolProcessed = true
 			}
 		}
 	}

--- a/convert/jenkinsjson/convertTestFiles/artifactUploadJfrog/artifactuploadSnippet.json
+++ b/convert/jenkinsjson/convertTestFiles/artifactUploadJfrog/artifactuploadSnippet.json
@@ -10,7 +10,6 @@
     "ci.pipeline.run.user": "SYSTEM",
     "jenkins.pipeline.step.id": "23",
     "jenkins.pipeline.step.type": "artifactoryUpload",
-    "harness-attribute": "{\n  \"failNoOp\" : false,\n  \"server\" : \"UNSERIALIZABLE\",\n  \"buildInfo\" : \"UNSERIALIZABLE\",\n  \"spec\" : \"{\\n                    \\\"files\\\": [{\\n                        \\\"pattern\\\": \\\"output1.txt\\\",\\n                        \\\"target\\\": \\\"/artifactory/generic-local/op-ci/\\\"\\n                    },{\\n                        \\\"pattern\\\": \\\"output2.txt\\\",\\n                        \\\"target\\\": \\\"/artifactory/generic-local/op-ci2/\\\"\\n                    },{\\n                        \\\"pattern\\\": \\\"output3.txt\\\",\\n                        \\\"target\\\": \\\"/artifactory/generic-local/op-ci3/\\\"\\n                    }]\\n                 }\"\n}",
     "jenkins.pipeline.step.plugin.name": "artifactory",
     "jenkins.pipeline.step.plugin.version": "4.0.8"
   },

--- a/convert/jenkinsjson/convert_test.go
+++ b/convert/jenkinsjson/convert_test.go
@@ -441,8 +441,8 @@ func TestHandleTool_ValidToolNodeMaven(t *testing.T) {
 	toolNode := jenkinsjson.Node{
 		AttributesMap: map[string]string{
 			"jenkins.pipeline.step.type": "tool",
-			"harness-attribute":          `{"type": "$MavenInstallation"}`,
 		},
+		ParameterMap: map[string]interface{}{"type": "$MavenInstallation"},
 	}
 	processedTools := &ProcessedTools{}
 	handleTool(toolNode, processedTools)
@@ -456,8 +456,8 @@ func TestHandleTool_ValidToolNodeGradle(t *testing.T) {
 	toolNode := jenkinsjson.Node{
 		AttributesMap: map[string]string{
 			"jenkins.pipeline.step.type": "tool",
-			"harness-attribute":          `{"type": "$GradleInstallation"}`,
 		},
+		ParameterMap: map[string]interface{}{"type": "$GradleInstallation"},
 	}
 	processedTools := &ProcessedTools{}
 	handleTool(toolNode, processedTools)
@@ -471,8 +471,8 @@ func TestHandleTool_ValidToolNodeAnt(t *testing.T) {
 	toolNode := jenkinsjson.Node{
 		AttributesMap: map[string]string{
 			"jenkins.pipeline.step.type": "tool",
-			"harness-attribute":          `{"type": "$AntInstallation"}`,
 		},
+		ParameterMap: map[string]interface{}{"type": "$AntInstallation"},
 	}
 	processedTools := &ProcessedTools{}
 	handleTool(toolNode, processedTools)

--- a/convert/jenkinsjson/json/artifactUploadJfrog.go
+++ b/convert/jenkinsjson/json/artifactUploadJfrog.go
@@ -8,22 +8,33 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+type Spec struct {
+	Files []FileSpec `json:"files"`
+}
+
 type FileSpec struct {
 	Pattern string `json:"pattern"`
 	Target  string `json:"target"`
 }
 
 func ConvertArtifactUploadJfrog(node Node, variables map[string]string, timeout string) *harness.Step {
+	pattern, ok1 := node.ParameterMap["pattern"].(string)
+	target, ok2 := node.ParameterMap["target"].(string)
+	if !ok1 || !ok2 {
+		fmt.Println("Missing 'pattern' or 'target' in artifactoryUpload step")
+		return nil
+	}
+
 	step := &harness.Step{
-		Name:    node.SpanName,
+		Name:    SanitizeForName(node.SpanName),
 		Timeout: timeout,
 		Id:      SanitizeForId(node.SpanName, node.SpanId),
 		Type:    "plugin",
 		Spec: &harness.StepPlugin{
 			Image: "plugins/artifactory:latest",
 			With: map[string]interface{}{
-				"source": node.AttributesMap["pattern"],
-				"target": node.AttributesMap["target"],
+				"source": pattern,
+				"target": target,
 			},
 		},
 	}

--- a/convert/jenkinsjson/json/artifactUploadJfrog_test.go
+++ b/convert/jenkinsjson/json/artifactUploadJfrog_test.go
@@ -41,7 +41,6 @@ func TestConvertArtifactUploadJfrog(t *testing.T) {
 					"jenkins.pipeline.step.plugin.name":    "artifactory",
 					"jenkins.pipeline.step.plugin.version": "4.0.8",
 					"jenkins.pipeline.step.type":           "artifactoryUpload",
-					"harness-attribute":                    "{\n  \"failNoOp\" : false,\n  \"server\" : \"UNSERIALIZABLE\",\n  \"buildInfo\" : \"UNSERIALIZABLE\",\n  \"spec\" : \"{\\n                    \\\"files\\\": [{\\n                        \\\"pattern\\\": \\\"output1.txt\\\",\\n                        \\\"target\\\": \\\"/artifactory/generic-local/op-ci/\\\"\\n                    },{\\n                        \\\"pattern\\\": \\\"output2.txt\\\",\\n                        \\\"target\\\": \\\"/artifactory/generic-local/op-ci2/\\\"\\n                    },{\\n                        \\\"pattern\\\": \\\"output3.txt\\\",\\n                        \\\"target\\\": \\\"/artifactory/generic-local/op-ci3/\\\"\\n                    }]\\n                 }\"\n}",
 					"harness-others":                       "",
 				},
 				Name:         "artifactuploadjfrog #8",


### PR DESCRIPTION
# What
Compiled trace files include both `parameterMap` and `harness-attributes` which tell this tool the type of step to generate.  
Both of these fields are now completely aligned, and contain essentially duplicate data.  In the tool, the `harness-attibutes` was being used for `artifactoryUpload` and `tool` types.  
This PR changes both of those steps to use `parameterMap` 

# Why
- Reduce duplication
- Adding features to upstream trace generator easier, as does not require parity for generating both fields. 

# Testing
- Updated unit tests
- Manual testing with trace files that contain both step types. 