### PR TITLE
feat: [CI-15022]: adding go convert logic for testResultsAggregator

### DIFF
--- a/convert/jenkinsjson/convert.go
+++ b/convert/jenkinsjson/convert.go
@@ -773,6 +773,10 @@ func collectStepsWithID(currentNode jenkinsjson.Node, stepGroupWithId *[]StepGro
 		step := jenkinsjson.ConvertArtifactoryRtCommand(currentNode.AttributesMap["jenkins.pipeline.step.type"], currentNode, variables)
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: step, ID: id})
 
+	case "testResultsAggregator":
+		*stepWithIDList = append(*stepWithIDList,
+			StepWithID{Step: jenkinsjson.ConvertTestResultsAggregator(currentNode, variables), ID: id})
+
 	case "readMavenPom":
 		*stepWithIDList = append(*stepWithIDList, StepWithID{Step: jenkinsjson.ConvertReadMavenPom(currentNode), ID: id})
 

--- a/convert/jenkinsjson/convertTestFiles/testResultsAggregator/Jenkinsfile
+++ b/convert/jenkinsjson/convertTestFiles/testResultsAggregator/Jenkinsfile
@@ -1,0 +1,44 @@
+pipeline {
+    agent any
+    stages {
+        stage('Clone Repository') {
+            steps {
+                git url: 'https://github.com/senthilhns/sample-test-projects.git', branch: 'main'
+            }
+        }
+        stage('Run JUnit Tests') {
+            steps {
+                dir('test-results-aggregator/SampleJavaProject') {
+                    sh 'mvn test -Dtest=AppJUnitTest'
+                }
+            }
+        }
+        stage('Run TestNG Tests') {
+            steps {
+                dir('test-results-aggregator/SampleJavaProject') {
+                    sh 'mvn test -Dtest=AppTestNGTest'
+                }
+            }
+        }
+        stage('Aggregate Results') {
+            steps {
+                testResultsAggregator(
+                    jobs: [
+                        [jobName: 'JUnit Tests'],
+                        [jobName: 'TestNG Tests']
+                    ],
+                    recipientsList: 'mail1@gmail.com',
+                    recipientsListCC: 'mail2@gmail.com',
+                    recipientsListBCC: 'mail3@gmail.com',
+                    subject: 'Aggregated Test Results',
+                    theme: 'light',
+                    compareWithPreviousRun: false,
+                    influxdbUrl: "",
+                    influxdbToken: "",
+                    influxdbBucket: "",
+                    influxdbOrg: ""
+                )
+            }
+        }
+    }
+}

