### PR TITLE
add conversion for service and infra inputs

### DIFF
--- a/convert/harness/yaml/service.go
+++ b/convert/harness/yaml/service.go
@@ -12,7 +12,7 @@ type (
 	DeploymentService struct {
 		ServiceRef   string        `json:"serviceRef,omitempty"    yaml:"serviceRef,omitempty"`
 		UseFromStage *UseFromStage `json:"useFromStage,omitempty" yaml:"useFromStage,omitempty"`
-		// ServiceInputs *flexible.Field[ServiceInputs] `json:"serviceInputs,omitempty" yaml:"serviceInputs,omitempty"`
+		ServiceInputs interface{} `json:"serviceInputs,omitempty" yaml:"serviceInputs,omitempty"`
 	}
 
 	DeploymentServiceConfig struct {

--- a/convert/v0tov1/convert_helpers/convert_stage_deployment.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_deployment.go
@@ -16,6 +16,7 @@ package converthelpers
 
 import (
 	"fmt"
+	"strings"
 
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
 	"github.com/drone/go-convert/convert/v0tov1/messagelog"
@@ -44,8 +45,18 @@ func ConvertDeploymentService(src *v0.DeploymentService, ctx *StageConversionCon
 
 	// For single service, return simple string reference
 	if src.ServiceRef != "" {
+		var serviceWith map[string]interface{}
+		if hasValidServiceInputs(src.ServiceInputs) {
+			serviceWith = map[string]interface{}{
+				"overlay": src.ServiceInputs,
+			}
+		}
+		serviceItem := &v1.ServiceItem{
+			Id:   src.ServiceRef,
+			With: serviceWith,
+		}
 		return &v1.ServiceRef{
-			Items:        []string{src.ServiceRef},
+			Items:        []*v1.ServiceItem{serviceItem},
 			MultiService: false,
 		}
 	}
@@ -97,10 +108,20 @@ func ConvertDeploymentServices(src *v0.DeploymentServices, ctx *StageConversionC
 		return nil
 	}
 
-	serviceRefs := make([]string, 0, len(values))
+	serviceItems := make([]*v1.ServiceItem, 0, len(values))
+
 	for _, service := range values {
 		if service != nil && service.ServiceRef != "" {
-			serviceRefs = append(serviceRefs, service.ServiceRef)
+			var serviceWith map[string]interface{}
+			if hasValidServiceInputs(service.ServiceInputs) {
+				serviceWith = map[string]interface{}{
+					"overlay": service.ServiceInputs,
+				}
+			}
+			serviceItems = append(serviceItems, &v1.ServiceItem{
+				Id:   service.ServiceRef,
+				With: serviceWith,
+			})
 		}
 	}
 	// by default set to true
@@ -108,9 +129,9 @@ func ConvertDeploymentServices(src *v0.DeploymentServices, ctx *StageConversionC
 	if src.Metadata != nil && src.Metadata.Parallel != nil {
 		sequential = flexible.NegateBool(src.Metadata.Parallel)
 	}
-	if len(serviceRefs) > 0 {
+	if len(serviceItems) > 0 {
 		return &v1.ServiceRef{
-			Items:        serviceRefs,
+			Items:        serviceItems,
 			MultiService: true,
 			Sequential:   sequential,
 		}
@@ -119,22 +140,43 @@ func ConvertDeploymentServices(src *v0.DeploymentServices, ctx *StageConversionC
 	return nil
 }
 
-func ConvertDeploymentServiceConfig(src *v0.DeploymentServiceConfig) *v1.ServiceRef {
-	if src == nil {
-		return nil
-	}
-	if src.ServiceRef != "" {
-		return &v1.ServiceRef{
-			Items: []string{src.ServiceRef},
-		}
+// func ConvertDeploymentServiceConfig(src *v0.DeploymentServiceConfig) *v1.ServiceRef {
+// 	if src == nil {
+// 		return nil
+// 	}
+// 	if src.ServiceRef != "" {
+// 		return &v1.ServiceRef{
+// 			Items: []string{src.ServiceRef},
+// 		}
+// 	}
+
+// 	if src.ServiceItem != nil {
+// 		return &v1.ServiceRef{
+// 			Items: []string{src.ServiceItem.Identifier},
+// 		}
+// 	}
+// 	return nil
+// }
+
+// hasValidServiceInputs checks if serviceInputs should be included in v1 output.
+// Returns false for nil, empty string, or expression values (strings containing <+).
+func hasValidServiceInputs(serviceInputs interface{}) bool {
+	if serviceInputs == nil {
+		return false
 	}
 
-	if src.ServiceItem != nil {
-		return &v1.ServiceRef{
-			Items: []string{src.ServiceItem.Identifier},
+	// Check if it's a string (expression or empty)
+	if str, ok := serviceInputs.(string); ok {
+		// Empty string or expression - skip
+		if str == "" || strings.Contains(str, "<+") {
+			return false
 		}
+		// Non-empty, non-expression string - this shouldn't happen but skip anyway
+		return false
 	}
-	return nil
+
+	// It's a struct/map - include it
+	return true
 }
 
 // ConvertEnvironment converts v0 Environment to v1 EnvironmentRef
@@ -315,7 +357,6 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 			return &v1.EnvironmentRef{
 				Sequential: seqField,
 				Group:      groupConfig,
-				
 			}
 		}
 	}
@@ -434,11 +475,33 @@ func collectInfraDefinitions(env *v0.Environment) *flexible.Field[[]*v0.Infrastr
 	return nil
 }
 
+// hasValidInfraInputs checks if infrastructure inputs should be included in v1 output.
+// Returns false for nil, empty string, or expression values (strings containing <+).
+func hasValidInfraInputs(inputs interface{}) bool {
+	if inputs == nil {
+		return false
+	}
+
+	// Check if it's a string (expression or empty)
+	if str, ok := inputs.(string); ok {
+		// Empty string or expression - skip
+		if str == "" || strings.Contains(str, "<+") {
+			return false
+		}
+		// Non-empty, non-expression string - this shouldn't happen but skip anyway
+		return false
+	}
+
+	// It's a struct/map - include it
+	return true
+}
+
 // resolveDeployTo determines the deploy-to value based on DeployToAll and infrastructure definitions.
 // - If DeployToAll is a boolean true → "all"
 // - If DeployToAll is <+input> → returns the infra value only (single string or list)
 // - If DeployToAll is any other expression → builds ternary: <+ <+expr> ? "all" : "infraValue" >
 // - If DeployToAll is nil/false → returns the infra value
+// - If infrastructure has inputs, returns DeployToItem with overlay
 func resolveDeployTo(deployToAll *flexible.Field[bool], infraDefs *flexible.Field[[]*v0.InfrastructureDefinition]) interface{} {
 	// Compute infra value from infrastructure definitions
 	var infraValue interface{}
@@ -447,13 +510,48 @@ func resolveDeployTo(deployToAll *flexible.Field[bool], infraDefs *flexible.Fiel
 			infraValue = infra
 		} else if infra, ok := infraDefs.AsStruct(); ok {
 			if len(infra) == 1 {
-				infraValue = infra[0].Identifier
-			} else if len(infra) > 1 {
-				infraList := make([]string, 0, len(infra))
-				for _, i := range infra {
-					infraList = append(infraList, i.Identifier)
+				// Single infrastructure - check for inputs
+				if hasValidInfraInputs(infra[0].Inputs) {
+					infraValue = &v1.DeployToItem{
+						Id: infra[0].Identifier,
+						With: map[string]interface{}{
+							"overlay": infra[0].Inputs,
+						},
+					}
+				} else {
+					infraValue = infra[0].Identifier
 				}
-				infraValue = infraList
+			} else if len(infra) > 1 {
+				// Multiple infrastructures - check each for inputs
+				hasAnyInputs := false
+				for _, i := range infra {
+					if hasValidInfraInputs(i.Inputs) {
+						hasAnyInputs = true
+						break
+					}
+				}
+
+				if hasAnyInputs {
+					// At least one has inputs - use DeployToItem array
+					infraItems := make([]*v1.DeployToItem, 0, len(infra))
+					for _, i := range infra {
+						item := &v1.DeployToItem{Id: i.Identifier}
+						if hasValidInfraInputs(i.Inputs) {
+							item.With = map[string]interface{}{
+								"overlay": i.Inputs,
+							}
+						}
+						infraItems = append(infraItems, item)
+					}
+					infraValue = infraItems
+				} else {
+					// No inputs - use simple string array
+					infraList := make([]string, 0, len(infra))
+					for _, i := range infra {
+						infraList = append(infraList, i.Identifier)
+					}
+					infraValue = infraList
+				}
 			}
 		}
 	}

--- a/convert/v0tov1/pipeline_converter/convert_stage.go
+++ b/convert/v0tov1/pipeline_converter/convert_stage.go
@@ -163,7 +163,7 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 			} else if spec.EnvironmentGroup != nil {
 				stage.Environment = convert_helpers.ConvertEnvironmentGroup(spec.EnvironmentGroup, c.stageCtx)
 			} else if spec.Infrastructure != nil {
-				GetMessageLogger().LogInfo(
+				GetMessageLogger().LogWarning(
 					"DEPRECATED_INFRA",
 					"deprecated infrastructure definition found in Deployment stage; infrastructure and service definition will be skipped",
 					WithStage(src.ID, string(v0.StageTypeDeployment)),
@@ -177,7 +177,11 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 			} else if spec.Services != nil {
 				stage.Service = convert_helpers.ConvertDeploymentServices(spec.Services, c.stageCtx)
 			} else if spec.ServiceConfig != nil && !deprecatedInfraDefinition {
-				stage.Service = convert_helpers.ConvertDeploymentServiceConfig(spec.ServiceConfig)
+				GetMessageLogger().LogWarning(
+					"DEPRECATED_SERVICE_CONFIG",
+					"deprecated service config found in Deployment stage; service config will be skipped",
+					WithStage(src.ID, string(v0.StageTypeDeployment)),
+				)
 			}
 			stage.Timeout = spec.Timeout
 		}

--- a/convert/v0tov1/pipeline_converter/stage_context_test.go
+++ b/convert/v0tov1/pipeline_converter/stage_context_test.go
@@ -12,7 +12,7 @@ import (
 func TestStageConversionContext_SetAndGet(t *testing.T) {
 	ctx := convert_helpers.NewStageConversionContext()
 
-	svc := &v1.ServiceRef{Items: []string{"my-service"}}
+	svc := &v1.ServiceRef{Items: []*v1.ServiceItem{{Id: "my-service"}}}
 	env := &v1.EnvironmentRef{Items: []*v1.EnvironmentItem{{Id: "my-env"}}}
 	rt := &v1.Runtime{Kubernetes: &v1.RuntimeKubernetes{Namespace: "default"}}
 
@@ -99,7 +99,7 @@ func TestUseFromStage_DeploymentServiceAndEnvironment(t *testing.T) {
 	if first.Service == nil {
 		t.Fatal("first stage: service should not be nil")
 	}
-	if len(first.Service.Items) != 1 || first.Service.Items[0] != "dashboard-svc" {
+	if len(first.Service.Items) != 1 || first.Service.Items[0].Id != "dashboard-svc" {
 		t.Errorf("first stage: expected service 'dashboard-svc', got %v", first.Service.Items)
 	}
 	if first.Environment == nil {
@@ -114,7 +114,7 @@ func TestUseFromStage_DeploymentServiceAndEnvironment(t *testing.T) {
 	if second.Service == nil {
 		t.Fatal("second stage: service should not be nil (useFromStage)")
 	}
-	if len(second.Service.Items) != 1 || second.Service.Items[0] != "dashboard-svc" {
+	if len(second.Service.Items) != 1 || second.Service.Items[0].Id != "dashboard-svc" {
 		t.Errorf("second stage: expected service 'dashboard-svc' from useFromStage, got %v", second.Service.Items)
 	}
 	if second.Environment == nil {
@@ -277,7 +277,7 @@ func TestUseFromStage_ServiceOnlyFromPreviousStage(t *testing.T) {
 
 	second := v1Stages[1]
 	// Service from useFromStage
-	if second.Service == nil || second.Service.Items[0] != "svc-alpha" {
+	if second.Service == nil || second.Service.Items[0].Id != "svc-alpha" {
 		t.Errorf("expected service 'svc-alpha' from useFromStage, got %v", second.Service)
 	}
 	// Environment is its own

--- a/convert/v0tov1/yaml/environment_ref_item.go
+++ b/convert/v0tov1/yaml/environment_ref_item.go
@@ -14,9 +14,80 @@
 
 package yaml
 
+import "encoding/json"
+
+// DeployToItem represents a single infrastructure deploy-to entry.
+// Can be either a simple string "infraId" or an object with id and overlay.
+type DeployToItem struct {
+	Id   string                 `json:"id,omitempty"`
+	With map[string]interface{} `json:"with,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler for DeployToItem.
+// Handles: string "infraId" or object {id: "infraId", with: {...}}
+func (d *DeployToItem) UnmarshalJSON(data []byte) error {
+	// Try as simple string first
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		d.Id = str
+		d.With = nil
+		return nil
+	}
+
+	// Try as full object
+	type Alias DeployToItem
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*d = DeployToItem(alias)
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for DeployToItem.
+// Outputs: string "infraId" if no With, or object {id: "infraId", with: {...}} if With exists
+func (d DeployToItem) MarshalJSON() ([]byte, error) {
+	// If no With, marshal as simple string
+	if len(d.With) == 0 {
+		return json.Marshal(d.Id)
+	}
+	// Otherwise marshal as full object
+	type Alias DeployToItem
+	return json.Marshal((Alias)(d))
+}
+
 // EnvironmentItem represents a single environment entry.
 type EnvironmentItem struct {
 	Id       string      `json:"id,omitempty" yaml:"id,omitempty"`
 	DeployTo interface{} `json:"deploy-to,omitempty" yaml:"deploy-to,omitempty"`
 	Filters  []*Filter   `json:"filters,omitempty" yaml:"filters,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler for EnvironmentItem.
+// Handles: string "envId" or object {id: "envId", deploy-to: ...}
+func (e *EnvironmentItem) UnmarshalJSON(data []byte) error {
+	// Try as simple string first
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		e.Id = str
+		e.DeployTo = nil
+		e.Filters = nil
+		return nil
+	}
+
+	// Try as full object
+	type Alias EnvironmentItem
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*e = EnvironmentItem(alias)
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for EnvironmentItem.
+// Always outputs object format {id: "envId", ...} for consistency
+func (e EnvironmentItem) MarshalJSON() ([]byte, error) {
+	type Alias EnvironmentItem
+	return json.Marshal((Alias)(e))
 }

--- a/convert/v0tov1/yaml/service_ref.go
+++ b/convert/v0tov1/yaml/service_ref.go
@@ -18,45 +18,108 @@ package yaml
 
 import (
 	"encoding/json"
+
 	"github.com/drone/go-convert/internal/flexible"
 )
 
-type ServiceRef struct {
-	Items       []string `json:"items,omitempty"`
-	Sequential    *flexible.Field[bool]     `json:"sequential,omitempty"`
-	MultiService bool     `json:"-"` // Don't serialize this field
+type ServiceItem struct {
+	Id   string                 `json:"id,omitempty"`
+	With map[string]interface{} `json:"with,omitempty"`
 }
 
-// UnmarshalJSON implement the json.Unmarshaler interface.
-func (v *ServiceRef) UnmarshalJSON(data []byte) error {
-	var out1 Stringorslice
-	var out2 = struct {
-		Items       []string `json:"items,omitempty"`
-		Sequential    *flexible.Field[bool]     `json:"sequential,omitempty"`
-		MultiService bool     `json:"-"`
-	}{}
-
-	if err := json.Unmarshal(data, &out1); err == nil {
-		v.Items = out1
+// UnmarshalJSON implements json.Unmarshaler for ServiceItem.
+// Handles: string "service1" or object {id: "service1", with: {...}}
+func (s *ServiceItem) UnmarshalJSON(data []byte) error {
+	// Try as simple string first
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		s.Id = str
+		s.With = nil
 		return nil
 	}
 
-	if err := json.Unmarshal(data, &out2); err == nil {
-		*v = out2
-		return nil
-	} else {
+	// Try as full object
+	type Alias ServiceItem
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
 		return err
 	}
+	*s = ServiceItem(alias)
+	return nil
 }
 
-// MarshalJSON implements the json.Marshaler interface.
+// MarshalJSON implements json.Marshaler for ServiceItem.
+// Outputs: string "service1" if no With, or object {id: "service1", with: {...}} if With exists
+func (s ServiceItem) MarshalJSON() ([]byte, error) {
+	// If no With, marshal as simple string
+	if len(s.With) == 0 {
+		return json.Marshal(s.Id)
+	}
+	// Otherwise marshal as full object
+	type Alias ServiceItem
+	return json.Marshal((Alias)(s))
+}
+
+type ServiceRef struct {
+	Items        []*ServiceItem        `json:"items,omitempty"`
+	Sequential   *flexible.Field[bool] `json:"sequential,omitempty"`
+	MultiService bool                  `json:"-"` // Don't serialize this field
+}
+
+// UnmarshalJSON implements json.Unmarshaler for ServiceRef.
+// Handles:
+// - Single string: "service1"
+// - Array of strings: ["service1", "service2"]
+// - Object with items: {items: [...], sequential: true}
+func (v *ServiceRef) UnmarshalJSON(data []byte) error {
+	// Try as single string
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		v.Items = []*ServiceItem{{Id: str}}
+		v.MultiService = false
+		return nil
+	}
+
+	// Try as array of strings/items
+	var arr []json.RawMessage
+	if err := json.Unmarshal(data, &arr); err == nil {
+		v.Items = make([]*ServiceItem, 0, len(arr))
+		for _, raw := range arr {
+			var item ServiceItem
+			if err := json.Unmarshal(raw, &item); err != nil {
+				return err
+			}
+			v.Items = append(v.Items, &item)
+		}
+		v.MultiService = len(v.Items) > 1
+		return nil
+	}
+
+	// Try as full object with items field
+	var out = struct {
+		Items      []*ServiceItem        `json:"items,omitempty"`
+		Sequential *flexible.Field[bool] `json:"sequential,omitempty"`
+	}{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	v.Items = out.Items
+	v.Sequential = out.Sequential
+	v.MultiService = len(v.Items) > 1
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for ServiceRef.
+// Outputs:
+// - Single string if one item without With and not MultiService: "service1"
+// - Object with items if MultiService: {items: [...]} or {items: [...], sequential: true}
 func (v *ServiceRef) MarshalJSON() ([]byte, error) {
-	// If there's exactly one item, and not forced to be array, marshal as a simple string
-	if len(v.Items) == 1 && !v.MultiService {
+	// Single item without With and not forced to be multi-service
+	if len(v.Items) == 1 && !v.MultiService && v.Sequential == nil {
 		return json.Marshal(v.Items[0])
 	}
-	
-	// Otherwise, marshal as the full struct
+
+	// Multi-service - always use items format
 	type Alias ServiceRef
 	return json.Marshal((*Alias)(v))
 }


### PR DESCRIPTION
### Service Inputs

- v0 yaml
```
pipeline:
  name: Service Inputs Comprehensive Test
  identifier: service_inputs_comprehensive_test
  projectIdentifier: default
  orgIdentifier: default
  tags: {}
  stages:
    # Stage 1: Service with full serviceInputs (should have overlay in v1)
    - stage:
        identifier: stage_with_service_inputs
        type: Deployment
        name: Stage With Service Inputs
        description: "Service with full serviceInputs configuration"
        spec:
          deploymentType: Kubernetes
          service:
            serviceRef: v0service
            serviceInputs:
              serviceDefinition:
                type: Kubernetes
                spec:
                  artifacts:
                    primary:
                      primaryArtifactRef: <+input>
                      sources: <+input>
                    sidecars:
                      - sidecar:
                          identifier: sidecar_1
                          type: DockerRegistry
                          spec:
                            tag: <+input>
                  manifests:
                    - manifest:
                        identifier: k8s_manifest
                        type: K8sManifest
                        spec:
                          store:
                            type: Git
                            spec:
                              paths: <+input>
          environment:
            environmentRef: dev
            deployToAll: false
            infrastructureDefinitions:
              - identifier: dev_infra
          execution:
            steps:
              - step:
                  type: K8sRollingDeploy
                  name: Rolling Deploy
                  identifier: rollingDeploy
                  spec:
                    skipDryRun: false
            rollbackSteps:
              - step:
                  type: K8sRollingRollback
                  name: Rollback
                  identifier: rollback
                  spec: {}
        tags: {}
        failureStrategies:
          - onFailure:
              errors:
                - AllErrors
              action:
                type: StageRollback

    # Stage 2: Multiple services with mixed serviceInputs
    - stage:
        identifier: stage_multi_services_mixed
        type: Deployment
        name: Stage Multi Services Mixed
        description: "Multiple services with mixed serviceInputs configurations"
        spec:
          deploymentType: Kubernetes
          services:
            metadata:
              parallel: false
            values:
              - serviceRef: svc_with_inputs
                serviceInputs:
                  serviceDefinition:
                    type: Kubernetes
                    spec:
                      variables:
                        - name: replicas
                          type: Number
                          value: 3
              - serviceRef: svc_without_inputs
          environment:
            environmentRef: prod
            deployToAll: false
            infrastructureDefinitions:
              - identifier: prod_k8s
          execution:
            steps:
              - step:
                  type: K8sRollingDeploy
                  name: Deploy All
                  identifier: deployAll
                  spec:
                    skipDryRun: false
            rollbackSteps:
              - step:
                  type: K8sRollingRollback
                  name: Rollback All
                  identifier: rollbackAll
                  spec: {}
        tags: {}
```
- v1 yaml
```
pipeline:
    clone:
        enabled: false
    id: service_inputs_comprehensive_test
    name: Service Inputs Comprehensive Test
    stages:
        - environment:
            deploy-to: dev_infra
            id: dev
          id: stage_with_service_inputs
          name: Stage With Service Inputs
          on-failure:
            - action: stage-rollback
              errors:
                - all
          rollback:
            - id: rollback
              name: Rollback
              template:
                uses: k8sRollingRollbackStep
                with: {}
          service:
            id: v0service
            with:
                overlay:
                    serviceDefinition:
                        spec:
                            artifacts:
                                primary:
                                    primaryArtifactRef: <+input>
                                    sources: <+input>
                                sidecars:
                                    - sidecar:
                                        identifier: sidecar_1
                                        spec:
                                            tag: <+input>
                                        type: DockerRegistry
                            manifests:
                                - manifest:
                                    identifier: k8s_manifest
                                    spec:
                                        store:
                                            spec:
                                                paths: <+input>
                                            type: Git
                                    type: K8sManifest
                        type: Kubernetes
          steps:
            - id: rollingDeploy
              name: Rolling Deploy
              template:
                uses: k8sRollingDeployStep
                with:
                    skip_dry_run: false
        - environment:
            deploy-to: prod_k8s
            id: prod
          id: stage_multi_services_mixed
          name: Stage Multi Services Mixed
          rollback:
            - id: rollbackAll
              name: Rollback All
              template:
                uses: k8sRollingRollbackStep
                with: {}
          service:
            items:
                - id: svc_with_inputs
                  with:
                    overlay:
                        serviceDefinition:
                            spec:
                                variables:
                                    - name: replicas
                                      type: Number
                                      value: 3
                            type: Kubernetes
                - svc_without_inputs
            sequential: true
          steps:
            - id: deployAll
              name: Deploy All
              template:
                uses: k8sRollingDeployStep
                with:
                    skip_dry_run: false
```
### Infrastructure Inputs
- v0 yaml
```
pipeline:
  name: Infrastructure Inputs Comprehensive Test
  identifier: infra_inputs_comprehensive_test
  projectIdentifier: default
  orgIdentifier: default
  tags: {}
  stages:
    # Stage 1: Single infrastructure with inputs (should have overlay in v1)
    - stage:
        identifier: stage_with_infra_inputs
        type: Deployment
        name: Stage With Infra Inputs
        description: "Infrastructure with full inputs configuration"
        spec:
          deploymentType: Kubernetes
          service:
            serviceRef: myservice
          environment:
            environmentRef: envrtmQQ
            deployToAll: false
            infrastructureDefinitions:
              - identifier: InfraSifZu
                inputs:
                  identifier: InfraSifZu
                  type: KubernetesDirect
                  spec:
                    connectorRef: account.cdautomationtest
                    namespace: default
                    releaseName: release1
          execution:
            steps:
              - step:
                  type: K8sRollingDeploy
                  name: Rolling Deploy
                  identifier: rollingDeploy
                  spec:
                    skipDryRun: false
            rollbackSteps:
              - step:
                  type: K8sRollingRollback
                  name: Rollback
                  identifier: rollback
                  spec: {}
        tags: {}
        failureStrategies:
          - onFailure:
              errors:
                - AllErrors
              action:
                type: StageRollback

    # Stage 2: Multiple infrastructures with some having inputs
    - stage:
        identifier: stage_multi_infra_mixed
        type: Deployment
        name: Stage Multi Infra Mixed
        description: "Multiple infrastructures with mixed inputs"
        spec:
          deploymentType: Kubernetes
          service:
            serviceRef: multiInfraService
          environment:
            environmentRef: staging
            deployToAll: false
            infrastructureDefinitions:
              - identifier: infra_with_inputs
                inputs:
                  type: KubernetesDirect
                  spec:
                    connectorRef: staging_connector
                    namespace: staging-ns
                    releaseName: staging-release
              - identifier: infra_no_inputs
              - identifier: infra_with_inputs_2
                inputs:
                  type: KubernetesDirect
                  spec:
                    connectorRef: staging_connector_2
                    namespace: staging-ns-2
          execution:
            steps:
              - step:
                  type: K8sRollingDeploy
                  name: Deploy
                  identifier: deploy
                  spec:
                    skipDryRun: false
            rollbackSteps:
              - step:
                  type: K8sRollingRollback
                  name: Rollback
                  identifier: rollback
                  spec: {}
        tags: {}
```
- v1 yaml
```
pipeline:
    clone:
        enabled: false
    id: infra_inputs_comprehensive_test
    name: Infrastructure Inputs Comprehensive Test
    stages:
        - environment:
            deploy-to:
                id: InfraSifZu
                with:
                    overlay:
                        identifier: InfraSifZu
                        spec:
                            connectorRef: account.cdautomationtest
                            namespace: default
                            releaseName: release1
                        type: KubernetesDirect
            id: envrtmQQ
          id: stage_with_infra_inputs
          name: Stage With Infra Inputs
          on-failure:
            - action: stage-rollback
              errors:
                - all
          rollback:
            - id: rollback
              name: Rollback
              template:
                uses: k8sRollingRollbackStep
                with: {}
          service: myservice
          steps:
            - id: rollingDeploy
              name: Rolling Deploy
              template:
                uses: k8sRollingDeployStep
                with:
                    skip_dry_run: false
        - environment:
            deploy-to:
                - id: infra_with_inputs
                  with:
                    overlay:
                        spec:
                            connectorRef: staging_connector
                            namespace: staging-ns
                            releaseName: staging-release
                        type: KubernetesDirect
                - infra_no_inputs
                - id: infra_with_inputs_2
                  with:
                    overlay:
                        spec:
                            connectorRef: staging_connector_2
                            namespace: staging-ns-2
                        type: KubernetesDirect
            id: staging
          id: stage_multi_infra_mixed
          name: Stage Multi Infra Mixed
          rollback:
            - id: rollback
              name: Rollback
              template:
                uses: k8sRollingRollbackStep
                with: {}
          service: multiInfraService
          steps:
            - id: deploy
              name: Deploy
              template:
                uses: k8sRollingDeployStep
                with:
                    skip_dry_run: false
```