### PR TITLE
fix: [PIPE-33046]: Use HAR registry for base images in Dockerfile

### DIFF
--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -37,7 +37,7 @@ pipeline:
                   identifier: test
                   spec:
                     connectorRef: account.harnessImage
-                    image: golang:1.24
+                    image: golang:1.25
                     shell: Sh
                     command: |-
                       go test -coverprofile=cover.out ./...
@@ -48,7 +48,7 @@ pipeline:
                   identifier: build
                   spec:
                     connectorRef: account.harnessImage
-                    image: golang:1.24
+                    image: golang:1.25
                     shell: Sh
                     command: |-
                       GOOS=linux   GOARCH=amd64   go build -o release/plugin-linux-amd64

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,11 +1,11 @@
-FROM golang:1.22-alpine AS builder
+FROM harness0.harness.io/oci/docker_artifacts/golang:1.25-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/go-convert-service ./cmd/server
 
-FROM gcr.io/distroless/static-debian12
+FROM harness0.harness.io/oci/docker_artifacts/static-debian12:latest
 COPY --from=builder /bin/go-convert-service /go-convert-service
 EXPOSE 8090
 ENTRYPOINT ["/go-convert-service"]


### PR DESCRIPTION
Use HAR registry for base images in Dockerfile