--- a/convert/jenkinsjson/convertTestFiles/testResultsAggregator/testResultsAggregator_test.json
+++ b/convert/jenkinsjson/convertTestFiles/testResultsAggregator/testResultsAggregator_test.json
@@ -1,0 +1,40 @@
+{
+  "spanId": "01c08da8822dc11e",
+  "traceId": "73b7e80c8e49a1fb9746b2018ded03ee",
+  "parent": "test-result-aggregator-03",
+  "all-info": "span(name: testResultsAggregator, spanId: 01c08da8822dc11e, parentSpanId: 5a447cde483c8a90, traceId: 73b7e80c8e49a1fb9746b2018ded03ee, attr: ci.pipeline.run.user:SYSTEM;harness-attribute:{\n  \"delegate\" : {\n    \"symbol\" : \"testResultsAggregator\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"compareWithPreviousRun\" : false,\n      \"influxdbBucket\" : \"\",\n      \"influxdbOrg\" : \"\",\n      \"influxdbToken\" : \"\",\n      \"influxdbUrl\" : \"\",\n      \"jobs\" : [ {\n        \"jobName\" : \"JUnit Tests\"\n      } ],\n      \"recipientsList\" : \"mail3@gmail.com\",\n      \"recipientsListBCC\" : \"mail3@gmail.com\",\n      \"recipientsListCC\" : \"mail3@gmail.com\",\n      \"subject\" : \"Aggregated Test Results\",\n      \"theme\" : \"light\"\n    },\n    \"model\" : null\n  }\n};harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@28ed13b6:io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@28ed13b6;harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@5212336a:org.jenkinsci.plugins.workflow.actions.TimingAction@5212336a;harness-others:-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep;jenkins.pipeline.step.id:30;jenkins.pipeline.step.name:Aggregate Test Results;jenkins.pipeline.step.plugin.name:test-results-aggregator;jenkins.pipeline.step.plugin.version:2.2;jenkins.pipeline.step.type:testResultsAggregator;)",
+  "name": "test-result-aggregator-03 #2",
+  "attributesMap": {
+    "harness-others": "-delegate-field org.jenkinsci.plugins.workflow.steps.CoreStep delegate-org.jenkinsci.plugins.workflow.steps.CoreStep.delegate-interface jenkins.tasks.SimpleBuildStep",
+    "jenkins.pipeline.step.name": "Aggregate Test Results",
+    "ci.pipeline.run.user": "SYSTEM",
+    "jenkins.pipeline.step.id": "30",
+    "harness-attribute-extra-pip: org.jenkinsci.plugins.workflow.actions.TimingAction@5212336a": "org.jenkinsci.plugins.workflow.actions.TimingAction@5212336a",
+    "jenkins.pipeline.step.type": "testResultsAggregator",
+    "harness-attribute": "{\n  \"delegate\" : {\n    \"symbol\" : \"testResultsAggregator\",\n    \"klass\" : null,\n    \"arguments\" : {\n      \"compareWithPreviousRun\" : false,\n      \"influxdbBucket\" : \"\",\n      \"influxdbOrg\" : \"\",\n      \"influxdbToken\" : \"\",\n      \"influxdbUrl\" : \"\",\n      \"jobs\" : [ {\n        \"jobName\" : \"JUnit Tests\"\n      } ],\n      \"recipientsList\" : \"mail3@gmail.com\",\n      \"recipientsListBCC\" : \"mail3@gmail.com\",\n      \"recipientsListCC\" : \"mail3@gmail.com\",\n      \"subject\" : \"Aggregated Test Results\",\n      \"theme\" : \"light\"\n    },\n    \"model\" : null\n  }\n}",
+    "jenkins.pipeline.step.plugin.name": "test-results-aggregator",
+    "harness-attribute-extra-pip: io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@28ed13b6": "io.jenkins.plugins.opentelemetry.MigrateHarnessUrlChildAction@28ed13b6",
+    "jenkins.pipeline.step.plugin.version": "2.2"
+  },
+  "type": "Run Phase Span",
+  "parentSpanId": "5a447cde483c8a90",
+  "parameterMap": {"delegate": {
+    "symbol": "testResultsAggregator",
+    "klass": null,
+    "arguments": {
+      "influxdbToken": "",
+      "influxdbOrg": "",
+      "compareWithPreviousRun": false,
+      "influxdbBucket": "",
+      "subject": "Aggregated Test Results",
+      "jobs": [{"jobName": "JUnit Tests"}],
+      "recipientsListCC": "mail3@gmail.com",
+      "theme": "light",
+      "recipientsListBCC": "mail3@gmail.com",
+      "influxdbUrl": "",
+      "recipientsList": "mail3@gmail.com"
+    },
+    "model": null
+  }},
+  "spanName": "testResultsAggregator"
+}

--- a/convert/jenkinsjson/convertTestFiles/testResultsAggregator/testResultsAggregator_test.yaml
+++ b/convert/jenkinsjson/convertTestFiles/testResultsAggregator/testResultsAggregator_test.yaml
@@ -1,0 +1,12 @@
+- step:
+    identifier: testresultsaggregator01c08d
+    name: testResultsAggregator
+    spec:
+      image: plugins/test-results-aggregator
+      settings:
+        group: <+input>
+        include_pattern: <+input>
+        reports_dir: <+input>
+        tool: <+input>
+    timeout: ""
+    type: Plugin

--- a/convert/jenkinsjson/json/testResultsAggregator.go
+++ b/convert/jenkinsjson/json/testResultsAggregator.go
@@ -1,0 +1,28 @@
+package json
+
+import (
+	harness "github.com/drone/spec/dist/go"
+)
+
+const (
+	testResultsAggregatorImage = "plugins/test-results-aggregator"
+)
+
+var ConvertTestResultsAggregatorParamMapperList = []JenkinsToDroneParamMapper{
+	{"compareWithPreviousRun", "compare_build_results", BoolType, nil},
+	{"influxdbBucket", "influxdb_bucket", StringType, nil},
+	{"influxdbOrg", "influxdb_org", StringType, nil},
+	{"influxdbToken", "influxdb_token", StringType, nil},
+	{"influxdbUrl", "influxdb_url", StringType, nil},
+}
+
+func ConvertTestResultsAggregator(node Node, variables map[string]string) *harness.Step {
+	step := ConvertToStepWithProperties(&node, variables, ConvertTestResultsAggregatorParamMapperList,
+		testResultsAggregatorImage)
+	tmpStepPlugin := step.Spec.(*harness.StepPlugin)
+	tmpStepPlugin.With["tool"] = "<+input>"
+	tmpStepPlugin.With["group"] = "<+input>"
+	tmpStepPlugin.With["include_pattern"] = "<+input>"
+	tmpStepPlugin.With["reports_dir"] = "<+input>"
+	return step
+}

