### PR TITLE
fix: [PIPE-33046]: Revert runtime base image to GCR distroless

### DIFF
--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -5,7 +5,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/go-convert-service ./cmd/server
 
-FROM harness0.harness.io/oci/docker_artifacts/static-debian12:latest
+FROM gcr.io/distroless/static-debian12
 COPY --from=builder /bin/go-convert-service /go-convert-service
 EXPOSE 8090
 ENTRYPOINT ["/go-convert-service"]


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

AI-Session-Id: 7b8163a7-c8dc-4f67-80f5-c20407558e2e
AI-Tool: claude-code
AI-Model: unknown