### PR TITLE
Ci 15185 Unified trace: handle branched sh

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -426,7 +426,7 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepGroupWithId *[]StepGro
 				clone, repo = collectStepsWithID(child, stepGroupWithId, stepWithIDList, processedTools, variables, timeout, dockerImage)
 			}
 		}
-	case "sh":
+	case "sh", "sh_unifiedTraceBranch":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertSh(currentNode, variables, timeout, dockerImage), ID: id})
 	case "bat":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertBat(currentNode, variables, timeout, defaultWindowsImage), ID: id})
@@ -862,7 +862,7 @@ func recursiveHandleWithTool(currentNode jenkinsjson.Node, stepWithIDList *[]Ste
 	for _, child := range currentNode.Children {
 		// Check if this child contains the type "sh"
 		stepType, ok := child.AttributesMap["jenkins.pipeline.step.type"]
-		if ok && stepType == "sh" {
+		if ok && (stepType == "sh" || stepType == "sh_unifiedTraceBranch") {
 			script, scriptOk := child.ParameterMap["script"]
 			if scriptOk {
 				// Check if the tool is not processed

--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -59,6 +59,10 @@ type ProcessedTools struct {
 	SonarCubePresent   bool
 }
 
+// In a unified pipeline trace, 'sh' types identified as branched/conditional will be pre-fixed with '_unifiedTraceBranch'
+// This is done because we don't want these steps to be merged, so that pipeline analysis is easier.
+const unifiedBranchedShStep = "sh_unifiedTraceBranch"
+
 var mavenGoals string
 var gradleGoals string
 
@@ -426,7 +430,8 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepGroupWithId *[]StepGro
 				clone, repo = collectStepsWithID(child, stepGroupWithId, stepWithIDList, processedTools, variables, timeout, dockerImage)
 			}
 		}
-	case "sh", "sh_unifiedTraceBranch":
+
+	case "sh", unifiedBranchedShStep:
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertSh(currentNode, variables, timeout, dockerImage), ID: id})
 	case "bat":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertBat(currentNode, variables, timeout, defaultWindowsImage), ID: id})
@@ -862,7 +867,7 @@ func recursiveHandleWithTool(currentNode jenkinsjson.Node, stepWithIDList *[]Ste
 	for _, child := range currentNode.Children {
 		// Check if this child contains the type "sh"
 		stepType, ok := child.AttributesMap["jenkins.pipeline.step.type"]
-		if ok && (stepType == "sh" || stepType == "sh_unifiedTraceBranch") {
+		if ok && (stepType == "sh" || stepType == unifiedBranchedShStep) {
 			script, scriptOk := child.ParameterMap["script"]
 			if scriptOk {
 				// Check if the tool is not processed

--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -432,7 +432,8 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepGroupWithId *[]StepGro
 		}
 
 	case "sh", unifiedBranchedShStep:
-		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertSh(currentNode, variables, timeout, dockerImage), ID: id})
+		name := currentNode.AttributesMap["jenkins.pipeline.step.type"]
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertSh(currentNode, variables, timeout, dockerImage, name), ID: id})
 	case "bat":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertBat(currentNode, variables, timeout, defaultWindowsImage), ID: id})
 	case "pwsh":

--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -431,9 +431,10 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepGroupWithId *[]StepGro
 			}
 		}
 
-	case "sh", unifiedBranchedShStep:
-		name := currentNode.AttributesMap["jenkins.pipeline.step.type"]
-		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertSh(currentNode, variables, timeout, dockerImage, name), ID: id})
+	case "sh":
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertSh(currentNode, variables, timeout, dockerImage, ""), ID: id})
+	case unifiedBranchedShStep:
+		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertSh(currentNode, variables, timeout, dockerImage, "_unifiedTraceBranch"), ID: id})
 	case "bat":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertBat(currentNode, variables, timeout, defaultWindowsImage), ID: id})
 	case "pwsh":

--- a/convert/jenkinsjson/json/sh.go
+++ b/convert/jenkinsjson/json/sh.go
@@ -6,15 +6,15 @@ import (
 	harness "github.com/drone/spec/dist/go"
 )
 
-func ConvertSh(node Node, variables map[string]string, timeout string, dockerImage string, name string) *harness.Step {
+func ConvertSh(node Node, variables map[string]string, timeout string, dockerImage string, label string) *harness.Step {
 	shStep := &harness.Step{
-		Name:    SanitizeForName(node.SpanName),
+		Name:    SanitizeForName(node.SpanName) + label,
 		Timeout: timeout,
 		Id:      SanitizeForId(node.SpanName, node.SpanId),
 		Type:    "script",
 		Spec: &harness.StepExec{
 			Image: dockerImage,
-			Shell: name,
+			Shell: "sh",
 			Run:   fmt.Sprintf("%v", node.ParameterMap["script"]),
 		},
 	}

--- a/convert/jenkinsjson/json/sh.go
+++ b/convert/jenkinsjson/json/sh.go
@@ -6,7 +6,7 @@ import (
 	harness "github.com/drone/spec/dist/go"
 )
 
-func ConvertSh(node Node, variables map[string]string, timeout string, dockerImage string) *harness.Step {
+func ConvertSh(node Node, variables map[string]string, timeout string, dockerImage string, name string) *harness.Step {
 	shStep := &harness.Step{
 		Name:    SanitizeForName(node.SpanName),
 		Timeout: timeout,
@@ -14,7 +14,7 @@ func ConvertSh(node Node, variables map[string]string, timeout string, dockerIma
 		Type:    "script",
 		Spec: &harness.StepExec{
 			Image: dockerImage,
-			Shell: "sh",
+			Shell: name,
 			Run:   fmt.Sprintf("%v", node.ParameterMap["script"]),
 		},
 	}


### PR DESCRIPTION
# What
Adds checks to not merge `sh` steps if they have a unified trace label

# Why
These belong to differente executions and are not logically related, so we should not merge them

# Testing
Manual 