--- a/convert/jenkinsjson/json/testResultsAggregator_test.go
+++ b/convert/jenkinsjson/json/testResultsAggregator_test.go
@@ -1,0 +1,65 @@
+package json
+
+import (
+	"encoding/json"
+	harness "github.com/drone/spec/dist/go"
+	"github.com/google/go-cmp/cmp"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const expectedTestResultsAggregatorStep = `{
+    "id": "testResultsAggregator01c08d",
+    "name": "testResultsAggregator",
+    "type": "plugin",
+    "spec": {
+        "image": "plugins/test-results-aggregator",
+        "with": {
+            "group": "\u003c+input\u003e",
+            "include_pattern": "\u003c+input\u003e",
+            "reports_dir": "\u003c+input\u003e",
+            "tool": "\u003c+input\u003e"
+        },
+        "inputs": {
+            "group": "\u003c+input\u003e",
+            "include_pattern": "\u003c+input\u003e",
+            "reports_dir": "\u003c+input\u003e",
+            "tool": "\u003c+input\u003e"
+        }
+    }
+}`
+
+func TestResultsAggregatorStep(t *testing.T) {
+	jsonFilePath := "../convertTestFiles/testResultsAggregator/testResultsAggregator_test.json"
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+
+	filePath := filepath.Join(workingDir, jsonFilePath)
+
+	jsonData, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read JSON file: %v", err)
+	}
+
+	var node Node
+	if err := json.Unmarshal(jsonData, &node); err != nil {
+		t.Fatalf("Failed to decode JSON: %v", err)
+	}
+
+	tmpTestStep := ConvertTestResultsAggregator(node, nil)
+
+	wantStep, err := ToStructFromJsonString[harness.Step](expectedTestResultsAggregatorStep)
+	if err != nil {
+		t.Fatalf("want step : %v", err)
+	}
+
+	diffs := cmp.Diff(wantStep, *tmpTestStep)
+
+	if len(diffs) != 0 {
+		t.Fatalf("Failed to convert JSON to struct: %v", diffs)
+	}
+}

--- a/samples/jenkins/Jenkinsfile
+++ b/samples/jenkins/Jenkinsfile
@@ -1357,5 +1357,48 @@ line3'''
             }
         }
     }
+
+    // testResultsAggregator
+    stages {
+        stage('Clone Repository') {
+            steps {
+                git url: 'https://github.com/senthilhns/sample-test-projects.git', branch: 'main'
+            }
+        }
+        stage('Run JUnit Tests') {
+            steps {
+                dir('test-results-aggregator/SampleJavaProject') {
+                    sh 'mvn test -Dtest=AppJUnitTest'
+                }
+            }
+        }
+        stage('Run TestNG Tests') {
+            steps {
+                dir('test-results-aggregator/SampleJavaProject') {
+                    sh 'mvn test -Dtest=AppTestNGTest'
+                }
+            }
+        }
+        stage('Aggregate Results') {
+            steps {
+                testResultsAggregator(
+                    jobs: [
+                        [jobName: 'JUnit Tests'],
+                        [jobName: 'TestNG Tests']
+                    ],
+                    recipientsList: 'mail1@gmail.com',
+                    recipientsListCC: 'mail2@gmail.com',
+                    recipientsListBCC: 'mail3@gmail.com',
+                    subject: 'Aggregated Test Results',
+                    theme: 'light',
+                    compareWithPreviousRun: false,
+                    influxdbUrl: "",
+                    influxdbToken: "",
+                    influxdbBucket: "",
+                    influxdbOrg: ""
+                )
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
Complete trace file json
[test-results-aggregator-trace.json](https://github.com/user-attachments/files/19095332/test-results-aggregator-trace.json)

converted yaml

```yaml
- step:
    identifier: testresultsaggregator01c08d
    name: testResultsAggregator
    spec:
      image: plugins/test-results-aggregator
      settings:
        group: <+input>
        include_pattern: <+input>
        reports_dir: <+input>
        tool: <+input>
    timeout: ""
    type: Plugin
```