### PR TITLE
feat: [CI-16470]: Support for configuring infrastructure options in the JenkinsJson to Harness YAML (V1) converter

### DIFF
--- a/convert/jenkinsjson/option.go
+++ b/convert/jenkinsjson/option.go
@@ -33,3 +33,24 @@ func WithKubernetes(namespace, connector string) Option {
 		d.kubeConnector = connector
 	}
 }
+
+// WithInfrastructure returns an option to set the infrastructure type.
+func WithInfrastructure(infra string) Option {
+	return func(d *Converter) {
+		d.infrastructure = infra
+	}
+}
+
+// WithOS returns an option to set the operating system.
+func WithOS(os string) Option {
+	return func(d *Converter) {
+		d.os = os
+	}
+}
+
+// WithArch returns an option to set the CPU architecture.
+func WithArch(arch string) Option {
+	return func(d *Converter) {
+		d.arch = arch
+	}
+}


### PR DESCRIPTION
Add support for configuring infrastructure options in the Jenkins to Harness YAML converter.

Changes:
- Add CLI flags:
  - `--infrastructure`: cloud (default), kubernetes, shell
  - `--os`: linux, windows, macos
  - `--arch`: amd64, arm64

- Add platform configuration:
  - OS and architecture settings
  - Normalize OS names (linux, windows, macos)

- Add runtime configuration:
  - cloud: Default cloud runtime
  - kubernetes: Kubernetes runtime
  - shell: Local shell runtime

- Add validation for all options
- Maintain backward compatibility with existing behavior