### PR TITLE
fix expression and pipeline conversion issues, update API

### DIFF
--- a/convert/convertexpressions/const.go
+++ b/convert/convertexpressions/const.go
@@ -1,30 +1,5 @@
 package convertexpressions
 
-// ConversionContext holds metadata for context-aware conversion
-type ConversionContext struct {
-	StepType    string            // Type of the step (e.g., "Run", "GCSUpload", "Http") - resolved lazily by trie
-	StepID      string            // ID of the current step we're inside (from postprocess)
-	StepTypeMap map[string]string // Map of step ID to step type for all steps in the pipeline
-
-	// CurrentStepType is the type of the step we're currently inside (set by postprocess)
-	// This is used as fallback when expression is "step.spec.*" (no explicit step ID)
-	CurrentStepType string
-
-	// UseFQN enables fully qualified name mode for step expressions.
-	// When true, at step_node the v1Path is replaced with the step's v1 FQN base path.
-	UseFQN bool
-
-	// CurrentStepV1Path is the v1 FQN base path to the current step we're inside.
-	// Example: "pipeline.stages.build.steps.restoreCache"
-	// Used when UseFQN is true and expression starts with "step." (the step we're inside).
-	CurrentStepV1Path string
-
-	// StepV1PathMap maps step ID to its v1 FQN base path for all steps in the pipeline.
-	// Example: {"restoreCache": "pipeline.stages.build.steps.restoreCache"}
-	// Used when UseFQN is true and expression references a specific step ID (e.g., "steps.STEPID.spec.X").
-	StepV1PathMap map[string]string
-}
-
 // Step type constants
 const (
 	// Continuous Integration

--- a/convert/convertexpressions/context.go
+++ b/convert/convertexpressions/context.go
@@ -1,0 +1,105 @@
+package convertexpressions
+
+// StepInfoFQN is the FQN-keyed step info record. The full v1 FQN is the map key
+// in ConversionContext.StepInfoByFQN, so V1Path is not stored here.
+type StepInfoFQN struct {
+	Type string `json:"type,omitempty"` // v0 step type (e.g. "Run", "StepGroup")
+	// Types holds candidate v0 types when a single v1 field maps to several v0
+	// types (e.g. v1 step.run -> Run/ShellScript/Plugin/...). When non-empty it
+	// takes precedence over Type during step-type resolution.
+	Types   []string `json:"types,omitempty"`
+	StageID string   `json:"stage_id,omitempty"`
+	Chain   []string `json:"chain,omitempty"`   // ancestor step-group IDs, stage→leaf, excluding the leaf
+	StepID  string   `json:"step_id,omitempty"` // leaf step/group ID (final FQN segment)
+}
+
+// ConversionContext holds metadata for context-aware conversion
+type ConversionContext struct {
+	StepType string // step type (e.g. "Run", "Http"); resolved lazily by the trie
+	CurrentStepID   string // ID of the current step (from postprocess)
+
+	// CurrentStepType is the type of the step we're inside; the fallback for
+	// "step.spec.*" expressions (no explicit step ID).
+	CurrentStepType string
+
+	// CurrentStepTypes holds candidate types for the step we're inside, used
+	// like Types when the current step's v1 field maps to several v0 types.
+	CurrentStepTypes []string
+
+	// Warnings collects per-conversion diagnostics (e.g. unmapped template
+	// uses, ambiguous step types resolved via best-match fallback). The caller
+	// resets this between expressions to attribute warnings per expression.
+	Warnings []string
+
+	// UseFQN enables FQN mode: at step_node the v1Path becomes the step's v1
+	// FQN base path.
+	UseFQN bool
+
+	// CurrentStageID is the call-site's stage ID (set during the postprocess walk).
+	CurrentStageID string
+
+	// --- FQN-keyed step info lookup (sole step-resolution model) ---
+
+	// StepInfoByFQN maps each step/step-group's full v1 FQN to its metadata
+	// (e.g. "pipeline.stages.prod.steps.PostDeploy.steps.smoke_test"). Callers
+	// filter step groups by Type.
+	StepInfoByFQN map[string]*StepInfoFQN
+
+	// CurrentStepGroupChain is the call-site's enclosing step-group chain
+	// (outermost first, leaf parent last; empty at stage level). Group-relative
+	// aliases prepend it to the captured chain to form effectiveChain.
+	CurrentStepGroupChain []string
+
+	// CurrentFQN is the call-site step's full v1 FQN; short-circuits references
+	// to "the current step" (e.g. "step.spec.*"). Empty when not inside a step.
+	CurrentFQN string
+
+	// Lazy indexes built by EnsureIndexes from StepInfoByFQN:
+	indexesBuilt     bool
+	stageIDs         []string                       // deduped stage IDs, for fuzzy matching
+	stepsByStageStep map[string]map[string][]string // [stage][stepID] -> FQNs; candidate gather
+	flatStepIDCount  map[string]int                 // leaf stepID -> count across stages (flat fallback)
+	flatStepIDFQN    map[string]string              // leaf stepID -> canonical FQN (when count==1)
+}
+
+// EnsureIndexes builds the lazy lookup indexes from StepInfoByFQN once per
+// context. Callers that mutate StepInfoByFQN afterwards must reset indexesBuilt.
+func (c *ConversionContext) EnsureIndexes() {
+	if c == nil || c.indexesBuilt {
+		return
+	}
+	c.indexesBuilt = true
+	if c.StepInfoByFQN == nil {
+		return
+	}
+	stageSet := map[string]struct{}{}
+	c.stepsByStageStep = make(map[string]map[string][]string, len(c.StepInfoByFQN))
+	c.flatStepIDCount = make(map[string]int, len(c.StepInfoByFQN))
+	c.flatStepIDFQN = make(map[string]string, len(c.StepInfoByFQN))
+	for fqn, info := range c.StepInfoByFQN {
+		if info == nil {
+			continue
+		}
+		stageSet[info.StageID] = struct{}{}
+		byStep := c.stepsByStageStep[info.StageID]
+		if byStep == nil {
+			byStep = make(map[string][]string)
+			c.stepsByStageStep[info.StageID] = byStep
+		}
+		byStep[info.StepID] = append(byStep[info.StepID], fqn)
+		c.flatStepIDCount[info.StepID]++
+		c.flatStepIDFQN[info.StepID] = fqn
+	}
+	c.stageIDs = make([]string, 0, len(stageSet))
+	for s := range stageSet {
+		c.stageIDs = append(c.stageIDs, s)
+	}
+}
+
+// addWarning appends a diagnostic message to the context (no-op on nil).
+func (c *ConversionContext) addWarning(msg string) {
+	if c == nil || msg == "" {
+		return
+	}
+	c.Warnings = append(c.Warnings, msg)
+}

--- a/convert/convertexpressions/expression.go
+++ b/convert/convertexpressions/expression.go
@@ -2,15 +2,32 @@ package convertexpressions
 
 import "strings"
 
-// FindHarnessExprs finds all top-level <+...> expressions in a string,
-// handling arbitrary nesting depth via balanced bracket scanning.
-// Returns a list of {start, end} index pairs.
-func FindHarnessExprs(s string) [][2]int {
-	var results [][2]int
+// delimKind identifies which delimiter style wraps a Harness expression:
+// <+ ... > (delimAngle) or ${{ ... }} (delimDollar).
+type delimKind int
+
+const (
+	delimAngle delimKind = iota
+	delimDollar
+)
+
+// exprSpan is a top-level expression's byte range [start,end) and delimiter style.
+type exprSpan struct {
+	start int
+	end   int
+	kind  delimKind
+}
+
+// findExprSpans returns all top-level Harness expressions in s in order,
+// recognizing both <+ ... > and ${{ ... }}. Same-style nesting is handled via
+// balanced bracket scanning.
+func findExprSpans(s string) []exprSpan {
+	var results []exprSpan
 	n := len(s)
-	for i := 0; i < n-1; i++ {
-		if s[i] == '<' && s[i+1] == '+' {
-			start := i
+	for i := 0; i < n; i++ {
+		switch {
+		case i+1 < n && s[i] == '<' && s[i+1] == '+':
+			// <+ ... >, balanced on <+ / >.
 			depth := 1
 			j := i + 2
 			for j < n && depth > 0 {
@@ -25,7 +42,26 @@ func FindHarnessExprs(s string) [][2]int {
 				}
 			}
 			if depth == 0 {
-				results = append(results, [2]int{start, j})
+				results = append(results, exprSpan{i, j, delimAngle})
+				i = j - 1 // skip past this expression
+			}
+		case i+2 < n && s[i] == '$' && s[i+1] == '{' && s[i+2] == '{':
+			// ${{ ... }}, balanced on ${{ / }}.
+			depth := 1
+			j := i + 3
+			for j < n && depth > 0 {
+				if j+2 < n && s[j] == '$' && s[j+1] == '{' && s[j+2] == '{' {
+					depth++
+					j += 3
+				} else if j+1 < n && s[j] == '}' && s[j+1] == '}' {
+					depth--
+					j += 2
+				} else {
+					j++
+				}
+			}
+			if depth == 0 {
+				results = append(results, exprSpan{i, j, delimDollar})
 				i = j - 1 // skip past this expression
 			}
 		}
@@ -33,20 +69,40 @@ func FindHarnessExprs(s string) [][2]int {
 	return results
 }
 
-// replaceHarnessExprs replaces all top-level <+...> expressions in s
-// using the provided converter function on the inner content (without <+ and >).
+// FindHarnessExprs returns the {start, end} byte ranges of all top-level
+// Harness expressions in s, recognizing both <+...> and ${{...}} delimiters.
+func FindHarnessExprs(s string) [][2]int {
+	spans := findExprSpans(s)
+	if len(spans) == 0 {
+		return nil
+	}
+	results := make([][2]int, len(spans))
+	for i, sp := range spans {
+		results[i] = [2]int{sp.start, sp.end}
+	}
+	return results
+}
+
+// replaceHarnessExprs converts the inner content of every top-level expression
+// in s via converter, preserving each one's original delimiter style.
 func replaceHarnessExprs(s string, converter func(inner string) string) string {
-	spans := FindHarnessExprs(s)
+	spans := findExprSpans(s)
 	if len(spans) == 0 {
 		return s
 	}
 	var b strings.Builder
 	prev := 0
 	for _, span := range spans {
-		b.WriteString(s[prev:span[0]])
-		innerContent := s[span[0]+2 : span[1]-1] // strip <+ and >
-		b.WriteString("<+" + converter(innerContent) + ">")
-		prev = span[1]
+		b.WriteString(s[prev:span.start])
+		switch span.kind {
+		case delimDollar:
+			innerContent := s[span.start+3 : span.end-2] // strip ${{ and }}
+			b.WriteString("${{" + converter(innerContent) + "}}")
+		default:
+			innerContent := s[span.start+2 : span.end-1] // strip <+ and >
+			b.WriteString("<+" + converter(innerContent) + ">")
+		}
+		prev = span.end
 	}
 	b.WriteString(s[prev:])
 	return b.String()

--- a/convert/convertexpressions/families.go
+++ b/convert/convertexpressions/families.go
@@ -1,0 +1,88 @@
+package convertexpressions
+
+// RunCandidateTypes are the v0 types that all convert to v1 step.run (HTTP is
+// excluded — it is detected separately by its hardcoded plugin image).
+var RunCandidateTypes = []string{
+	StepTypeRun,
+	StepTypePlugin,
+	StepTypeAction,
+	StepTypeBitrise,
+	StepTypeContainer,
+	StepTypeShellScript,
+	StepTypeShellScriptProvision,
+}
+
+// RunTestCandidateTypes are the v0 types that convert to v1 step.run-test.
+var RunTestCandidateTypes = []string{
+	StepTypeRunTests,
+	StepTypeTest,
+}
+
+// TemplateUsesToV0Type maps a v1 step.template `uses` to the v0 step type that
+// keys the conversion rules.
+var TemplateUsesToV0Type = map[string]string{
+	// Cache
+	"saveCacheToGCS":      StepTypeSaveCacheGCS,
+	"saveCacheToS3":       StepTypeSaveCacheS3,
+	"restoreCacheFromGCS": StepTypeRestoreCacheGCS,
+	"restoreCacheFromS3":  StepTypeRestoreCacheS3,
+
+	// Artifact upload
+	"uploadArtifactsToGCS":              StepTypeGCSUpload,
+	"uploadArtifactsToS3":               StepTypeS3Upload,
+	"uploadArtifactsToJfrogArtifactory": StepTypeArtifactoryUpload,
+
+	// Build & push
+	"buildAndPushToECR":    StepTypeBuildAndPushECR,
+	"buildAndPushToGAR":    StepTypeBuildAndPushGAR,
+	"buildAndPushToACR":    StepTypeBuildAndPushACR,
+	"buildAndPushToDocker": StepTypeBuildAndPushDockerRegistry,
+
+	// Jira / ServiceNow / Email
+	"jiraCreate":       StepTypeJiraCreate,
+	"jiraUpdate":       StepTypeJiraUpdate,
+	"serviceNowCreate": StepTypeServiceNowCreate,
+	"serviceNowUpdate": StepTypeServiceNowUpdate,
+	"email":            StepTypeEmail,
+
+	// Git clone
+	"gitCloneStep": StepTypeGitClone,
+
+	// Kubernetes
+	"k8sRollingDeployStep":                  StepTypeK8sRollingDeploy,
+	"k8sRollingRollbackStep":                StepTypeK8sRollingRollback,
+	"k8sApplyStep":                          StepTypeK8sApply,
+	"k8sBlueGreenSwapServicesSelectorsStep": StepTypeK8sBGSwapServices,
+	"k8sBlueGreenStageScaleDownStep":        StepTypeK8sBlueGreenStageScaleDown,
+	"k8sCanaryDeleteStep":                   StepTypeK8sCanaryDelete,
+	"k8sDeleteStep":                         StepTypeK8sDelete,
+	"k8sDiffStep":                           StepTypeK8sDiff,
+	"k8sRolloutStep":                        StepTypeK8sRollout,
+	"k8sScaleStep":                          StepTypeK8sScale,
+	"k8sDryRunStep":                         StepTypeK8sDryRun,
+	"k8sTrafficRoutingStep":                 StepTypeK8sTrafficRouting,
+	"k8sCanaryDeployStep":                   StepTypeK8sCanaryDeploy,
+	"k8sBlueGreenDeployStep":                StepTypeK8sBlueGreenDeploy,
+	"k8sPatchStep":                          StepTypeK8sPatch,
+
+	// Helm
+	"helmBlueGreenDeployStep": StepTypeHelmBGDeploy,
+	"helmBlueGreenSwapStep":   StepTypeHelmBlueGreenSwapStep,
+	"helmCanaryDeployStep":    StepTypeHelmCanaryDeploy,
+	"helmCanaryDeleteStep":    StepTypeHelmCanaryDelete,
+	"helmDeleteStep":          StepTypeHelmDelete,
+	"helmBasicDeployStep":     StepTypeHelmDeploy,
+	"helmRollbackStep":        StepTypeHelmRollback,
+
+	// IACM
+	"terraformStep": StepTypeIACMTerraformPlugin,
+	"openTofuStep":  StepTypeIACMOpenTofuPlugin,
+}
+
+// ApprovalUsesToV0Type maps a v1 step.approval `uses` to the v0 step type.
+var ApprovalUsesToV0Type = map[string]string{
+	"harness":    StepTypeHarnessApproval,
+	"custom":     StepTypeCustomApproval,
+	"jira":       StepTypeJiraApproval,
+	"servicenow": StepTypeServiceNowApproval,
+}

--- a/convert/convertexpressions/lookup.go
+++ b/convert/convertexpressions/lookup.go
@@ -1,0 +1,527 @@
+package convertexpressions
+
+import (
+	"sort"
+	"strings"
+)
+
+// AliasKind controls chain scoping: group-relative aliases prepend
+// CurrentStepGroupChain to the captured chain; absolute aliases do not.
+type AliasKind int
+
+const (
+	// AliasAbsolute — stages./pipeline.stages./stage./execution. or none; the
+	// chain is a stage-anchored absolute path.
+	AliasAbsolute AliasKind = iota
+	// AliasGroupRelative — steps. or stepGroup.; the chain is scoped to the
+	// call-site's enclosing step group.
+	AliasGroupRelative
+)
+
+// prefixMatchWithBoundary returns true if registered is a prefix of static
+// AND the character following the prefix in static is a delimiter (or static
+// equals registered). Prevents over-matching like "prod" → "production".
+func prefixMatchWithBoundary(static, registered string) bool {
+	if !strings.HasPrefix(static, registered) {
+		return false
+	}
+	if len(static) == len(registered) {
+		return true
+	}
+	switch static[len(registered)] {
+	case '_', '-', '.', '<':
+		return true
+	}
+	return false
+}
+
+// fuzzyIDMatch reports whether captured matches registered, tolerating
+// matrix-expansion suffixes (captured="prod_0" vs "prod") and dynamic <+...>
+// substitutions (captured="LZ_<+x>" vs "LZ_Page"). It accepts exact equality, a
+// boundary-respecting prefix in either direction, or a pure-dynamic wildcard.
+// Boundaries are '_', '-', '.', '<', or end-of-string.
+func fuzzyIDMatch(captured, registered string) bool {
+	if captured == registered {
+		return true
+	}
+	sp := staticPrefix(captured)
+	if sp == "" {
+		// Pure-dynamic captured: wildcard match against any registered.
+		return true
+	}
+	// (a) Registered shorter: captured begins with registered + boundary.
+	if prefixMatchWithBoundary(sp, registered) {
+		return true
+	}
+	// (b) Captured-static shorter: registered begins with captured-static, with a
+	// boundary either at the end of sp or in registered just after it.
+	if strings.HasPrefix(registered, sp) && len(registered) > len(sp) {
+		// Inner boundary at the end of sp.
+		switch sp[len(sp)-1] {
+		case '_', '-', '.', '>':
+			return true
+		}
+		// Outer boundary in registered just after sp.
+		switch registered[len(sp)] {
+		case '_', '-', '.', '<':
+			return true
+		}
+	}
+	return false
+}
+
+// isLiteralEqual reports whether captured and registered are byte-equal — the
+// "best" possible match, used by the literal-equal-beats-fuzzy tie-breaker.
+func isLiteralEqual(captured, registered string) bool {
+	return captured == registered
+}
+
+// ResolveStepFQN finds the v1 FQN of the step (or step group) referenced by
+// (stageRef, chainRef, stepRef). aliasKind controls how chainRef composes with
+// the call-site's CurrentStepGroupChain; skipStepGroups drops StepGroup
+// candidates. Returns the FQN, its info, and an outcome (the pick reason on
+// success or the failure mode) that callers use to decide logging/emission.
+func (c *ConversionContext) ResolveStepFQN(
+	stageRef, stepRef string,
+	chainRef []string,
+	aliasKind AliasKind,
+	skipStepGroups bool,
+) (fqn string, info *StepInfoFQN, outcome ResolutionOutcome) {
+	return c.resolveStepFQN(stageRef, stepRef, chainRef, aliasKind, skipStepGroups, 0)
+}
+
+// resolveStepFQN is the parent-hop-aware implementation behind ResolveStepFQN.
+// For group-relative aliases, parentHops trailing elements are dropped from
+// CurrentStepGroupChain (one per getParentStepGroup edge) before prepending.
+func (c *ConversionContext) resolveStepFQN(
+	stageRef, stepRef string,
+	chainRef []string,
+	aliasKind AliasKind,
+	skipStepGroups bool,
+	parentHops int,
+) (fqn string, info *StepInfoFQN, outcome ResolutionOutcome) {
+	if c == nil || c.StepInfoByFQN == nil {
+		return "", nil, OutcomeUnknown
+	}
+	c.EnsureIndexes()
+
+	// Step 0 — build effective chain. For group-relative aliases, prepend the
+	// call-site's enclosing step-group chain, after trimming parentHops trailing
+	// elements to honour each getParentStepGroup navigation.
+	effectiveChain := chainRef
+	if aliasKind == AliasGroupRelative && len(c.CurrentStepGroupChain) > 0 {
+		base := c.CurrentStepGroupChain
+		if parentHops > 0 {
+			if parentHops >= len(base) {
+				base = nil
+			} else {
+				base = base[:len(base)-parentHops]
+			}
+		}
+		prepended := make([]string, 0, len(base)+len(chainRef))
+		prepended = append(prepended, base...)
+		prepended = append(prepended, chainRef...)
+		effectiveChain = prepended
+	}
+
+	// Step 1 — resolve stage. When neither expression nor context supplies a
+	// stage, we still allow the flat-ID fallback below to recover globally
+	// unique step IDs (typical for pipeline-level expressions written before
+	// the stage was known).
+	resolvedStage := c.resolveStageID(stageRef)
+	if resolvedStage == "" {
+		if len(effectiveChain) == 0 {
+			if c.flatStepIDCount[stepRef] == 1 {
+				fqn := c.flatStepIDFQN[stepRef]
+				info := c.StepInfoByFQN[fqn]
+				if !(skipStepGroups && info != nil && info.Type == "StepGroup") {
+					return fqn, info, OutcomeFlatUniqueFallback
+				}
+			}
+			if c.flatStepIDCount[stepRef] > 1 {
+				return "", nil, OutcomeAmbiguousFlatFallback
+			}
+		}
+		return "", nil, OutcomePureDynamic
+	}
+
+	// Step 2 — gather candidates by (stage, stepID). Refuse a pure-dynamic LEAF
+	// step ID: wildcard-matching + tie-breaking would invent an arbitrary leaf.
+	// (Dynamic chain elements are fine — they only narrow candidates.)
+	if staticPrefix(stepRef) == "" {
+		return "", nil, OutcomePureDynamic
+	}
+	candidates := c.gatherStepCandidates(resolvedStage, stepRef, skipStepGroups)
+	if len(candidates) == 0 {
+		// Step 5 — flat-ID fallback when chainRef is empty AND bare ID is
+		// globally unique. This recovers the "step ID alone, no chain" case
+		// without making silent picks on duplicates.
+		if len(effectiveChain) == 0 && c.flatStepIDCount[stepRef] == 1 {
+			fqn := c.flatStepIDFQN[stepRef]
+			info := c.StepInfoByFQN[fqn]
+			if !(skipStepGroups && info != nil && info.Type == "StepGroup") {
+				return fqn, info, OutcomeFlatUniqueFallback
+			}
+		}
+		if len(effectiveChain) == 0 && c.flatStepIDCount[stepRef] > 1 {
+			return "", nil, OutcomeAmbiguousFlatFallback
+		}
+		return "", nil, OutcomeUnknown
+	}
+
+	// Step 3 — exact-chain phase.
+	exactMatches := exactChainMatches(c.StepInfoByFQN, candidates, effectiveChain)
+	if len(exactMatches) == 1 {
+		return exactMatches[0], c.StepInfoByFQN[exactMatches[0]], OutcomeExactChain
+	}
+	if len(exactMatches) > 1 {
+		// Tie-breaker 3 (literal-equal beats fuzzy). Tertiary alphabetical.
+		picked, tied := tieBreakLiteralThenAlpha(exactMatches, c.StepInfoByFQN, effectiveChain)
+		if !tied {
+			return picked, c.StepInfoByFQN[picked], OutcomeExactChain
+		}
+		return "", nil, OutcomeAmbiguousExactChain
+	}
+
+	// Step 4 — subsequence fallback.
+	subMatches := subsequenceMatches(c.StepInfoByFQN, candidates, effectiveChain)
+	if len(subMatches) == 0 {
+		// Try flat-ID fallback even when chainRef is non-empty — the chain
+		// may simply be wrong. Same hybrid guard: only if globally unique.
+		if c.flatStepIDCount[stepRef] == 1 {
+			fqn := c.flatStepIDFQN[stepRef]
+			info := c.StepInfoByFQN[fqn]
+			if !(skipStepGroups && info != nil && info.Type == "StepGroup") {
+				return fqn, info, OutcomeFlatUniqueFallback
+			}
+		}
+		return "", nil, OutcomeUnknown
+	}
+	// Tie-breakers: 1 shallowest, 2 most-compact, 3 literal-equal-beats-fuzzy,
+	// 4 alphabetical.
+	winners := subMatches
+	if len(winners) > 1 {
+		winners = filterShallowest(winners, c.StepInfoByFQN)
+	}
+	if len(winners) > 1 {
+		winners = filterMostCompact(winners, c.StepInfoByFQN, effectiveChain)
+	}
+	if len(winners) > 1 {
+		picked, tied := tieBreakLiteralThenAlpha(winners, c.StepInfoByFQN, effectiveChain)
+		if tied {
+			return "", nil, OutcomeAmbiguousSubsequence
+		}
+		return picked, c.StepInfoByFQN[picked], OutcomeSubsequenceWithGap
+	}
+	return winners[0], c.StepInfoByFQN[winners[0]], OutcomeSubsequenceWithGap
+}
+
+// resolveStageID picks the stage ID to use. Preference: the expression's
+// stageRef (with fuzzyIDMatch against known stage IDs); otherwise fall back to
+// CurrentStageID. Returns "" if no usable stage was found (pure-dynamic with
+// no context).
+func (c *ConversionContext) resolveStageID(stageRef string) string {
+	if stageRef == "" {
+		return c.CurrentStageID
+	}
+	// Exact match wins.
+	for _, s := range c.stageIDs {
+		if s == stageRef {
+			return s
+		}
+	}
+	// Fuzzy match: pick the longest registered stage ID matching the captured
+	// reference bidirectionally. Longest wins to favour the most specific
+	// stage (e.g. "prod_2" should match registered "prod_2" not bare "prod").
+	best := ""
+	for _, s := range c.stageIDs {
+		if fuzzyIDMatch(stageRef, s) {
+			if len(s) > len(best) {
+				best = s
+			}
+		}
+	}
+	if best != "" {
+		return best
+	}
+	// Last resort: fall back to call-site context.
+	return c.CurrentStageID
+}
+
+// gatherStepCandidates returns the FQNs whose stageID matches resolvedStage and
+// whose leaf step ID fuzzy-matches stepRef, optionally filtering step groups.
+func (c *ConversionContext) gatherStepCandidates(resolvedStage, stepRef string, skipStepGroups bool) []string {
+	byStep := c.stepsByStageStep[resolvedStage]
+	if byStep == nil {
+		return nil
+	}
+	var out []string
+	// Try exact first to keep the hot path fast.
+	if exact, ok := byStep[stepRef]; ok {
+		for _, fqn := range exact {
+			info := c.StepInfoByFQN[fqn]
+			if skipStepGroups && info != nil && info.Type == "StepGroup" {
+				continue
+			}
+			out = append(out, fqn)
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	// Fuzzy step-ID fallback.
+	for sid, fqns := range byStep {
+		if !fuzzyIDMatch(stepRef, sid) {
+			continue
+		}
+		for _, fqn := range fqns {
+			info := c.StepInfoByFQN[fqn]
+			if skipStepGroups && info != nil && info.Type == "StepGroup" {
+				continue
+			}
+			out = append(out, fqn)
+		}
+	}
+	return out
+}
+
+// exactChainMatches filters candidates to those whose chain length matches
+// len(effectiveChain) and whose elements all fuzzy-match in order.
+func exactChainMatches(byFQN map[string]*StepInfoFQN, candidates []string, effectiveChain []string) []string {
+	var out []string
+	for _, fqn := range candidates {
+		info := byFQN[fqn]
+		if info == nil {
+			continue
+		}
+		if len(info.Chain) != len(effectiveChain) {
+			continue
+		}
+		ok := true
+		for i := range effectiveChain {
+			if !fuzzyIDMatch(effectiveChain[i], info.Chain[i]) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			out = append(out, fqn)
+		}
+	}
+	return out
+}
+
+// subsequenceMatches filters candidates to those whose chain contains
+// effectiveChain as an in-order subsequence (each element of effectiveChain
+// fuzzy-matches some chain element, in order). Returns the FQNs only —
+// per-candidate match positions are recomputed by tie-breakers as needed.
+func subsequenceMatches(byFQN map[string]*StepInfoFQN, candidates []string, effectiveChain []string) []string {
+	var out []string
+	for _, fqn := range candidates {
+		info := byFQN[fqn]
+		if info == nil {
+			continue
+		}
+		if isSubsequenceFuzzy(effectiveChain, info.Chain) {
+			out = append(out, fqn)
+		}
+	}
+	return out
+}
+
+// isSubsequenceFuzzy reports whether short appears as an in-order subsequence
+// of long using fuzzyIDMatch element-by-element. Greedy from the left — the
+// first viable position consumes the short[i] element.
+func isSubsequenceFuzzy(short, long []string) bool {
+	if len(short) == 0 {
+		return true
+	}
+	j := 0
+	for i := 0; i < len(long) && j < len(short); i++ {
+		if fuzzyIDMatch(short[j], long[i]) {
+			j++
+		}
+	}
+	return j == len(short)
+}
+
+// matchPositions returns the indices in long where short[i] matched, using
+// the same greedy strategy as isSubsequenceFuzzy. Returns nil if not a
+// subsequence at all.
+func matchPositions(short, long []string) []int {
+	if len(short) == 0 {
+		return []int{}
+	}
+	out := make([]int, 0, len(short))
+	j := 0
+	for i := 0; i < len(long) && j < len(short); i++ {
+		if fuzzyIDMatch(short[j], long[i]) {
+			out = append(out, i)
+			j++
+		}
+	}
+	if j == len(short) {
+		return out
+	}
+	return nil
+}
+
+// filterShallowest returns the subset of candidates whose chain length equals
+// the minimum among candidates.
+func filterShallowest(candidates []string, byFQN map[string]*StepInfoFQN) []string {
+	minLen := -1
+	for _, fqn := range candidates {
+		info := byFQN[fqn]
+		if info == nil {
+			continue
+		}
+		if minLen < 0 || len(info.Chain) < minLen {
+			minLen = len(info.Chain)
+		}
+	}
+	var out []string
+	for _, fqn := range candidates {
+		info := byFQN[fqn]
+		if info == nil || len(info.Chain) != minLen {
+			continue
+		}
+		out = append(out, fqn)
+	}
+	return out
+}
+
+// filterMostCompact selects candidates whose subsequence match has the
+// smallest sum of "gap positions" (i.e., the positions in the candidate's
+// chain not matched by the expression).
+func filterMostCompact(candidates []string, byFQN map[string]*StepInfoFQN, effectiveChain []string) []string {
+	type scored struct {
+		fqn string
+		sum int
+	}
+	scoredList := make([]scored, 0, len(candidates))
+	for _, fqn := range candidates {
+		info := byFQN[fqn]
+		if info == nil {
+			continue
+		}
+		positions := matchPositions(effectiveChain, info.Chain)
+		matched := map[int]struct{}{}
+		for _, p := range positions {
+			matched[p] = struct{}{}
+		}
+		sum := 0
+		for i := range info.Chain {
+			if _, ok := matched[i]; !ok {
+				sum += i
+			}
+		}
+		scoredList = append(scoredList, scored{fqn, sum})
+	}
+	if len(scoredList) == 0 {
+		return nil
+	}
+	minSum := scoredList[0].sum
+	for _, s := range scoredList[1:] {
+		if s.sum < minSum {
+			minSum = s.sum
+		}
+	}
+	var out []string
+	for _, s := range scoredList {
+		if s.sum == minSum {
+			out = append(out, s.fqn)
+		}
+	}
+	return out
+}
+
+// tieBreakLiteralThenAlpha picks among candidates by most literal-equal chain
+// matches, then alphabetical FQN. The tied flag is reserved for future strict
+// policies; the alphabetical fallback currently always disambiguates.
+func tieBreakLiteralThenAlpha(candidates []string, byFQN map[string]*StepInfoFQN, effectiveChain []string) (string, bool) {
+	if len(candidates) == 0 {
+		return "", true
+	}
+	if len(candidates) == 1 {
+		return candidates[0], false
+	}
+	// Score each candidate by number of literal-equal matches.
+	type scored struct {
+		fqn   string
+		score int
+	}
+	scoredList := make([]scored, 0, len(candidates))
+	for _, fqn := range candidates {
+		info := byFQN[fqn]
+		if info == nil {
+			continue
+		}
+		positions := matchPositions(effectiveChain, info.Chain)
+		if positions == nil {
+			// Exact-chain phase guarantees same length; positions may be nil
+			// if alignment failed — score 0 in that case.
+			scoredList = append(scoredList, scored{fqn, 0})
+			continue
+		}
+		s := 0
+		for i, p := range positions {
+			if i < len(effectiveChain) && isLiteralEqual(effectiveChain[i], info.Chain[p]) {
+				s++
+			}
+		}
+		scoredList = append(scoredList, scored{fqn, s})
+	}
+	maxScore := -1
+	for _, s := range scoredList {
+		if s.score > maxScore {
+			maxScore = s.score
+		}
+	}
+	var top []string
+	for _, s := range scoredList {
+		if s.score == maxScore {
+			top = append(top, s.fqn)
+		}
+	}
+	if len(top) == 1 {
+		return top[0], false
+	}
+	// Alphabetical FQN as the final, deterministic tie-breaker.
+	sort.Strings(top)
+	return top[0], false
+}
+
+// ParseFQN splits a full step FQN into its stage, ancestor-group chain, and
+// leaf step ID, e.g. "pipeline.stages.prod.steps.G1.steps.G2.steps.X" →
+// stage="prod", chain=["G1","G2"], step="X".
+func ParseFQN(fqn string) (stage string, chain []string, step string, ok bool) {
+	parts := strings.Split(fqn, ".")
+	// Expect at least: pipeline.stages.<stage>.steps.<step>
+	if len(parts) < 5 {
+		return "", nil, "", false
+	}
+	if parts[0] != "pipeline" || parts[1] != "stages" {
+		return "", nil, "", false
+	}
+	stage = parts[2]
+	// Remaining must be alternating "steps" / "<id>".
+	rest := parts[3:]
+	if len(rest)%2 != 0 {
+		return "", nil, "", false
+	}
+	ids := make([]string, 0, len(rest)/2)
+	for i := 0; i < len(rest); i += 2 {
+		if rest[i] != "steps" {
+			return "", nil, "", false
+		}
+		ids = append(ids, rest[i+1])
+	}
+	if len(ids) == 0 {
+		return "", nil, "", false
+	}
+	step = ids[len(ids)-1]
+	if len(ids) > 1 {
+		chain = ids[:len(ids)-1]
+	}
+	return stage, chain, step, true
+}

--- a/convert/convertexpressions/node_builder.go
+++ b/convert/convertexpressions/node_builder.go
@@ -81,6 +81,13 @@ func (nb *NodeBuilder) WithV1Name(v1Name string) *NodeBuilder {
 	return nb
 }
 
+// WithNoFQNOverride marks this node as an FQN-suppressing entry point: an
+// expression entering here converts structurally (no FQN stage/chain expansion).
+func (nb *NodeBuilder) WithNoFQNOverride() *NodeBuilder {
+	nb.node.noFQNOverride = true
+	return nb
+}
+
 // AsWildcard marks this node as a wildcard (already set by Node("*"))
 func (nb *NodeBuilder) AsWildcard() *NodeBuilder {
 	nb.node.isWildcard = true
@@ -108,7 +115,7 @@ func (nb *NodeBuilder) LinkToNodeByID(edgeName string, targetNodeID string) *Nod
 		fmt.Printf("Warning: target node ID '%s' not found in trie\n", targetNodeID)
 		return nb
 	}
-	
+
 	if edgeName == "*" {
 		// Create wildcard edge
 		nb.node.wildcardChild = targetNode
@@ -116,6 +123,6 @@ func (nb *NodeBuilder) LinkToNodeByID(edgeName string, targetNodeID string) *Nod
 		// Create named edge
 		nb.node.children[edgeName] = targetNode
 	}
-	
+
 	return nb
 }

--- a/convert/convertexpressions/pipeline_trie.go
+++ b/convert/convertexpressions/pipeline_trie.go
@@ -19,13 +19,16 @@ func GetPipelineTrie() *Trie {
 func buildPipelineTrie() *Trie {
 	trie := NewTrie()
 
-	// Build main pipeline structure with proper hierarchy
+	// Build main pipeline structure with proper hierarchy. The stage node, its
+	// ancestors (pipeline./stages.), and the execution roots (spec./execution.)
+	// are flagged WithNoFQNOverride(): they already carry stage context, so FQN
+	// expansion is skipped and the remainder converts structurally.
 	trie.AddPath().
-		Node("pipeline").WithAlias("pipeline").WithV1Name("pipeline").WithID("pipeline_node").
-		Node("stages").WithAlias("stages").WithV1Name("stages").WithID("stages_node").
-		Node("*").WithAlias("stage").WithID("stage_node").WithV1Name("*").
-		Node("spec").WithAlias("spec").WithV1Name("-").WithID("stage_spec_node").
-		Node("execution").WithAlias("execution").WithV1Name("-").WithID("stage_execution_node").
+		Node("pipeline").WithAlias("pipeline").WithV1Name("pipeline").WithID("pipeline_node").WithNoFQNOverride().
+		Node("stages").WithAlias("stages").WithV1Name("stages").WithID("stages_node").WithNoFQNOverride().
+		Node("*").WithAlias("stage").WithID("stage_node").WithV1Name("*").WithNoFQNOverride().
+		Node("spec").WithAlias("spec").WithV1Name("-").WithID("stage_spec_node").WithNoFQNOverride().
+		Node("execution").WithAlias("execution").WithV1Name("-").WithID("stage_execution_node").WithNoFQNOverride().
 		Node("steps").WithAlias("steps").WithV1Name("steps").WithID("steps_node").
 		Node("*").WithAlias("step").WithV1Name("*").WithID("step_node").
 		Node("spec").WithAlias("spec").WithV1Name("-").WithID("step_spec_node")
@@ -46,9 +49,15 @@ func buildPipelineTrie() *Trie {
 		Node("stepGroup").WithAlias("stepGroup").WithV1Name("group").WithID("step_group_node").
 		LinkToNodeByID("steps", "steps_node")
 
-	// Add getParentStepGroup edge that loops back to stepGroup
+	// getParentStepGroup edge: a dedicated intermediate node so the v1 output
+	// keeps the edge name "getParentStepGroup" rather than the target's "group".
 	trie.AddPathFromID("step_group_node").
-		LinkToNodeByID("getParentStepGroup", "step_group_node") // Self-reference
+		Node("getParentStepGroup").WithV1Name("getParentStepGroup").WithID("parent_step_group_node").
+		LinkToNodeByID("steps", "steps_node")
+
+	// Allow chaining: getParentStepGroup.getParentStepGroup...
+	trie.AddPathFromID("parent_step_group_node").
+		LinkToNodeByID("getParentStepGroup", "parent_step_group_node")
 
 	trie.AddPathFromID("stage_execution_node").
 		Node("rollbackSteps").WithAlias("rollbackSteps").WithV1Name("rollback").WithID("rollback_node").

--- a/convert/convertexpressions/resolution.go
+++ b/convert/convertexpressions/resolution.go
@@ -1,0 +1,50 @@
+package convertexpressions
+
+// ResolutionOutcome categorises the result of ResolveStepFQN. Callers use it
+// to choose the emitted path and whether to log a warning.
+type ResolutionOutcome int
+
+const (
+	OutcomeNone ResolutionOutcome = iota
+	// OutcomeExactChain — one candidate's chain matched effectiveChain exactly.
+	OutcomeExactChain
+	// OutcomeSubsequenceWithGap — matched via in-order subsequence (unmentioned
+	// groups); caller warns EXPRESSION_SUBSEQUENCE_GAP_FILLED.
+	OutcomeSubsequenceWithGap
+	// OutcomeAmbiguousExactChain — multiple exact-chain matches, unresolved.
+	OutcomeAmbiguousExactChain
+	// OutcomeAmbiguousSubsequence — multiple subsequence matches, unresolved.
+	OutcomeAmbiguousSubsequence
+	// OutcomeFlatUniqueFallback — empty chainRef, globally unique bare step ID.
+	OutcomeFlatUniqueFallback
+	// OutcomeAmbiguousFlatFallback — empty chainRef, bare step ID not unique.
+	OutcomeAmbiguousFlatFallback
+	// OutcomeUnknown — no candidate found.
+	OutcomeUnknown
+	// OutcomePureDynamic — fully dynamic stage/step ID with no usable context.
+	OutcomePureDynamic
+)
+
+// String returns a stable identifier for the outcome, suitable for log codes.
+func (o ResolutionOutcome) String() string {
+	switch o {
+	case OutcomeExactChain:
+		return "EXACT_CHAIN"
+	case OutcomeSubsequenceWithGap:
+		return "SUBSEQUENCE_GAP_FILLED"
+	case OutcomeAmbiguousExactChain:
+		return "AMBIGUOUS_EXACT_CHAIN"
+	case OutcomeAmbiguousSubsequence:
+		return "AMBIGUOUS_SUBSEQUENCE"
+	case OutcomeFlatUniqueFallback:
+		return "FLAT_UNIQUE_FALLBACK"
+	case OutcomeAmbiguousFlatFallback:
+		return "AMBIGUOUS_FLAT_FALLBACK"
+	case OutcomeUnknown:
+		return "UNKNOWN_STEP"
+	case OutcomePureDynamic:
+		return "PURELY_DYNAMIC"
+	default:
+		return "NONE"
+	}
+}

--- a/convert/convertexpressions/steps.go
+++ b/convert/convertexpressions/steps.go
@@ -284,7 +284,7 @@ var StepSpecConversionRules = map[string][]ConversionRule{
 	// GCSUpload -> uses="uploadArtifactsToGCS", id = gcsUpload
 	StepTypeGCSUpload: {
 		{"sourcePath", "steps.gcsUpload.spec.with.SOURCE"},
-		{"bucket", "steps.gcsUpload.spec.with.TARGET"},
+		{"bucket", "steps.gcsUpload.spec.with.BUCKET"},
 		{"target", "steps.gcsUpload.spec.with.TARGET"},
 	},
 

--- a/convert/convertexpressions/trie.go
+++ b/convert/convertexpressions/trie.go
@@ -38,6 +38,12 @@ type TrieNode struct {
 	isWildcard bool   // True for dynamic IDs (STAGE_ID, STEP_ID)
 	isArray    bool   // True if this node represents an array
 
+	// noFQNOverride marks an alias entry node where FQN stage/chain expansion
+	// is disabled (the remainder converts structurally). Set via
+	// WithNoFQNOverride() on the stage node, its ancestors (pipeline./stages.),
+	// and the execution roots, which already carry stage context.
+	noFQNOverride bool
+
 	// Array parent path support for rules like: outputVariables[i].name -> (spec.output[i]).alias
 	// When set, this indicates the array node maps to a multi-segment v1 path
 	arrayParentV1Path string // e.g., "spec.output" for the array node itself
@@ -448,8 +454,21 @@ type matchContext struct {
 	lastStepID  string // Last step ID seen in path (captured from wildcard after "steps")
 	inStepsPath bool   // True if we're currently inside a "steps" path segment
 
+	// Scoped context for disambiguating duplicate step IDs
+	lastStageID      string // Stage ID captured from wildcard after "stages" node
+	lastGroupID      string // Step group ID captured when a step-group wildcard is resolved
+	inStepGroupAlias bool   // True if we entered through the "stepGroup" alias root
+
+	// parentHops counts the number of getParentStepGroup edges traversed since
+	// entering the "stepGroup" alias.
+	parentHops int
+
 	// FQN mode tracking
 	fqnAttempted bool // True if we've already attempted FQN conversion (prevents infinite recursion)
+
+	// suppressFQN disables FQN expansion for the current match; set when entry
+	// is at a noFQNOverride node so the leaf step stays structural.
+	suppressFQN bool
 }
 
 func (t *Trie) Match(path string, context *ConversionContext) (string, bool) {
@@ -471,10 +490,45 @@ func (t *Trie) Match(path string, context *ConversionContext) (string, bool) {
 				v1Path:       []string{},
 			}
 
-			// FQN MODE: For "step." alias, replace v1Path with CurrentStepV1Path
-			// This handles expressions like "step.spec.bucket" where "step" refers to the current step
-			if firstSegment == "step" && context != nil && context.UseFQN && context.CurrentStepV1Path != "" {
-				ctx.v1Path = strings.Split(context.CurrentStepV1Path, ".")
+			// Bracketed alias root (stages[X] / steps[X] without the "pipeline."
+			// prefix): matchBracketedKeyword emits a combined "keyword[X]" segment
+			// and captures the bracket content as the stage/step ID.
+			if parts[0].arrayIndex != "" && (firstSegment == "stages" || firstSegment == "steps") && aliasNode.wildcardChild != nil {
+				if firstSegment == "steps" {
+					ctx.inStepsPath = true
+					ctx.inStepGroupAlias = true
+				}
+				if result, matched := t.matchBracketedKeyword(nil, aliasNode, parts, 0, ctx, context); matched {
+					score := t.calculateMatchScore(aliasNode, parts, 1, context)
+					if score > bestScore {
+						bestScore = score
+						bestResult = result
+						bestMatched = true
+					}
+				}
+				continue
+			}
+
+			// Stage-relative execution roots (execution.* / spec.execution.*) carry
+			// no explicit stage, so they later emit the v1 "stage" self-reference
+			// keyword. FQN suppression is handled below via noFQNOverride.
+			isExecutionRoot := firstSegment == "execution"
+			isSpecExecutionRoot := firstSegment == "spec" && len(parts) > 1 && parts[1].name == "execution"
+
+			// noFQNOverride (set at build time on the stage/ancestor and execution
+			// root nodes) disables FQN expansion: these already carry stage context.
+			if aliasNode.noFQNOverride {
+				ctx.suppressFQN = true
+			}
+
+			// Seed v1Path by alias root: execution roots emit the "stage"
+			// self-reference; a "step." spec/output reference in FQN mode seeds the
+			// current step's FQN; otherwise use the alias node's v1Name.
+			if isExecutionRoot || isSpecExecutionRoot {
+				ctx.v1Path = append(ctx.v1Path, "stage")
+			} else if firstSegment == "step" && context != nil && context.UseFQN && context.CurrentFQN != "" &&
+				len(parts) > 1 && (parts[1].name == "spec" || parts[1].name == "output") {
+				ctx.v1Path = strings.Split(context.CurrentFQN, ".")
 			} else if aliasNode.v1Name != "" && aliasNode.v1Name != "-" {
 				if aliasNode.v1Name == "*" {
 					ctx.v1Path = append(ctx.v1Path, parts[0].name)
@@ -486,6 +540,12 @@ func (t *Trie) Match(path string, context *ConversionContext) (string, bool) {
 			// Set inStepsPath if we're matching "steps" alias - this enables step ID capture
 			if firstSegment == "steps" {
 				ctx.inStepsPath = true
+			}
+
+			// "stepGroup"/"steps" are group-relative: resolution scopes them to the
+			// call-site's CurrentStepGroupChain.
+			if firstSegment == "stepGroup" || firstSegment == "steps" {
+				ctx.inStepGroupAlias = true
 			}
 
 			if result, matched := t.matchRecursive(aliasNode, parts, 1, ctx, context); matched {
@@ -561,7 +621,8 @@ func (t *Trie) parsePath(path string) []pathPart {
 // hasResolvableContext returns true if the ConversionContext can resolve a step type.
 func hasResolvableContext(convContext *ConversionContext, ctx *matchContext) bool {
 	return convContext != nil && (convContext.StepType != "" || convContext.CurrentStepType != "" ||
-		(ctx.lastStepID != "" && convContext.StepTypeMap != nil))
+		len(convContext.CurrentStepTypes) > 0 ||
+		(ctx.lastStepID != "" && convContext.StepInfoByFQN != nil))
 }
 
 // tryMatchChild attempts to match remaining parts through a child node using both
@@ -572,11 +633,11 @@ func (t *Trie) tryMatchChild(child *TrieNode, parts []pathPart, nextIndex int, c
 	hasCtx := hasResolvableContext(convContext, ctx)
 
 	if hasCtx {
-		// Try context-specific rules first (lazy resolution happens in tryContextMatch)
-		if result, matched := t.tryContextMatch(child, parts, nextIndex, ctx, convContext); matched {
+		// 1) Candidate-specific rules first (resolved single type or clash-free family).
+		if result, matched := t.tryContextMatchCandidates(child, parts, nextIndex, ctx, convContext); matched {
 			return result, true
 		}
-		// Fall back to general rules
+		// 2) General (non-context) rules.
 		if result, matched := t.matchRecursive(child, parts, nextIndex, ctx, convContext); matched {
 			if !isSkipped || !t.isSkippedNodePassthrough(result, ctx, parts, nextIndex) {
 				return result, true
@@ -587,6 +648,12 @@ func (t *Trie) tryMatchChild(child *TrieNode, parts []pathPart, nextIndex int, c
 				return result + "." + skippedSegment, true
 			}
 			// Children matched with passthrough - don't accept this match
+		}
+		// 3) Deterministic all-rules best-match fallback. Internally gated to a
+		// no-op when a single precise type resolved, so the v0-context flow
+		// never reaches it; only multi-type v1 families and unmapped uses do.
+		if result, matched := t.tryContextMatchAny(child, parts, nextIndex, ctx, convContext); matched {
+			return result, true
 		}
 	} else {
 		// No context: try general rules first, then deterministic context fallback
@@ -616,6 +683,16 @@ func (t *Trie) matchRecursive(node *TrieNode, parts []pathPart, index int, ctx *
 
 	currentPart := parts[index]
 
+	// Bracketed keyword forms stages[X] / steps[X]: the bracket content acts as
+	// the next wildcard segment (stage/step ID). See matchBracketedKeyword.
+	if currentPart.arrayIndex != "" && (currentPart.name == "stages" || currentPart.name == "steps") {
+		if child, ok := node.children[currentPart.name]; ok && child.wildcardChild != nil {
+			if result, matched := t.matchBracketedKeyword(node, child, parts, index, ctx, convContext); matched {
+				return result, true
+			}
+		}
+	}
+
 	if currentPart.arrayIndex != "" {
 		ctx.arrayIndices = append(ctx.arrayIndices, currentPart.arrayIndex)
 	}
@@ -633,6 +710,13 @@ func (t *Trie) matchRecursive(node *TrieNode, parts []pathPart, index int, ctx *
 			ctx.inStepsPath = true
 		}
 
+		// Each parent_step_group_node hop moves one level up from the call-site's
+		// group; resolution trims that many trailing elements off the chain.
+		savedParentHops := ctx.parentHops
+		if child.id == "parent_step_group_node" {
+			ctx.parentHops++
+		}
+
 		isSkipped := child.v1Name == "-"
 		skippedSegment := ""
 		if isSkipped {
@@ -647,6 +731,7 @@ func (t *Trie) matchRecursive(node *TrieNode, parts []pathPart, index int, ctx *
 		}
 
 		// Backtrack
+		ctx.parentHops = savedParentHops
 		ctx.inStepsPath = wasInStepsPath
 		if v1Segment != "" {
 			ctx.v1Path = ctx.v1Path[:len(ctx.v1Path)-1]
@@ -669,28 +754,43 @@ func (t *Trie) matchRecursive(node *TrieNode, parts []pathPart, index int, ctx *
 		// Capture step ID when matching wildcard after "steps"
 		// This enables lazy step type resolution for step.spec expressions
 		savedStepID := ctx.lastStepID
+		savedStageID := ctx.lastStageID
+		savedGroupID := ctx.lastGroupID
 		savedV1Path := make([]string, len(ctx.v1Path))
 		copy(savedV1Path, ctx.v1Path)
+
+		// Capture stage ID when this wildcard is directly under "stages_node"
+		if node.id == "stages_node" {
+			ctx.lastStageID = currentPart.name
+		}
 
 		if ctx.inStepsPath {
 			ctx.lastStepID = currentPart.name
 			ctx.inStepsPath = false // Reset after capturing
 
-			// FQN MODE: When we've just captured a step ID and UseFQN is enabled,
-			// replace ctx.v1Path with the step's v1 FQN base path.
-			if convContext != nil && convContext.UseFQN {
-				stepID := currentPart.name
-				var v1BasePath string
+			// FQN substitution applies only when the step reference targets a spec
+			// or output node; other fields (status, name, ...) stay structural.
+			targetsSpecOrOutput := stepRefTargetsSpecOrOutput(parts, index)
 
-				// Look up the step's v1 FQN base path from StepV1PathMap
-				if convContext.StepV1PathMap != nil {
-					v1BasePath = convContext.StepV1PathMap[stepID]
-				}
+			// In FQN mode, merge the accumulated path with the step's v1 FQN base.
+			if convContext != nil && convContext.UseFQN && targetsSpecOrOutput && !ctx.suppressFQN {
+				stepID := currentPart.name
+				v1BasePath := resolveStepV1Path(stepID, ctx, convContext)
 
 				if v1BasePath != "" {
-					// Replace v1Path with the FQN base path segments
-					ctx.v1Path = strings.Split(v1BasePath, ".")
+					// mergeFQN preserves dynamic segments in the accumulated path.
+					rawSeg := currentPart.name
+					if currentPart.arrayIndex != "" {
+						rawSeg += currentPart.arrayIndex
+					}
+					ctx.v1Path = mergeFQN(ctx.v1Path, v1BasePath, rawSeg)
 				}
+			}
+
+			// If the captured ID is a step group, append it to the chain so nested
+			// steps resolve within it.
+			if convContext != nil && targetsSpecOrOutput {
+				promoteGroupChain(ctx, currentPart.name, convContext)
 			}
 		}
 
@@ -700,6 +800,8 @@ func (t *Trie) matchRecursive(node *TrieNode, parts []pathPart, index int, ctx *
 
 		// Backtrack
 		ctx.lastStepID = savedStepID
+		ctx.lastStageID = savedStageID
+		ctx.lastGroupID = savedGroupID
 		ctx.v1Path = savedV1Path[:len(savedV1Path)-1]
 	}
 
@@ -730,48 +832,90 @@ func (t *Trie) matchRecursive(node *TrieNode, parts []pathPart, index int, ctx *
 // If convContext.StepType is empty but we have a step ID captured in matchContext,
 // we resolve the step type from StepTypeMap before attempting context matching.
 func (t *Trie) tryContextMatch(node *TrieNode, parts []pathPart, index int, ctx *matchContext, convContext *ConversionContext) (string, bool) {
+	if result, matched := t.tryContextMatchCandidates(node, parts, index, ctx, convContext); matched {
+		return result, true
+	}
+	return t.tryContextMatchAny(node, parts, index, ctx, convContext)
+}
+
+// tryContextMatchCandidates matches against only the resolved candidate step
+// types (a single confident type, or a clash-free family like run / run-test).
+// Returns false when no candidate resolves or none has a matching sub-trie.
+func (t *Trie) tryContextMatchCandidates(node *TrieNode, parts []pathPart, index int, ctx *matchContext, convContext *ConversionContext) (string, bool) {
 	if node.contextChildren == nil {
 		return "", false
 	}
-
-	// Lazy step type resolution: resolve from captured step ID or current step
-	resolvedStepType := t.resolveStepType(ctx, convContext)
-
-	// If we have a resolved step type, try that specific context
-	if resolvedStepType != "" {
-		contextRoot, exists := node.contextChildren[resolvedStepType]
-		if !exists {
-			return "", false
-		}
-
-		result, matched := t.tryContextSubtree(contextRoot, parts, index, ctx, convContext)
-		if matched {
-			return result, true
-		}
+	cands := t.resolveStepTypeCandidates(ctx, convContext)
+	if len(cands) == 0 {
 		return "", false
 	}
+	var keys []string
+	for _, c := range cands {
+		if _, ok := node.contextChildren[c]; ok {
+			keys = append(keys, c)
+		}
+	}
+	if len(keys) == 0 {
+		return "", false
+	}
+	return t.bestContextMatchAmong(node, keys, parts, index, ctx, convContext)
+}
 
-	// No context provided - try all available contexts and pick the one
-	// with the most node matches against the v0 input path.
-	// Ties are broken alphabetically by context key for determinism.
+// tryContextMatchAny is the deterministic fallback: try every available context
+// sub-trie and keep the one with the most node matches against the path (ties
+// broken alphabetically). Used when no step type resolves or candidate matching
+// fails; emits a warning so callers can surface the best-effort guess.
+func (t *Trie) tryContextMatchAny(node *TrieNode, parts []pathPart, index int, ctx *matchContext, convContext *ConversionContext) (string, bool) {
+	if node.contextChildren == nil {
+		return "", false
+	}
+	// Gate: when a single, precise step type resolved, do NOT fall back to the
+	// all-rules best-match. This keeps the v0-context flow (which always
+	// resolves exactly one precise type) unchanged
+	if len(t.resolveStepTypeCandidates(ctx, convContext)) == 1 {
+		return "", false
+	}
 	var contextKeys []string
 	for key := range node.contextChildren {
 		contextKeys = append(contextKeys, key)
 	}
-
 	if len(contextKeys) == 0 {
 		return "", false
 	}
+	result, matched := t.bestContextMatchAmong(node, contextKeys, parts, index, ctx, convContext)
+	// Warn only when some step context was expected (FQN map or an explicit
+	// step type) but the type couldn't be pinned down — i.e. an unmapped
+	// template/approval `uses` or an unresolved candidate. Pure no-context
+	// conversions deterministically use best-match and need no warning.
+	if matched && contextExpected(convContext) {
+		convContext.addWarning("ambiguous step type for path '" + t.buildRemainingPath(parts, index) +
+			"'; resolved via best-match across all step rule sets")
+	}
+	return result, matched
+}
 
-	// Sort to ensure deterministic tie-breaking
-	sortStrings(contextKeys)
+// contextExpected reports whether the caller supplied step context (an FQN map
+// or an explicit/current step type) such that a best-match fallback is worth
+// flagging as a warning.
+func contextExpected(cc *ConversionContext) bool {
+	return cc != nil && (cc.StepInfoByFQN != nil || cc.StepType != "" ||
+		cc.CurrentStepType != "" || len(cc.CurrentStepTypes) > 0)
+}
+
+// bestContextMatchAmong tries each given context key's sub-trie and returns the
+// match with the highest node-match score; ties are broken alphabetically.
+func (t *Trie) bestContextMatchAmong(node *TrieNode, keys []string, parts []pathPart, index int, ctx *matchContext, convContext *ConversionContext) (string, bool) {
+	sortStrings(keys)
 
 	var bestResult string
 	bestScore := -1
 	bestKey := ""
 
-	for _, contextKey := range contextKeys {
+	for _, contextKey := range keys {
 		contextRoot := node.contextChildren[contextKey]
+		if contextRoot == nil {
+			continue
+		}
 		result, matched := t.tryContextSubtree(contextRoot, parts, index, ctx, convContext)
 		if matched {
 			score := t.countContextNodeMatches(contextRoot, parts, index)
@@ -786,7 +930,6 @@ func (t *Trie) tryContextMatch(node *TrieNode, parts []pathPart, index int, ctx 
 	if bestScore >= 0 {
 		return bestResult, true
 	}
-
 	return "", false
 }
 
@@ -870,6 +1013,120 @@ func sortStrings(strs []string) {
 	sort.Strings(strs)
 }
 
+// matchBracketedKeyword handles stages[X] / steps[X], where X is an index or an
+// (optionally quoted/dynamic) identifier. It advances through the keyword's
+// wildcard child in one step, emits a combined "keyword[X]" segment, and uses
+// the bracket content for ID context (lastStageID/lastStepID, group promotion,
+// FQN merging) like a normal wildcard. Numeric indices are emitted verbatim
+// without FQN lookup.
+func (t *Trie) matchBracketedKeyword(node, keywordNode *TrieNode, parts []pathPart, index int, ctx *matchContext, convContext *ConversionContext) (string, bool) {
+	currentPart := parts[index]
+	wildcardChild := keywordNode.wildcardChild
+
+	// Save state for backtracking
+	savedV1Path := make([]string, len(ctx.v1Path))
+	copy(savedV1Path, ctx.v1Path)
+	savedStepID := ctx.lastStepID
+	savedStageID := ctx.lastStageID
+	savedGroupID := ctx.lastGroupID
+	savedInStepsPath := ctx.inStepsPath
+
+	// Emit the combined keyword[X] segment. Keyword v1Name comes from the
+	// keywordNode (e.g. "stages" / "steps"); fall back to part name when blank.
+	keywordV1 := keywordNode.v1Name
+	if keywordV1 == "" || keywordV1 == "-" {
+		keywordV1 = currentPart.name
+	}
+	combinedSeg := keywordV1 + currentPart.arrayIndex
+	ctx.v1Path = append(ctx.v1Path, combinedSeg)
+
+	// Extract and classify the bracket content.
+	bracketID := extractBracketContent(currentPart.arrayIndex)
+	isIndex := isNumericIndex(bracketID)
+
+	// Mirror the wildcard-capture context updates from matchRecursive.
+	if keywordNode.id == "stages_node" && !isIndex {
+		ctx.lastStageID = bracketID
+	}
+
+	if currentPart.name == "steps" && !isIndex {
+		ctx.lastStepID = bracketID
+		ctx.inStepsPath = false
+
+		// FQN substitution applies only for spec/output references.
+		targetsSpecOrOutput := stepRefTargetsSpecOrOutput(parts, index)
+
+		// In FQN mode, merge the accumulated path with the step's v1 FQN base.
+		if convContext != nil && convContext.UseFQN && targetsSpecOrOutput && !ctx.suppressFQN {
+			v1Base := resolveStepV1Path(bracketID, ctx, convContext)
+			if v1Base != "" {
+				// Drop the just-appended combinedSeg before merging, then re-add.
+				accPath := ctx.v1Path[:len(ctx.v1Path)-1]
+				ctx.v1Path = mergeFQN(accPath, v1Base, combinedSeg)
+			}
+		}
+
+		// Promote lastGroupID when the captured ID resolves to a step group.
+		if convContext != nil && targetsSpecOrOutput {
+			promoteGroupChain(ctx, bracketID, convContext)
+		}
+	}
+
+	if result, matched := t.tryMatchChild(wildcardChild, parts, index+1, ctx, convContext, false, ""); matched {
+		return result, true
+	}
+
+	// Backtrack on failure so the caller can fall back to normal matching.
+	ctx.v1Path = savedV1Path
+	ctx.lastStepID = savedStepID
+	ctx.lastStageID = savedStageID
+	ctx.lastGroupID = savedGroupID
+	ctx.inStepsPath = savedInStepsPath
+	return "", false
+}
+
+// extractBracketContent returns the content between the outermost square
+// brackets, stripping one surrounding pair of quotes if present. Examples:
+//
+//	"[0]"                          -> "0"
+//	"['approval_dev']"             -> "approval_dev"
+//	"[\"approval_dev\"]"           -> "approval_dev"
+//	"[<+stage.var.X>]"             -> "<+stage.var.X>"
+//	"['approval_<+stage.env.name>']" -> "approval_<+stage.env.name>"
+func extractBracketContent(bracketStr string) string {
+	s := strings.TrimPrefix(bracketStr, "[")
+	s = strings.TrimSuffix(s, "]")
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+			s = s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// appendGroupChain appends id to a '>'-separated step-group ancestry chain
+// (e.g. "Outer>Inner"), matching the registration key format in postprocess.go.
+func appendGroupChain(chain, id string) string {
+	if chain == "" {
+		return id
+	}
+	return chain + ">" + id
+}
+
+// isNumericIndex reports whether s is a non-empty string of ASCII digits.
+func isNumericIndex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // buildV1Segment builds the v1 output segment for a node
 func (t *Trie) buildV1Segment(node *TrieNode, part pathPart) string {
 	// Handle array nodes with arrayParentV1Path (from parenthesized rules)
@@ -915,42 +1172,278 @@ func (t *Trie) buildRemainingPath(parts []pathPart, startIndex int) string {
 	return strings.Join(segments, ".")
 }
 
-// resolveStepType performs lazy step type resolution for context-aware matching.
-// Resolution priority:
-//  1. If convContext.StepType is already set, use it (pre-resolved)
-//  2. If matchContext has a captured step ID, look it up in StepTypeMap
-//  3. Fall back to convContext.CurrentStepType (the step we're inside)
-//
-// This enables efficient context resolution only when needed (at step.spec nodes).
-func (t *Trie) resolveStepType(ctx *matchContext, convContext *ConversionContext) string {
+// resolveStepTypeCandidates mirrors resolveStepType but returns candidate
+// types: a single confident type, or a clash-free family (e.g. run /
+// run-test) when one v1 field maps to several v0 types. Empty when nothing
+// resolves (the caller then uses the all-rules best-match fallback).
+func (t *Trie) resolveStepTypeCandidates(ctx *matchContext, convContext *ConversionContext) []string {
 	if convContext == nil {
-		return ""
+		return nil
 	}
 
-	// Priority 1: Already resolved step type
+	// Priority 1: explicitly pre-set step type.
 	if convContext.StepType != "" {
-		return convContext.StepType
+		return []string{convContext.StepType}
 	}
 
-	// Priority 2: Look up captured step ID from path traversal
-	if ctx.lastStepID != "" && convContext.StepTypeMap != nil {
-		if stepType, ok := convContext.StepTypeMap[ctx.lastStepID]; ok {
-			return stepType
+	// Priority 2: captured step ID via the FQN resolver.
+	if ctx.lastStepID != "" && convContext.StepInfoByFQN != nil {
+		stageRef := ctx.lastStageID
+		if stageRef == "" {
+			stageRef = convContext.CurrentStageID
+		}
+		chainRef := splitChain(ctx.lastGroupID)
+		aliasKind := AliasAbsolute
+		if ctx.inStepGroupAlias {
+			aliasKind = AliasGroupRelative
+		}
+		if _, info, outcome := convContext.resolveStepFQN(stageRef, ctx.lastStepID, chainRef, aliasKind, false, ctx.parentHops); info != nil &&
+			(outcome == OutcomeExactChain || outcome == OutcomeSubsequenceWithGap || outcome == OutcomeFlatUniqueFallback) {
+			if len(info.Types) > 0 {
+				return info.Types
+			}
+			if info.Type != "" {
+				return []string{info.Type}
+			}
 		}
 	}
 
-	// Priority 3: Fall back to current step type (step we're inside)
-	return convContext.CurrentStepType
+	// Priority 3: the step we're physically inside.
+	if len(convContext.CurrentStepTypes) > 0 {
+		return convContext.CurrentStepTypes
+	}
+	if convContext.CurrentStepType != "" {
+		return []string{convContext.CurrentStepType}
+	}
+	return nil
 }
 
-// isStepInternalField checks if a field name indicates step-internal content
-// that should trigger FQN building when UseFQN is enabled.
-func isStepInternalField(fieldName string) bool {
-	switch fieldName {
-	case "spec", "output", "identifier", "name", "type", "timeout", "failureStrategies",
-		"strategy", "when", "delegateSelectors", "description", "status":
-		return true
-	default:
-		return false
+// mergeFQN overlays the trie-accumulated path (accPath) onto the resolved FQN
+// base (fqnBase), preserving accPath's dynamic <+...> segments in their ID
+// positions. ID positions are matched per keyword ("stages"/"steps") right-to-
+// left, so a dynamic step-group ID is never placed in a stage slot; the last
+// segment is then replaced with rawSeg to keep its raw captured form.
+//
+// Example: accPath ["steps","<+stepGroup.identifier>","steps","Sonar_Scan"] over
+// fqnBase "pipeline.stages.CI.steps.Python_Sonar.steps.Sonar_Scan" yields
+// "pipeline.stages.CI.steps.<+stepGroup.identifier>.steps.Sonar_Scan". When
+// accPath is empty, returns fqnBase with its last segment replaced by rawSeg.
+func mergeFQN(accPath []string, fqnBase string, rawSeg string) []string {
+	if fqnBase == "" {
+		return accPath
+	}
+	fqnParts := strings.Split(fqnBase, ".")
+
+	if len(accPath) == 0 {
+		// No accumulated path; use FQN directly, replacing last with rawSeg
+		if rawSeg != "" && len(fqnParts) > 0 {
+			fqnParts[len(fqnParts)-1] = rawSeg
+		}
+		return fqnParts
+	}
+
+	// Start with fqnParts as the base result
+	merged := make([]string, len(fqnParts))
+	copy(merged, fqnParts)
+
+	// Partition ID positions by preceding keyword. Stage IDs and step IDs must
+	// be matched independently so a step-group dynamic segment never lands in
+	// a stage slot (and vice versa).
+	fqnStageIDs := extractIDPositionsByKind(fqnParts, "stages")
+	fqnStepIDs := extractStepIDPositions(fqnParts)
+	accStageIDs := extractIDPositionsByKind(accPath, "stages")
+	accStepIDs := extractStepIDPositions(accPath)
+
+	substituteDynamicByKind(merged, fqnStageIDs, accPath, accStageIDs)
+	substituteDynamicByKind(merged, fqnStepIDs, accPath, accStepIDs)
+
+	// Always apply rawSeg to the last segment (preserves the raw captured form)
+	if rawSeg != "" && len(merged) > 0 {
+		merged[len(merged)-1] = rawSeg
+	}
+
+	// Restore bracketed forms so a dynamic bracketed reference (e.g.
+	// stages[<+stage.identifier>]) isn't rewritten to the FQN's static ID.
+	merged = collapseBracketedKeywords(merged, accPath)
+
+	return merged
+}
+
+// collapseBracketedKeywords rewrites "kind"+"ID" pairs in merged back into
+// combined "kind[X]" segments where accPath used the bracketed form, matched
+// left-to-right per kind (stages or steps).
+func collapseBracketedKeywords(merged, accPath []string) []string {
+	var stageBrackets, stepBrackets []string
+	for _, seg := range accPath {
+		if !strings.HasSuffix(seg, "]") {
+			continue
+		}
+		if strings.HasPrefix(seg, "stages[") {
+			stageBrackets = append(stageBrackets, seg)
+		} else if strings.HasPrefix(seg, "steps[") {
+			stepBrackets = append(stepBrackets, seg)
+		}
+	}
+	if len(stageBrackets) == 0 && len(stepBrackets) == 0 {
+		return merged
+	}
+	result := make([]string, 0, len(merged))
+	si, ti := 0, 0
+	for i := 0; i < len(merged); i++ {
+		if i+1 < len(merged) && merged[i] == "stages" && si < len(stageBrackets) {
+			result = append(result, stageBrackets[si])
+			si++
+			i++ // skip following ID slot
+			continue
+		}
+		if i+1 < len(merged) && merged[i] == "steps" && ti < len(stepBrackets) {
+			result = append(result, stepBrackets[ti])
+			ti++
+			i++ // skip following ID slot
+			continue
+		}
+		result = append(result, merged[i])
+	}
+	return result
+}
+
+// substituteDynamicByKind matches accIDs to fqnIDs right-to-left (so the most
+// recent / closest entries align first) and writes any dynamic accPath segment
+// into the corresponding merged slot.
+func substituteDynamicByKind(merged []string, fqnIDs []int, accPath []string, accIDs []int) {
+	for i := 0; i < len(accIDs) && i < len(fqnIDs); i++ {
+		accIdx := accIDs[len(accIDs)-1-i]
+		fqnIdx := fqnIDs[len(fqnIDs)-1-i]
+		accSeg := accPath[accIdx]
+		if strings.Contains(accSeg, "<+") {
+			merged[fqnIdx] = accSeg
+		}
+	}
+}
+
+// extractIDPositions returns the indices of segments that are identifiers
+// (stage IDs, step IDs, group IDs) — i.e., segments immediately after
+// "stages" or "steps".
+func extractIDPositions(parts []string) []int {
+	var positions []int
+	for i := range parts {
+		if i > 0 && (parts[i-1] == "stages" || parts[i-1] == "steps") {
+			positions = append(positions, i)
+		}
+	}
+	return positions
+}
+
+// extractIDPositionsByKind returns the indices of segments whose immediately
+// preceding segment equals kind (e.g. "stages" or "steps").
+func extractIDPositionsByKind(parts []string, kind string) []int {
+	var positions []int
+	for i := range parts {
+		if i > 0 && parts[i-1] == kind {
+			positions = append(positions, i)
+		}
+	}
+	return positions
+}
+
+// extractStepIDPositions returns the indices of step ID segments, treating
+// "steps", "rollbackSteps", and "rollback" as the same step-container keyword
+// so they align during mergeFQN (v0, trie output, and registry FQNs differ).
+func extractStepIDPositions(parts []string) []int {
+	var positions []int
+	for i := range parts {
+		if i == 0 {
+			continue
+		}
+		prev := parts[i-1]
+		if prev == "steps" || prev == "rollbackSteps" || prev == "rollback" {
+			positions = append(positions, i)
+		}
+	}
+	return positions
+}
+
+// staticPrefix extracts the static (non-expression) prefix of a path segment.
+// e.g., "Linux_Connectivity_<+expr>" → "Linux_Connectivity_"
+//
+//	"Test_Helm_Chart<+stepGroup.id>" → "Test_Helm_Chart"
+//	"plainID" → "plainID"
+func staticPrefix(seg string) string {
+	idx := strings.Index(seg, "<+")
+	if idx < 0 {
+		return seg
+	}
+	return seg[:idx]
+}
+
+// resolveStepV1Path resolves the v1 FQN base path for stepID via ResolveStepFQN.
+// Unknown/ambiguous references return "" so the caller leaves the segment as-is.
+func resolveStepV1Path(stepID string, ctx *matchContext, convContext *ConversionContext) string {
+	if convContext == nil || convContext.StepInfoByFQN == nil {
+		return ""
+	}
+
+	stageRef := ctx.lastStageID
+	if stageRef == "" {
+		stageRef = convContext.CurrentStageID
+	}
+	chainRef := splitChain(ctx.lastGroupID)
+	aliasKind := AliasAbsolute
+	if ctx.inStepGroupAlias {
+		aliasKind = AliasGroupRelative
+	}
+	fqn, info, outcome := convContext.resolveStepFQN(stageRef, stepID, chainRef, aliasKind, true, ctx.parentHops)
+	switch outcome {
+	case OutcomeExactChain, OutcomeSubsequenceWithGap, OutcomeFlatUniqueFallback:
+		if fqn != "" && info != nil {
+			return fqn
+		}
+	}
+	return ""
+}
+
+// splitChain converts the legacy ">"-joined chain string into a slice. Empty
+// input yields an empty slice (not nil-of-one-empty-string).
+func splitChain(chain string) []string {
+	if chain == "" {
+		return nil
+	}
+	return strings.Split(chain, ">")
+}
+
+// stepRefTargetsSpecOrOutput reports whether the step reference at stepIndex
+// ultimately targets a "spec" or "output" node (walking past nested steps.<id>
+// pairs). Only such targets get FQN substitution; other fields stay structural.
+func stepRefTargetsSpecOrOutput(parts []pathPart, stepIndex int) bool {
+	pos := stepIndex + 1
+	for pos+1 < len(parts) && parts[pos].name == "steps" {
+		pos += 2
+	}
+	if pos < len(parts) {
+		f := parts[pos].name
+		return f == "spec" || f == "output"
+	}
+	return false
+}
+
+// promoteGroupChain appends capturedID to ctx.lastGroupID if it resolves to a
+// step group (resolver called with skipStepGroups=false).
+func promoteGroupChain(ctx *matchContext, capturedID string, convContext *ConversionContext) {
+	if convContext == nil || convContext.StepInfoByFQN == nil {
+		return
+	}
+	stageRef := ctx.lastStageID
+	if stageRef == "" {
+		stageRef = convContext.CurrentStageID
+	}
+	chainRef := splitChain(ctx.lastGroupID)
+	aliasKind := AliasAbsolute
+	if ctx.inStepGroupAlias {
+		aliasKind = AliasGroupRelative
+	}
+	_, info, outcome := convContext.resolveStepFQN(stageRef, capturedID, chainRef, aliasKind, false, ctx.parentHops)
+	if info != nil && info.Type == "StepGroup" &&
+		(outcome == OutcomeExactChain || outcome == OutcomeSubsequenceWithGap || outcome == OutcomeFlatUniqueFallback) {
+		ctx.lastGroupID = appendGroupChain(ctx.lastGroupID, info.StepID)
 	}
 }

--- a/convert/convertexpressions/trie_convert_test.go
+++ b/convert/convertexpressions/trie_convert_test.go
@@ -269,7 +269,7 @@ func TestTrieConvert_StepLevel(t *testing.T) {
 			name:     "Relative Run step command",
 			input:    "<+execution.steps.step1.spec.command>",
 			context:  &ConversionContext{StepType: StepTypeRun},
-			expected: "<+steps.step1.spec.script>",
+			expected: "<+stage.steps.step1.spec.script>",
 		},
 		// Background step
 		{
@@ -315,7 +315,7 @@ func TestTrieConvert_StepLevel(t *testing.T) {
 			name:     "Relative RestoreCacheS3",
 			input:    "<+execution.steps.restore1.spec.bucket>",
 			context:  &ConversionContext{StepType: StepTypeRestoreCacheS3},
-			expected: "<+steps.restore1.steps.restoreCacheS3.spec.with.BUCKET>",
+			expected: "<+stage.steps.restore1.steps.restoreCacheS3.spec.with.BUCKET>",
 		},
 		{
 			name:     "StepGroup RestoreCacheS3",
@@ -481,11 +481,12 @@ func TestTrieConvert_ComplexNested(t *testing.T) {
 
 // TestTrieConvert_LazyStepTypeResolution tests that step type resolution happens
 // lazily inside the trie when it encounters step.spec expressions.
-// The trie captures step IDs during path traversal and resolves step type from StepTypeMap.
+// The trie captures step IDs during path traversal and resolves step type via
+// the FQN-keyed StepInfoByFQN lookup.
 // TestTrieConvert_FQNMode tests that when UseFQN is enabled, relative step expressions
 // are converted to fully qualified names.
-// - "step." prefix uses CurrentStepV1Path and CurrentStepType (the step we're inside)
-// - "steps.STEPID" prefix uses StepV1PathMap and StepTypeMap to look up the referenced step
+// - "step." prefix uses CurrentFQN and CurrentStepType (the step we're inside)
+// - "steps.STEPID" prefix uses StepInfoByFQN to look up the referenced step
 func TestTrieConvert_FQNMode(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -500,9 +501,9 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "step.spec.bucket with FQN - RestoreCacheGCS",
 			input: "<+step.spec.bucket>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.restoreCache",
-				CurrentStepType:   StepTypeRestoreCacheGCS,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.restoreCache",
+				CurrentStepType: StepTypeRestoreCacheGCS,
 			},
 			expected: "<+pipeline.stages.build.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
 		},
@@ -510,9 +511,9 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "step.spec.key with FQN - RestoreCacheS3",
 			input: "<+step.spec.key>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.restoreS3",
-				CurrentStepType:   StepTypeRestoreCacheS3,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.restoreS3",
+				CurrentStepType: StepTypeRestoreCacheS3,
 			},
 			expected: "<+pipeline.stages.build.steps.restoreS3.steps.restoreCacheS3.spec.with.CACHE_KEY>",
 		},
@@ -520,30 +521,32 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "step.spec.command with FQN - Run step",
 			input: "<+step.spec.command>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.runStep",
-				CurrentStepType:   StepTypeRun,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.runStep",
+				CurrentStepType: StepTypeRun,
 			},
 			expected: "<+pipeline.stages.build.steps.runStep.spec.script>",
 		},
 		{
+			// .identifier is not a spec/output node, so FQN substitution is
+			// suppressed and the relative "step" alias is preserved.
 			name:  "step.identifier with FQN",
 			input: "<+step.identifier>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.myStep",
-				CurrentStepType:   StepTypeRun,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.myStep",
+				CurrentStepType: StepTypeRun,
 			},
-			expected: "<+pipeline.stages.build.steps.myStep.id>",
+			expected: "<+step.id>",
 		},
 		// Step inside step group with FQN
 		{
 			name:  "step.spec.bucket in step group with FQN",
 			input: "<+step.spec.bucket>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.cacheGroup.steps.restoreCache",
-				CurrentStepType:   StepTypeRestoreCacheGCS,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.cacheGroup.steps.restoreCache",
+				CurrentStepType: StepTypeRestoreCacheGCS,
 			},
 			expected: "<+pipeline.stages.build.steps.cacheGroup.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
 		},
@@ -552,9 +555,9 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "step.spec.bucket in nested step group with FQN",
 			input: "<+step.spec.bucket>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.outerGroup.steps.innerGroup.steps.restoreCache",
-				CurrentStepType:   StepTypeRestoreCacheGCS,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.outerGroup.steps.innerGroup.steps.restoreCache",
+				CurrentStepType: StepTypeRestoreCacheGCS,
 			},
 			expected: "<+pipeline.stages.build.steps.outerGroup.steps.innerGroup.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
 		},
@@ -563,9 +566,9 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "step.spec.url with FQN - HTTP step",
 			input: "<+step.spec.url>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.httpCall",
-				CurrentStepType:   StepTypeHTTP,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.httpCall",
+				CurrentStepType: StepTypeHTTP,
 			},
 			expected: "<+pipeline.stages.build.steps.httpCall.spec.env.PLUGIN_URL>",
 		},
@@ -574,9 +577,9 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "step.output.httpResponseCode with FQN - HTTP step",
 			input: "<+step.output.httpResponseCode>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.httpCall",
-				CurrentStepType:   StepTypeHTTP,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.httpCall",
+				CurrentStepType: StepTypeHTTP,
 			},
 			expected: "<+pipeline.stages.build.steps.httpCall.steps.httpStep.output.outputVariables.PLUGIN_HTTP_RESPONSE_CODE>",
 		},
@@ -585,9 +588,9 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "multiple step expressions with FQN",
 			input: `bucket: <+step.spec.bucket> key: <+step.spec.key>`,
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.restoreCache",
-				CurrentStepType:   StepTypeRestoreCacheS3,
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.restoreCache",
+				CurrentStepType: StepTypeRestoreCacheS3,
 			},
 			expected: `bucket: <+pipeline.stages.build.steps.restoreCache.steps.restoreCacheS3.spec.with.BUCKET> key: <+pipeline.stages.build.steps.restoreCache.steps.restoreCacheS3.spec.with.CACHE_KEY>`,
 		},
@@ -599,9 +602,9 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "step.spec.command without FQN flag",
 			input: "<+step.spec.command>",
 			context: &ConversionContext{
-				UseFQN:            false,
-				CurrentStepV1Path: "pipeline.stages.build.steps.runStep",
-				CurrentStepType:   StepTypeRun,
+				UseFQN:          false,
+				CurrentFQN:      "pipeline.stages.build.steps.runStep",
+				CurrentStepType: StepTypeRun,
 			},
 			expected: "<+step.spec.script>", // Normal relative conversion
 		},
@@ -610,9 +613,9 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "step.spec.command with FQN but no path",
 			input: "<+step.spec.command>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "",
-				CurrentStepType:   StepTypeRun,
+				UseFQN:          true,
+				CurrentFQN:      "",
+				CurrentStepType: StepTypeRun,
 			},
 			expected: "<+step.spec.script>", // Normal relative conversion
 		},
@@ -621,11 +624,12 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "already FQN path with FQN enabled",
 			input: "<+pipeline.stages.build.spec.execution.steps.step1.spec.command>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.step1",
-				CurrentStepType:   StepTypeRun,
-				StepTypeMap:       map[string]string{"step1": StepTypeRun},
-				StepV1PathMap:     map[string]string{"step1": "pipeline.stages.build.steps.step1"},
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.step1",
+				CurrentStepType: StepTypeRun,
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.step1": {Type: StepTypeRun, StageID: "build", StepID: "step1"},
+				},
 			},
 			expected: "<+pipeline.stages.build.steps.step1.spec.script>",
 		},
@@ -637,9 +641,11 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "steps.STEPID.spec.command with FQN - Run step",
 			input: "<+steps.runStep.spec.command>",
 			context: &ConversionContext{
-				UseFQN:        true,
-				StepTypeMap:   map[string]string{"runStep": StepTypeRun},
-				StepV1PathMap: map[string]string{"runStep": "pipeline.stages.build.steps.runStep"},
+				UseFQN:         true,
+				CurrentStageID: "build",
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.runStep": {Type: StepTypeRun, StageID: "build", StepID: "runStep"},
+				},
 			},
 			expected: "<+pipeline.stages.build.steps.runStep.spec.script>",
 		},
@@ -647,9 +653,11 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "steps.STEPID.spec.bucket with FQN - RestoreCacheGCS",
 			input: "<+steps.restoreCache.spec.bucket>",
 			context: &ConversionContext{
-				UseFQN:        true,
-				StepTypeMap:   map[string]string{"restoreCache": StepTypeRestoreCacheGCS},
-				StepV1PathMap: map[string]string{"restoreCache": "pipeline.stages.build.steps.restoreCache"},
+				UseFQN:         true,
+				CurrentStageID: "build",
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.restoreCache": {Type: StepTypeRestoreCacheGCS, StageID: "build", StepID: "restoreCache"},
+				},
 			},
 			expected: "<+pipeline.stages.build.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
 		},
@@ -658,31 +666,37 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "execution.steps.STEPID.spec.bucket with FQN",
 			input: "<+execution.steps.restoreCache.spec.bucket>",
 			context: &ConversionContext{
-				UseFQN:        true,
-				StepTypeMap:   map[string]string{"restoreCache": StepTypeRestoreCacheGCS},
-				StepV1PathMap: map[string]string{"restoreCache": "pipeline.stages.build.steps.restoreCache"},
+				UseFQN:         true,
+				CurrentStageID: "build",
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.restoreCache": {Type: StepTypeRestoreCacheGCS, StageID: "build", StepID: "restoreCache"},
+				},
 			},
-			expected: "<+pipeline.stages.build.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
+			expected: "<+stage.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
 		},
 		// spec.execution.steps.STEPID.spec.bucket
 		{
 			name:  "spec.execution.steps.STEPID.spec.bucket with FQN",
 			input: "<+spec.execution.steps.restoreCache.spec.bucket>",
 			context: &ConversionContext{
-				UseFQN:        true,
-				StepTypeMap:   map[string]string{"restoreCache": StepTypeRestoreCacheGCS},
-				StepV1PathMap: map[string]string{"restoreCache": "pipeline.stages.build.steps.restoreCache"},
+				UseFQN:         true,
+				CurrentStageID: "build",
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.restoreCache": {Type: StepTypeRestoreCacheGCS, StageID: "build", StepID: "restoreCache"},
+				},
 			},
-			expected: "<+pipeline.stages.build.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
+			expected: "<+stage.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
 		},
 		// stepGroup.steps.STEPID.spec.bucket
 		{
 			name:  "stepGroup.steps.STEPID.spec.bucket with FQN",
 			input: "<+stepGroup.steps.restoreCache.spec.bucket>",
 			context: &ConversionContext{
-				UseFQN:        true,
-				StepTypeMap:   map[string]string{"restoreCache": StepTypeRestoreCacheGCS},
-				StepV1PathMap: map[string]string{"restoreCache": "pipeline.stages.build.steps.cacheGroup.steps.restoreCache"},
+				UseFQN:         true,
+				CurrentStageID: "build",
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.cacheGroup.steps.restoreCache": {Type: StepTypeRestoreCacheGCS, StageID: "build", Chain: []string{"cacheGroup"}, StepID: "restoreCache"},
+				},
 			},
 			expected: "<+pipeline.stages.build.steps.cacheGroup.steps.restoreCache.steps.restoreCacheGCS.spec.with.BUCKET>",
 		},
@@ -691,11 +705,13 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			name:  "steps.otherStep reference from inside currentStep",
 			input: "<+steps.otherStep.output.result>",
 			context: &ConversionContext{
-				UseFQN:            true,
-				CurrentStepV1Path: "pipeline.stages.build.steps.currentStep",
-				CurrentStepType:   StepTypeRun,
-				StepTypeMap:       map[string]string{"otherStep": StepTypeRun, "currentStep": StepTypeRun},
-				StepV1PathMap:     map[string]string{"otherStep": "pipeline.stages.build.steps.otherStep", "currentStep": "pipeline.stages.build.steps.currentStep"},
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.currentStep",
+				CurrentStepType: StepTypeRun,
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.otherStep":   {Type: StepTypeRun, StageID: "build", StepID: "otherStep"},
+					"pipeline.stages.build.steps.currentStep": {Type: StepTypeRun, StageID: "build", StepID: "currentStep"},
+				},
 			},
 			expected: "<+pipeline.stages.build.steps.otherStep.output.result>",
 		},
@@ -705,8 +721,7 @@ func TestTrieConvert_FQNMode(t *testing.T) {
 			input: "<+steps.unknownStep.spec.command>",
 			context: &ConversionContext{
 				UseFQN:        true,
-				StepTypeMap:   map[string]string{},
-				StepV1PathMap: map[string]string{},
+				StepInfoByFQN: map[string]*StepInfoFQN{},
 			},
 			expected: "<+steps.unknownStep.spec.script>", // Falls back to normal conversion
 		},
@@ -734,7 +749,9 @@ func TestTrieConvert_LazyStepTypeResolution(t *testing.T) {
 			name:  "Lazy resolution from StepTypeMap for Run step",
 			input: "<+pipeline.stages.build.spec.execution.steps.runStep1.spec.command>",
 			context: &ConversionContext{
-				StepTypeMap: map[string]string{"runStep1": StepTypeRun},
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.runStep1": {Type: StepTypeRun, StageID: "build", StepID: "runStep1"},
+				},
 				// Note: StepType is NOT set - should be resolved lazily
 			},
 			expected: "<+pipeline.stages.build.steps.runStep1.spec.script>",
@@ -743,7 +760,9 @@ func TestTrieConvert_LazyStepTypeResolution(t *testing.T) {
 			name:  "Lazy resolution from StepTypeMap for Http step",
 			input: "<+pipeline.stages.build.spec.execution.steps.httpStep.spec.url>",
 			context: &ConversionContext{
-				StepTypeMap: map[string]string{"httpStep": StepTypeHTTP},
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.httpStep": {Type: StepTypeHTTP, StageID: "build", StepID: "httpStep"},
+				},
 			},
 			expected: "<+pipeline.stages.build.steps.httpStep.spec.env.PLUGIN_URL>",
 		},
@@ -751,7 +770,9 @@ func TestTrieConvert_LazyStepTypeResolution(t *testing.T) {
 			name:  "Lazy resolution for nested step group",
 			input: "<+pipeline.stages.build.spec.execution.steps.myGroup.steps.innerRun.spec.command>",
 			context: &ConversionContext{
-				StepTypeMap: map[string]string{"innerRun": StepTypeRun},
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.myGroup.steps.innerRun": {Type: StepTypeRun, StageID: "build", Chain: []string{"myGroup"}, StepID: "innerRun"},
+				},
 			},
 			expected: "<+pipeline.stages.build.steps.myGroup.steps.innerRun.spec.script>",
 		},
@@ -761,7 +782,6 @@ func TestTrieConvert_LazyStepTypeResolution(t *testing.T) {
 			input: "<+step.spec.command>",
 			context: &ConversionContext{
 				CurrentStepType: StepTypeRun,
-				StepTypeMap:     map[string]string{},
 			},
 			expected: "<+step.spec.script>",
 		},
@@ -770,10 +790,10 @@ func TestTrieConvert_LazyStepTypeResolution(t *testing.T) {
 			name:  "Multiple step types - resolves correct type for each",
 			input: "<+pipeline.stages.build.spec.execution.steps.gcsStep.spec.env.bucket>",
 			context: &ConversionContext{
-				StepTypeMap: map[string]string{
-					"runStep1": StepTypeRun,
-					"gcsStep":  StepTypeGCSUpload,
-					"httpStep": StepTypeHTTP,
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.runStep1": {Type: StepTypeRun, StageID: "build", StepID: "runStep1"},
+					"pipeline.stages.build.steps.gcsStep":  {Type: StepTypeGCSUpload, StageID: "build", StepID: "gcsStep"},
+					"pipeline.stages.build.steps.httpStep": {Type: StepTypeHTTP, StageID: "build", StepID: "httpStep"},
 				},
 			},
 			expected: "<+pipeline.stages.build.steps.gcsStep.spec.env.bucket>",
@@ -783,7 +803,9 @@ func TestTrieConvert_LazyStepTypeResolution(t *testing.T) {
 			name:  "Unknown step ID - deterministic fallback to first matching context",
 			input: "<+pipeline.stages.build.spec.execution.steps.unknownStep.spec.command>",
 			context: &ConversionContext{
-				StepTypeMap: map[string]string{"runStep1": StepTypeRun},
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.runStep1": {Type: StepTypeRun, StageID: "build", StepID: "runStep1"},
+				},
 			},
 			// When step ID not found, trie uses deterministic fallback (alphabetically first matching context)
 			// "Run" context has command->script rule, so it applies
@@ -794,9 +816,11 @@ func TestTrieConvert_LazyStepTypeResolution(t *testing.T) {
 			name:  "Relative steps path with lazy resolution",
 			input: "<+execution.steps.runStep1.spec.command>",
 			context: &ConversionContext{
-				StepTypeMap: map[string]string{"runStep1": StepTypeRun},
+				StepInfoByFQN: map[string]*StepInfoFQN{
+					"pipeline.stages.build.steps.runStep1": {Type: StepTypeRun, StageID: "build", StepID: "runStep1"},
+				},
 			},
-			expected: "<+steps.runStep1.spec.script>",
+			expected: "<+stage.steps.runStep1.spec.script>",
 		},
 	}
 
@@ -805,6 +829,68 @@ func TestTrieConvert_LazyStepTypeResolution(t *testing.T) {
 			got := ConvertExpressionWithTrie(tt.input, tt.context, false)
 			if got != tt.expected {
 				t.Errorf("ConvertExpressionWithTrie() lazy resolution failed\ninput:    %s\ncontext:  %+v\ngot:      %s\nexpected: %s", tt.input, tt.context, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestTrieConvert_DollarDelimiter verifies that ${{ ... }} delimited expressions
+// are detected and converted with the same path-conversion logic as <+ ... >,
+// and that the ${{ }} delimiter style is preserved on output.
+func TestTrieConvert_DollarDelimiter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		context  *ConversionContext
+		expected string
+	}{
+		{
+			name:     "Dollar step output path collapse",
+			input:    "${{pipeline.stages.cs1.spec.execution.steps.ShellScript_1.output.outputVariables.rishi1}}",
+			expected: "${{pipeline.stages.cs1.steps.ShellScript_1.output.outputVariables.rishi1}}",
+		},
+		{
+			name:     "Dollar stage identifier",
+			input:    "${{pipeline.stages.build.identifier}}",
+			expected: "${{pipeline.stages.build.id}}",
+		},
+		{
+			name:     "Dollar codebase prefix",
+			input:    "${{pipeline.properties.ci.codebase.branch}}",
+			expected: "${{codebase.branch}}",
+		},
+		{
+			name:     "Dollar mixed with text",
+			input:    "echo ${{pipeline.stages.build.spec.execution.steps.step1.output}} done",
+			expected: "echo ${{pipeline.stages.build.steps.step1.output}} done",
+		},
+		{
+			name:     "Dollar and angle delimiters in same string",
+			input:    "${{pipeline.stages.build.spec.execution.steps.step1.output}} and <+pipeline.stages.deploy.spec.execution.steps.step2.output>",
+			expected: "${{pipeline.stages.build.steps.step1.output}} and <+pipeline.stages.deploy.steps.step2.output>",
+		},
+		{
+			name:     "Dollar plain string passthrough",
+			input:    "${{just.a.plain.path.no.conversion}}",
+			expected: "${{just.a.plain.path.no.conversion}}",
+		},
+		{
+			name:  "Dollar step self-reference in FQN mode",
+			input: "${{step.spec.command}}",
+			context: &ConversionContext{
+				UseFQN:          true,
+				CurrentFQN:      "pipeline.stages.build.steps.compile",
+				CurrentStepType: StepTypeRun,
+			},
+			expected: "${{pipeline.stages.build.steps.compile.spec.script}}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertExpressionWithTrie(tt.input, tt.context, false)
+			if got != tt.expected {
+				t.Errorf("ConvertExpressionWithTrie() dollar delimiter failed\ninput:    %s\ngot:      %s\nexpected: %s", tt.input, got, tt.expected)
 			}
 		})
 	}

--- a/convert/convertexpressions/trie_rules_test.go
+++ b/convert/convertexpressions/trie_rules_test.go
@@ -139,25 +139,25 @@ func TestTrieRules_StepLevel(t *testing.T) {
 			name:     "output variables relative",
 			path:     "spec.execution.steps.step1.output.outputVariables.var1",
 			context:  &ConversionContext{StepType: StepTypeRun},
-			expected: "steps.step1.output.outputVariables.var1",
+			expected: "stage.steps.step1.output.outputVariables.var1",
 		},
 		{
 			name:     "output variables spec name",
 			path:     "spec.execution.steps.step1.spec.outputVariables[1].name",
 			context:  &ConversionContext{StepType: StepTypeRun},
-			expected: "steps.step1.spec.output[1].alias",
+			expected: "stage.steps.step1.spec.output[1].alias",
 		},
 		{
 			name:     "output variables spec",
 			path:     "spec.execution.steps.step1.spec.outputVariables",
 			context:  &ConversionContext{StepType: StepTypeRun},
-			expected: "steps.step1.spec.output",
+			expected: "stage.steps.step1.spec.output",
 		},
 		{
 			name:     "output variables relative with function",
 			path:     "spec.execution.steps.step1.output.outputVariables.var1.some_func(\"param\")",
 			context:  &ConversionContext{StepType: StepTypeRun},
-			expected: "steps.step1.output.outputVariables.var1.some_func(\"param\")",
+			expected: "stage.steps.step1.output.outputVariables.var1.some_func(\"param\")",
 		},
 		// Failure strategies
 		{
@@ -183,7 +183,7 @@ func TestTrieRules_StepLevel(t *testing.T) {
 			name:     "save cache to gcs relative",
 			path:     "execution.steps.STEPID.spec.bucket",
 			context:  &ConversionContext{StepType: StepTypeSaveCacheGCS},
-			expected: "steps.STEPID.steps.saveCacheGCS.spec.with.BUCKET",
+			expected: "stage.steps.STEPID.steps.saveCacheGCS.spec.with.BUCKET",
 		},
 		// Step-specific rules with context - RestoreCacheS3
 		{
@@ -196,7 +196,7 @@ func TestTrieRules_StepLevel(t *testing.T) {
 			name:     "restore cache from s3 relative",
 			path:     "execution.steps.STEPID.spec.bucket",
 			context:  &ConversionContext{StepType: StepTypeRestoreCacheS3},
-			expected: "steps.STEPID.steps.restoreCacheS3.spec.with.BUCKET",
+			expected: "stage.steps.STEPID.steps.restoreCacheS3.spec.with.BUCKET",
 		},
 		{
 			name:     "restore cache from s3 inside step group",
@@ -533,7 +533,7 @@ func TestTrieRules_K8sSteps(t *testing.T) {
 			name:     "K8sRollingDeploy skipDryRun relative",
 			path:     "execution.steps.step1.spec.skipDryRun",
 			context:  &ConversionContext{StepType: StepTypeK8sRollingDeploy},
-			expected: "steps.step1.steps.k8sApplyAction.spec.env.PLUGIN_SKIP_DRY_RUN",
+			expected: "stage.steps.step1.steps.k8sApplyAction.spec.env.PLUGIN_SKIP_DRY_RUN",
 		},
 	}
 
@@ -675,7 +675,7 @@ func TestTrieRules_HelmSteps(t *testing.T) {
 			name:     "HelmBGDeploy ignoreReleaseHistFailStatus relative",
 			path:     "execution.steps.step1.spec.ignoreReleaseHistFailStatus",
 			context:  &ConversionContext{StepType: StepTypeHelmBGDeploy},
-			expected: "steps.step1.steps.helmBluegreenDeployAction.spec.env.PLUGIN_IGNORE_HISTORY_FAILURE",
+			expected: "stage.steps.step1.steps.helmBluegreenDeployAction.spec.env.PLUGIN_IGNORE_HISTORY_FAILURE",
 		},
 	}
 
@@ -821,7 +821,7 @@ func TestTrieRules_BuildAndPushSteps(t *testing.T) {
 			name:     "BuildAndPushDockerRegistry repo relative",
 			path:     "execution.steps.step1.spec.repo",
 			context:  &ConversionContext{StepType: StepTypeBuildAndPushDockerRegistry},
-			expected: "steps.step1.steps.pushWithBuildx.spec.with.REPO",
+			expected: "stage.steps.step1.steps.pushWithBuildx.spec.with.REPO",
 		},
 		// BuildAndPushECR inside stepGroup
 		{
@@ -1068,7 +1068,7 @@ func TestTrieRules_StepOutputConversions(t *testing.T) {
 			name:     "HTTP output responseHeaders relative",
 			path:     "execution.steps.http1.output.responseHeaders",
 			context:  &ConversionContext{StepType: StepTypeHTTP},
-			expected: "steps.http1.steps.httpStep.output.outputVariables.PLUGIN_RESPONSE_HEADERS",
+			expected: "stage.steps.http1.steps.httpStep.output.outputVariables.PLUGIN_RESPONSE_HEADERS",
 		},
 
 		// ============================================================
@@ -1434,19 +1434,19 @@ func TestTrieRules_StepOutputConversions(t *testing.T) {
 			name:     "K8sRollingDeploy output releaseName relative",
 			path:     "execution.steps.step1.output.releaseName",
 			context:  &ConversionContext{StepType: StepTypeK8sRollingDeploy},
-			expected: "steps.step1.steps.k8sApplyAction.output.outputVariables.PLUGIN_RELEASE_NAME",
+			expected: "stage.steps.step1.steps.k8sApplyAction.output.outputVariables.PLUGIN_RELEASE_NAME",
 		},
 		{
 			name:     "HelmDeploy output releaseName relative",
 			path:     "execution.steps.step1.output.releaseName",
 			context:  &ConversionContext{StepType: StepTypeHelmDeploy},
-			expected: "steps.step1.steps.helmBasicDeployAction.output.outputVariables.PLUGIN_RELEASE_NAME",
+			expected: "stage.steps.step1.steps.helmBasicDeployAction.output.outputVariables.PLUGIN_RELEASE_NAME",
 		},
 		{
 			name:     "K8sApply output pods relative",
 			path:     "execution.steps.step1.output.pods",
 			context:  &ConversionContext{StepType: StepTypeK8sApply},
-			expected: "steps.step1.steps.k8sApplySteadyStateCheckAction.output.outputVariables.PLUGIN_PODS",
+			expected: "stage.steps.step1.steps.k8sApplySteadyStateCheckAction.output.outputVariables.PLUGIN_PODS",
 		},
 
 		// ============================================================

--- a/convert/harness/yaml/pipeline.go
+++ b/convert/harness/yaml/pipeline.go
@@ -41,6 +41,8 @@ type (
 		NotificationRules []*NotificationRule                `json:"notificationRules,omitempty" yaml:"notificationRules,omitempty"`
 		DelegateSelectors *flexible.Field[[]string]          `json:"delegateSelectors,omitempty" yaml:"delegateSelectors,omitempty"`
 		Template          *PipelineTemplate                  `json:"template,omitempty"          yaml:"template,omitempty"`
+		AllowStageExecutions *flexible.Field[bool]           `json:"allowStageExecutions,omitempty" yaml:"allowStageExecutions,omitempty"`
+		Timeout           string                             `json:"timeout,omitempty"           yaml:"timeout,omitempty"`
 	}
 
 	PipelineTemplate struct {
@@ -124,15 +126,17 @@ type (
 	}
 
 	Variable struct {
-		Name     string      `json:"name,omitempty"  yaml:"name,omitempty"`
-		Type     string      `json:"type,omitempty"  yaml:"type,omitempty"` // Secret|String|Number
-		Value    interface{} `json:"value,omitempty" yaml:"value,omitempty"`
-		Required bool        `json:"required,omitempty" yaml:"required,omitempty"`
-		Default  interface{} `json:"default,omitempty" yaml:"default,omitempty"`
+		Description string      `json:"description,omitempty" yaml:"description,omitempty"`
+		Name        string      `json:"name,omitempty"  yaml:"name,omitempty"`
+		Type        string      `json:"type,omitempty"  yaml:"type,omitempty"` // Secret|String|Number
+		Value       interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+		Required    bool        `json:"required,omitempty" yaml:"required,omitempty"`
+		Default     interface{} `json:"default,omitempty" yaml:"default,omitempty"`
 	}
 
 	Execution struct {
-		Steps []*Steps `json:"steps,omitempty" yaml:"steps,omitempty"` // Un-necessary
+		Steps         []*Steps `json:"steps,omitempty"         yaml:"steps,omitempty"`         // Un-necessary
+		RollbackSteps []*Steps `json:"rollbackSteps,omitempty" yaml:"rollbackSteps,omitempty"` // Un-necessary
 	}
 
 	Steps struct {
@@ -189,7 +193,9 @@ type (
 		Args       *flexible.Field[[]string]               `json:"args,omitempty"           yaml:"args,omitempty"`
 		Conn       string                                  `json:"connectorRef,omitempty"   yaml:"connectorRef,omitempty"`
 		Image      string                                  `json:"image,omitempty"          yaml:"image,omitempty"`
+		ImagePullPolicy string                             `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 		Resources  *Resources                              `json:"resources,omitempty"      yaml:"resources,omitempty"`
+		RunAsUser  *flexible.Field[int]                    `json:"runAsUser,omitempty"      yaml:"runAsUser,omitempty"`
 		Privileged *flexible.Field[bool]                   `json:"privileged,omitempty"     yaml:"privileged,omitempty"`
 		PortBindings *flexible.Field[map[string]string]    `json:"portBindings,omitempty" yaml:"portBindings,omitempty"`
 	}

--- a/convert/harness/yaml/stage.go
+++ b/convert/harness/yaml/stage.go
@@ -35,6 +35,8 @@ type (
 		Strategy          *Strategy                           `json:"strategy,omitempty"          yaml:"strategy,omitempty"`
 		FailureStrategies *flexible.Field[[]*FailureStrategy] `json:"failureStrategies,omitempty" yaml:"failureStrategies,omitempty"`
 		Template          *StageTemplate                      `json:"template,omitempty"          yaml:"template,omitempty"`
+		Tags              *flexible.Field[map[string]string]  `json:"tags,omitempty"              yaml:"tags,omitempty"`
+		Timeout           string                              `json:"timeout,omitempty"           yaml:"timeout,omitempty"`
 	}
 
 	// StageTemplate defines a stage template reference.
@@ -58,12 +60,14 @@ type (
 		Execution *Execution `json:"execution,omitempty" yaml:"execution,omitempty"`
 		Environment *Environment `json:"environment,omitempty" yaml:"environment,omitempty"`
 		Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+		Services []*Service `json:"serviceDependencies,omitempty" yaml:"serviceDependencies,omitempty"`
 	}
 
 	// StageApproval defines an approval stage.
 	StageApproval struct {
 		Execution *Execution `json:"execution,omitempty" yaml:"execution,omitempty"`
 		Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+		Services []*Service `json:"serviceDependencies,omitempty" yaml:"serviceDependencies,omitempty"`
 	}
 
 	// StageIACM defines an IACM stage.

--- a/convert/harness/yaml/step.go
+++ b/convert/harness/yaml/step.go
@@ -155,6 +155,7 @@ type (
 		Reports                []*Report                          `json:"reports,omitempty"                 yaml:"reports,omitempty"`
 		Resources              *Resources                         `json:"resources,omitempty"               yaml:"resources,omitempty"`
 		RunAsUser              *flexible.Field[int]               `json:"runAsUser,omitempty"               yaml:"runAsUser,omitempty"`
+		RegistryRef      string                             `json:"registryRef,omitempty"             yaml:"registryRef,omitempty"`
 		Tags                   *flexible.Field[[]string]          `json:"tags,omitempty"                    yaml:"tags,omitempty"`
 		Target                 string                             `json:"target,omitempty"                  yaml:"target,omitempty"`
 		Caching                *flexible.Field[bool]              `json:"caching,omitempty"                 yaml:"caching,omitempty"`

--- a/convert/v0tov1/convert_helpers/convert_output_variables.go
+++ b/convert/v0tov1/convert_helpers/convert_output_variables.go
@@ -12,8 +12,11 @@ func ConvertOutputVariables(src []*v0.Output) []*v1.Output {
 			continue
 		}
 
-		name := outputVar.Name   // Harness key (required)
-		alias := outputVar.Value // Shell variable to capture (optional)
+		alias := outputVar.Name   // Harness key (required)
+		name := outputVar.Value // Shell variable to capture (optional)
+		if name == "" {
+			name = alias
+		}
 
 		mask := false
 		if outputVar.Type == "Secret" {

--- a/convert/v0tov1/convert_helpers/convert_output_variables_test.go
+++ b/convert/v0tov1/convert_helpers/convert_output_variables_test.go
@@ -30,7 +30,7 @@ func TestConvertOutputVariables(t *testing.T) {
 				{Name: "approvalStatus", Value: "STATUS"},
 			},
 			expected: []*v1.Output{
-				{Name: "approvalStatus", Alias: "STATUS", Mask: false},
+				{Name: "STATUS", Alias: "approvalStatus", Mask: false},
 			},
 		},
 		{
@@ -48,7 +48,7 @@ func TestConvertOutputVariables(t *testing.T) {
 				{Name: "MY_VAR", Value: ""},
 			},
 			expected: []*v1.Output{
-				{Name: "MY_VAR", Alias: "", Mask: false},
+				{Name: "MY_VAR", Alias: "MY_VAR", Mask: false},
 			},
 		},
 		{
@@ -59,9 +59,9 @@ func TestConvertOutputVariables(t *testing.T) {
 				{Name: "version", Value: "APP_VERSION"},
 			},
 			expected: []*v1.Output{
-				{Name: "buildNumber", Alias: "BUILD_NUM", Mask: false},
-				{Name: "commitHash", Alias: "GIT_COMMIT", Mask: false},
-				{Name: "version", Alias: "APP_VERSION", Mask: false},
+				{Name: "BUILD_NUM", Alias: "buildNumber", Mask: false},
+				{Name: "GIT_COMMIT", Alias: "commitHash", Mask: false},
+				{Name: "APP_VERSION", Alias: "version", Mask: false},
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func TestConvertOutputVariables(t *testing.T) {
 				{Name: "apiToken", Value: "API_TOKEN", Type: "Secret"},
 			},
 			expected: []*v1.Output{
-				{Name: "apiToken", Alias: "API_TOKEN", Mask: true},
+				{Name: "API_TOKEN", Alias: "apiToken", Mask: true},
 			},
 		},
 		{
@@ -79,7 +79,7 @@ func TestConvertOutputVariables(t *testing.T) {
 				{Name: "result", Value: "RESULT", Type: "String"},
 			},
 			expected: []*v1.Output{
-				{Name: "result", Alias: "RESULT", Mask: false},
+				{Name: "RESULT", Alias: "result", Mask: false},
 			},
 		},
 		{
@@ -90,8 +90,8 @@ func TestConvertOutputVariables(t *testing.T) {
 				{Name: "third", Value: "THIRD"},
 			},
 			expected: []*v1.Output{
-				{Name: "first", Alias: "FIRST", Mask: false},
-				{Name: "third", Alias: "THIRD", Mask: false},
+				{Name: "FIRST", Alias: "first", Mask: false},
+				{Name: "THIRD", Alias: "third", Mask: false},
 			},
 		},
 		{
@@ -102,9 +102,9 @@ func TestConvertOutputVariables(t *testing.T) {
 				{Name: "status", Value: ""},
 			},
 			expected: []*v1.Output{
-				{Name: "publicKey", Alias: "PUBLIC_KEY", Mask: false},
-				{Name: "privateKey", Alias: "PRIVATE_KEY", Mask: true},
-				{Name: "status", Alias: "", Mask: false},
+				{Name: "PUBLIC_KEY", Alias: "publicKey", Mask: false},
+				{Name: "PRIVATE_KEY", Alias: "privateKey", Mask: true},
+				{Name: "status", Alias: "status", Mask: false},
 			},
 		},
 		{
@@ -114,8 +114,8 @@ func TestConvertOutputVariables(t *testing.T) {
 				{Name: "deploymentId", Value: "DEPLOY_ID", Type: "String"},
 			},
 			expected: []*v1.Output{
-				{Name: "approvalStatus", Alias: "STATUS", Mask: false},
-				{Name: "deploymentId", Alias: "DEPLOY_ID", Mask: false},
+				{Name: "STATUS", Alias: "approvalStatus", Mask: false},
+				{Name: "DEPLOY_ID", Alias: "deploymentId", Mask: false},
 			},
 		},
 	}

--- a/convert/v0tov1/convert_helpers/convert_stage_ci.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_ci.go
@@ -309,6 +309,8 @@ func ConvertServiceDependencyToBackgroundStep(src *v0.Service) *v1.Step {
 			Args:         src.Spec.Args,
 			Privileged:   src.Spec.Privileged,
 			PortBindings: src.Spec.PortBindings,
+			User:         src.Spec.RunAsUser,
+			Pull:         ConvertImagePullPolicy(src.Spec.ImagePullPolicy),
 		}
 	}
 

--- a/convert/v0tov1/convert_helpers/convert_step_build_push_docker.go
+++ b/convert/v0tov1/convert_helpers/convert_step_build_push_docker.go
@@ -1,7 +1,10 @@
 package converthelpers
 
 import (
+	"fmt"
+
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	"github.com/drone/go-convert/convert/v0tov1/messagelog"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
 )
 
@@ -18,12 +21,29 @@ func ConvertStepBuildAndPushDockerRegistry(src *v0.Step) *v1.StepTemplate {
 
 	with := make(map[string]interface{})
 
+	var isHarnessRegistry bool = false
 	if spec.ConnectorRef != "" {
 		with["connector"] = spec.ConnectorRef
+	} else if spec.RegistryRef != "" {
+		isHarnessRegistry = true
+	} else {
+		messagelog.GetMessageLogger().LogWarning(
+			"NO_CONNECTOR_OR_REGISTRY_REF",
+			fmt.Sprintf("Connector or registryRef not provided in BuildAndPushDockerRegistry step: %s", src.ID),
+			messagelog.WithStep(src.ID, src.Type),
+		)
 	}
 
-	if spec.Repo != "" {
+	if spec.Repo != "" && !isHarnessRegistry {
 		with["repo"] = spec.Repo
+	} else if spec.Repo != "" && isHarnessRegistry {
+		with["repo"] = fmt.Sprintf("%s/%s", spec.RegistryRef, spec.Repo)
+	} else {
+		messagelog.GetMessageLogger().LogWarning(
+			"REPO_NOT_PROVIDED",
+			fmt.Sprintf("Repo not provided in BuildAndPushDockerRegistry step: %s", src.ID),
+			messagelog.WithStep(src.ID, src.Type),
+		)
 	}
 
 	if spec.Tags != nil {
@@ -88,8 +108,15 @@ func ConvertStepBuildAndPushDockerRegistry(src *v0.Step) *v1.StepTemplate {
 		with["cache_repo"] = spec.RemoteCacheRepo
 	}
 
+    var uses string
+    if isHarnessRegistry {
+        uses = "buildAndPushToHAR"
+    } else {
+        uses = "buildAndPushToDocker"
+    }
+
 	return &v1.StepTemplate{
-		Uses: "buildAndPushToDocker",
+		Uses: uses,
 		With: with,
 	}
 }

--- a/convert/v0tov1/convert_helpers/convert_step_run_tests_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_run_tests_test.go
@@ -33,7 +33,7 @@ func TestConvertStepRunTests(t *testing.T) {
 					ImagePullPolicy:      "Always",
 					Privileged:           &flexible.Field[bool]{Value: false},
 					RunAsUser:            &flexible.Field[int]{Value: 1000},
-					TestGlobs: "**/*Test.java, **/*Tests.java, **/*IT.java",
+					TestGlobs:            "**/*Test.java, **/*Tests.java, **/*IT.java",
 					Shell:                "Bash",
 					EnvVariables: &flexible.Field[map[string]string]{Value: map[string]string{
 						"MAVEN_OPTS": "-Xmx512m",
@@ -65,9 +65,9 @@ func TestConvertStepRunTests(t *testing.T) {
 				Env: &flexible.Field[map[string]string]{Value: map[string]string{
 					"MAVEN_OPTS": "-Xmx512m",
 				}},
-				Match:  &flexible.Field[[]string]{Value: []string{"**/*Test.java", "**/*Tests.java", "**/*IT.java"}},
+				Match: &flexible.Field[[]string]{Value: []string{"**/*Test.java", "**/*Tests.java", "**/*IT.java"}},
 				Outputs: []*v1.Output{
-					{Name: "TEST_RESULT"},
+					{Name: "TEST_RESULT", Alias: "TEST_RESULT"},
 				},
 				Report: &v1.Reports{
 					Type:  "junit",
@@ -113,7 +113,7 @@ func TestConvertStepRunTests(t *testing.T) {
 				},
 			},
 			expected: &v1.StepTest{
-				Script: v1.Stringorslice{"dotnet restore\ndotnet test --configuration Release --no-build"},
+				Script:  v1.Stringorslice{"dotnet restore\ndotnet test --configuration Release --no-build"},
 				Outputs: []*v1.Output{},
 			},
 		},
@@ -131,7 +131,7 @@ func TestConvertStepRunTests(t *testing.T) {
 				},
 			},
 			expected: &v1.StepTest{
-				Script: v1.Stringorslice{"bundle install\nrspec --format documentation --color"},
+				Script:  v1.Stringorslice{"bundle install\nrspec --format documentation --color"},
 				Outputs: []*v1.Output{},
 			},
 		},
@@ -149,7 +149,7 @@ func TestConvertStepRunTests(t *testing.T) {
 				},
 			},
 			expected: &v1.StepTest{
-				Script: v1.Stringorslice{"export SBT_OPTS='-Xmx2G'\nsbt test -v"},
+				Script:  v1.Stringorslice{"export SBT_OPTS='-Xmx2G'\nsbt test -v"},
 				Outputs: []*v1.Output{},
 			},
 		},
@@ -167,7 +167,7 @@ func TestConvertStepRunTests(t *testing.T) {
 				},
 			},
 			expected: &v1.StepTest{
-				Script: v1.Stringorslice{"chmod +x gradlew\n./gradlew test --info --stacktrace"},
+				Script:  v1.Stringorslice{"chmod +x gradlew\n./gradlew test --info --stacktrace"},
 				Outputs: []*v1.Output{},
 			},
 		},
@@ -184,7 +184,7 @@ func TestConvertStepRunTests(t *testing.T) {
 				},
 			},
 			expected: &v1.StepTest{
-				Script: v1.Stringorslice{"bazel test //src/test/... --test_output=all"},
+				Script:  v1.Stringorslice{"bazel test //src/test/... --test_output=all"},
 				Outputs: []*v1.Output{},
 			},
 		},
@@ -201,7 +201,7 @@ func TestConvertStepRunTests(t *testing.T) {
 				},
 			},
 			expected: &v1.StepTest{
-				Script: v1.Stringorslice{"python -m unittest discover -s tests -p 'test_*.py'"},
+				Script:  v1.Stringorslice{"python -m unittest discover -s tests -p 'test_*.py'"},
 				Outputs: []*v1.Output{},
 			},
 		},
@@ -212,14 +212,14 @@ func TestConvertStepRunTests(t *testing.T) {
 				Name: "NUnit Tests",
 				Type: v0.StepTypeRunTests,
 				Spec: &v0.StepRunTests{
-					Language:  "Csharp",
-					BuildTool: "Nunitconsole",
-					Args:      "--workers=4 --timeout=30000",
+					Language:             "Csharp",
+					BuildTool:            "Nunitconsole",
+					Args:                 "--workers=4 --timeout=30000",
 					RunOnlySelectedTests: &flexible.Field[bool]{Value: false},
 				},
 			},
 			expected: &v1.StepTest{
-				Script: v1.Stringorslice{"nunit3-console --workers=4 --timeout=30000"},
+				Script:  v1.Stringorslice{"nunit3-console --workers=4 --timeout=30000"},
 				Outputs: []*v1.Output{},
 				Intelligence: &v1.TestIntelligence{
 					Disabled: &flexible.Field[bool]{Value: true},

--- a/convert/v0tov1/convert_v0_to_v1.go
+++ b/convert/v0tov1/convert_v0_to_v1.go
@@ -185,7 +185,7 @@ func convertSingleFile(inputPath string) {
 		if v1Pipeline == nil {
 			log.Fatalf("Failed to convert pipeline to v1 format")
 		}
-		pipeline_converter.PostProcessExpressions(v1Pipeline, converter.GetStepTypeMap(), true)
+		pipeline_converter.PostProcessExpressions(v1Pipeline, converter.GetStepInfoByFQN(), true)
 		if err := v1.WritePipelineFile(outputPath, v1Pipeline); err != nil {
 			log.Fatalf("Failed to write v1 pipeline YAML: %v", err)
 		}
@@ -335,7 +335,7 @@ func convertBaseDirectory(baseDir string) {
 				log.Printf("ERROR_PIPELINE %s: failed to convert pipeline to v1 format", inputPath)
 				continue
 			}
-			pipeline_converter.PostProcessExpressions(v1Pipeline, converter.GetStepTypeMap(), true)
+			pipeline_converter.PostProcessExpressions(v1Pipeline, converter.GetStepInfoByFQN(), true)
 			if err := v1.WritePipelineFile(outputPath, v1Pipeline); err != nil {
 				log.Printf("ERROR_PIPELINE %s: failed to write v1 pipeline YAML: %v", inputPath, err)
 				continue
@@ -564,7 +564,7 @@ func convertFile(inputPath, outputPath string) bool {
 			log.Printf("Skipping %s: failed to convert pipeline to v1 format", inputPath)
 			return false
 		}
-		pipeline_converter.PostProcessExpressions(v1Pipeline, converter.GetStepTypeMap(), true)
+		pipeline_converter.PostProcessExpressions(v1Pipeline, converter.GetStepInfoByFQN(), true)
 		writeErr = v1.WritePipelineFile(outputPath, v1Pipeline)
 		writeDur := time.Since(writeStart)
 		if writeErr != nil {

--- a/convert/v0tov1/pipeline_converter/convert_pipeline.go
+++ b/convert/v0tov1/pipeline_converter/convert_pipeline.go
@@ -6,32 +6,28 @@ import (
 	"strconv"
 	"strings"
 
+	convertexpressions "github.com/drone/go-convert/convert/convertexpressions"
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
 	convert_helpers "github.com/drone/go-convert/convert/v0tov1/convert_helpers"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
 )
 
-type StepInfo struct {
-	Type   string // v0 step type (e.g., "Run", "Action", "K8sRollingDeploy")
-	V0Path string // full v0 path (e.g., "pipeline.stages.build.spec.execution.steps.compile")
-	V1Path string // full v1 path (e.g., "pipeline.stages.build.steps.compile")
-}
-
 type PipelineConverter struct {
-	stageCtx    *convert_helpers.StageConversionContext
-	stepTypeMap map[string]*StepInfo // maps step ID to step info (type + v0 path)
+	stageCtx      *convert_helpers.StageConversionContext
+	stepInfoByFQN map[string]*convertexpressions.StepInfoFQN // v1 FQN -> step info (sole step registry)
 }
 
 func NewPipelineConverter() *PipelineConverter {
 	return &PipelineConverter{
-		stageCtx:    convert_helpers.NewStageConversionContext(),
-		stepTypeMap: make(map[string]*StepInfo),
+		stageCtx:      convert_helpers.NewStageConversionContext(),
+		stepInfoByFQN: make(map[string]*convertexpressions.StepInfoFQN),
 	}
 }
 
-// GetStepTypeMap returns the accumulated step ID to step info mapping.
-func (c *PipelineConverter) GetStepTypeMap() map[string]*StepInfo {
-	return c.stepTypeMap
+// GetStepInfoByFQN returns the accumulated FQN-keyed step (and step group)
+// info map, keyed by each step's full v1 FQN.
+func (c *PipelineConverter) GetStepInfoByFQN() map[string]*convertexpressions.StepInfoFQN {
+	return c.stepInfoByFQN
 }
 
 // ConvertPipeline converts a v0 Pipeline to a v1 Pipeline.
@@ -65,6 +61,8 @@ func (c *PipelineConverter) ConvertPipeline(src *v0.Pipeline) *v1.Pipeline {
 	dst.Clone = clone
 	dst.Notifications = convert_helpers.ConvertNotifications(src.NotificationRules)
 	dst.Delegate = convert_helpers.ConvertDelegate(src.DelegateSelectors, nil)
+	dst.Timeout = src.Timeout
+	dst.AllowStageExecutions = src.AllowStageExecutions
 
 	return dst
 }
@@ -152,8 +150,9 @@ func (c *PipelineConverter) convertVariables(src []*v0.Variable) map[string]*v1.
 		v1Type := convertVariableType(variable.Type)
 
 		input := &v1.Input{
-			Type:     v1Type,
-			Required: variable.Required,
+			Type:        v1Type,
+			Required:    variable.Required,
+			Description: variable.Description,
 		}
 
 		if !isEmptyValue(variable.Value) {

--- a/convert/v0tov1/pipeline_converter/convert_stage.go
+++ b/convert/v0tov1/pipeline_converter/convert_stage.go
@@ -58,6 +58,8 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 	stage.Strategy = convert_helpers.ConvertStrategy(src.Strategy)
 	stage.If = convert_helpers.ConvertStageWhen(src.When)
 	stage.Env = convertStageInputsToEnv(stage.Inputs)
+	stage.Timeout = src.Timeout
+	stage.Tags = src.Tags
 
 	stepsPath := stagePath + ".spec.execution.steps"
 	rollbackStepsPath := stagePath + ".spec.execution.rollbackSteps"
@@ -67,19 +69,40 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 		spec, ok := src.Spec.(*v0.StageApproval)
 		if ok && spec != nil {
 			if spec.Execution != nil {
-				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath)
+				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
+				if spec.Execution.RollbackSteps != nil {
+					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
+				}
 			}
-			stage.Timeout = spec.Timeout
+
+			// Convert service dependencies to background steps and prepend them
+			if len(spec.Services) > 0 {
+				backgroundSteps := convert_helpers.ConvertServiceDependenciesToBackgroundSteps(spec.Services)
+				if len(backgroundSteps) > 0 {
+					stage.Steps = append(backgroundSteps, stage.Steps...)
+				}
+			}
 		}
 
 	case v0.StageTypeCustom:
 		spec, ok := src.Spec.(*v0.StageCustom)
 		if ok && spec != nil {
 			if spec.Execution != nil {
-				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath)
+				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
+				if spec.Execution.RollbackSteps != nil {
+					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
+				}
 			}
+			
+			// Convert service dependencies to background steps and prepend them
+			if len(spec.Services) > 0 {
+				backgroundSteps := convert_helpers.ConvertServiceDependenciesToBackgroundSteps(spec.Services)
+				if len(backgroundSteps) > 0 {
+					stage.Steps = append(backgroundSteps, stage.Steps...)
+				}
+			}
+
 			stage.Environment = convert_helpers.ConvertEnvironment(spec.Environment, c.stageCtx)
-			stage.Timeout = spec.Timeout
 			// custom stage to local
 			stage.Runtime = &v1.Runtime{
 				Shell: &v1.RuntimeShell{},
@@ -90,9 +113,11 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 		spec, ok := src.Spec.(*v0.StageIACM)
 		if ok && spec != nil {
 			if spec.Execution != nil {
-				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath)
+				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
+				if spec.Execution.RollbackSteps != nil {
+					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
+				}
 			}
-			stage.Timeout = spec.Timeout
 
 			if spec.Infrastructure != nil {
 				stage.Runtime = convert_helpers.ConvertInfrastructureToRuntime(spec.Infrastructure, c.stageCtx)
@@ -112,7 +137,10 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 	case v0.StageTypeCI:
 		spec, ok := src.Spec.(*v0.StageCI)
 		if ok && spec != nil {
-			stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath)
+			stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
+			if spec.Execution.RollbackSteps != nil {
+				stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
+			}
 
 			// Convert service dependencies to background steps and prepend them
 			if len(spec.Services) > 0 {
@@ -125,7 +153,6 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 			stage.Clone = convert_helpers.ConvertCloneCodebase(spec.Clone)
 			stage.Cache = convert_helpers.ConvertCaching(spec.Cache)
 			stage.BuildIntelligence = convert_helpers.ConvertBuildIntelligence(spec.BuildIntelligence)
-			stage.Timeout = spec.Timeout
 
 			// Convert shared paths to volumes
 			if spec.Infrastructure != nil {
@@ -148,9 +175,9 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 		if ok && spec != nil {
 			// Convert deployment steps
 			if spec.Execution != nil {
-				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath)
+				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
 				if spec.Execution.RollbackSteps != nil {
-					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath)
+					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
 				}
 			}
 
@@ -183,7 +210,6 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 					WithStage(src.ID, string(v0.StageTypeDeployment)),
 				)
 			}
-			stage.Timeout = spec.Timeout
 		}
 
 	case v0.StageTypePipeline:
@@ -207,7 +233,6 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 					InputSets: spec.InputSetRefs,
 				},
 			}
-			stage.Timeout = spec.Timeout
 		}
 
 	default:
@@ -242,17 +267,17 @@ func convertStageInputsToEnv(inputs map[string]*v1.Input) map[string]interface{}
 	return env
 }
 
-func(c *PipelineConverter) constructChainUses(spec *v0.StagePipeline) (string, error) {
+func (c *PipelineConverter) constructChainUses(spec *v0.StagePipeline) (string, error) {
 	if spec == nil {
 		return "", fmt.Errorf("pipeline chain spec is nil")
-	} 
+	}
 	if spec.Org == "" || spec.Project == "" || spec.Pipeline == "" {
 		return "", fmt.Errorf("pipeline chain spec is missing org, project or pipeline")
 	}
 	return fmt.Sprintf("%s/%s/%s", spec.Org, spec.Project, spec.Pipeline), nil
-} 
+}
 
-func(c *PipelineConverter) constructChainInputs(spec *v0.StagePipeline) map[string]interface{} {
+func (c *PipelineConverter) constructChainInputs(spec *v0.StagePipeline) map[string]interface{} {
 	if spec == nil || spec.Inputs == nil {
 		return nil
 	}
@@ -265,7 +290,6 @@ func(c *PipelineConverter) constructChainInputs(spec *v0.StagePipeline) map[stri
 	}
 
 	overlay := map[string]interface{}{}
-	
 
 	if spec.Inputs.Stages != nil {
 		stages := c.convertStages(spec.Inputs.Stages, "pipeline")
@@ -280,19 +304,19 @@ func(c *PipelineConverter) constructChainInputs(spec *v0.StagePipeline) map[stri
 
 	if len(overlay) > 0 {
 		inputs["overlay"] = overlay
-	} 
-	
+	}
+
 	return inputs
 }
 
-func(c *PipelineConverter) constructChainOutputs(spec *v0.StagePipeline) []*v1.ChainOutput {
+func (c *PipelineConverter) constructChainOutputs(spec *v0.StagePipeline) []*v1.ChainOutput {
 	if spec == nil || spec.Outputs == nil {
 		return nil
 	}
 	outputs := make([]*v1.ChainOutput, 0, len(spec.Outputs))
 	for _, output := range spec.Outputs {
 		outputs = append(outputs, &v1.ChainOutput{
-			Name: output.Name,
+			Name:  output.Name,
 			Value: output.Value,
 		})
 	}

--- a/convert/v0tov1/pipeline_converter/convert_step_template.go
+++ b/convert/v0tov1/pipeline_converter/convert_step_template.go
@@ -27,7 +27,7 @@ func (c *PipelineConverter) convertStepTemplate(src *v0.Step, isRollback bool, b
 	// If templateInputs exists, convert it to overlay.step
 	if template.TemplateInputs != nil {
 		// Convert the templateInputs (which is a *Step) directly
-		overlayStep := c.ConvertSingleStep(template.TemplateInputs, isRollback, basePath)
+		overlayStep := c.ConvertSingleStep(template.TemplateInputs, isRollback, basePath, "", "")
 		if overlayStep != nil {
 			result.With = &v1.StepTemplateWith{
 				Overlay: &v1.StepTemplateOverlay{

--- a/convert/v0tov1/pipeline_converter/convert_stepgroup_template.go
+++ b/convert/v0tov1/pipeline_converter/convert_stepgroup_template.go
@@ -35,7 +35,7 @@ func (c *PipelineConverter) convertStepGroupTemplate(src *v0.StepGroup, isRollba
 		overlayStep.Group = &v1.StepGroup{Steps: make([]*v1.Step, 0)}
 
 		if inputs.Steps != nil {
-			overlayStep.Group.Steps = c.ConvertSteps(inputs.Steps, isRollback, groupPath)
+			overlayStep.Group.Steps = c.ConvertSteps(inputs.Steps, isRollback, groupPath, "", "")
 		}
 
 		if inputs.Variables != nil {

--- a/convert/v0tov1/pipeline_converter/convert_steps.go
+++ b/convert/v0tov1/pipeline_converter/convert_steps.go
@@ -5,14 +5,35 @@ import (
 	"reflect"
 	"strings"
 
+	convertexpressions "github.com/drone/go-convert/convert/convertexpressions"
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
 	convert_helpers "github.com/drone/go-convert/convert/v0tov1/convert_helpers"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
 	"github.com/drone/go-convert/internal/flexible"
 )
 
-// convertSteps converts a list of v0.Steps to list of v1.Step.
-func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, basePath string) []*v1.Step {
+// appendGroupChain appends a step group ID to an existing group chain.
+// The chain uses ">" as separator: "A>B>C" means A is the outermost group.
+func appendGroupChain(chain, groupID string) string {
+	if chain == "" {
+		return groupID
+	}
+	return chain + ">" + groupID
+}
+
+// splitGroupChain converts a ">"-joined group chain into its slice form,
+// yielding nil (not a one-empty-string slice) for an empty chain.
+func splitGroupChain(groupID string) []string {
+	if groupID == "" {
+		return nil
+	}
+	return strings.Split(groupID, ">")
+}
+
+// convertSteps converts a list of v0.Steps to a list of v1.Step. stageID and
+// groupID scope step registration; groupID is the ">"-joined ancestor chain
+// (e.g. "A>B>C") that disambiguates same-named groups.
+func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, basePath, stageID, groupID string) []*v1.Step {
 	if len(src) == 0 {
 		return make([]*v1.Step, 0)
 	}
@@ -22,14 +43,14 @@ func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, baseP
 			continue
 		}
 		if s.Step != nil {
-			if step := c.ConvertSingleStep(s.Step, isRollBack, basePath); step != nil {
+			if step := c.ConvertSingleStep(s.Step, isRollBack, basePath, stageID, groupID); step != nil {
 				dst = append(dst, step)
 			}
 			continue
 		}
 		if s.Parallel != nil {
 			parallel_group := &v1.StepGroup{
-				Steps: c.ConvertSteps(s.Parallel, isRollBack, basePath),
+				Steps: c.ConvertSteps(s.Parallel, isRollBack, basePath, stageID, groupID),
 			}
 			parallel := &v1.Step{
 				Parallel: parallel_group,
@@ -44,14 +65,28 @@ func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, baseP
 				Id:   s.StepGroup.ID,
 			}
 
+			// Register the step group itself into the FQN-keyed registry
+			if s.StepGroup.ID != "" {
+				v0Path := basePath + "." + s.StepGroup.ID
+				v1Path := convertV0PathToV1Path(v0Path)
+				c.stepInfoByFQN[v1Path] = &convertexpressions.StepInfoFQN{
+					Type:    "StepGroup",
+					StageID: stageID,
+					Chain:   splitGroupChain(groupID), // ancestor groups (empty for stage-level groups)
+					StepID:  s.StepGroup.ID,
+				}
+			}
+
 			// Check for Template - if template exists, convert it and skip normal conversion
 			if s.StepGroup.Template != nil {
 				group.Template = c.convertStepGroupTemplate(s.StepGroup, isRollBack, groupPath)
 			} else {
 				// Normal step group conversion
+				// Children of this group use the extended chain as their groupID
 				group.Env = s.StepGroup.Env
+				childGroupID := appendGroupChain(groupID, s.StepGroup.ID)
 				group.Group = &v1.StepGroup{
-					Steps:  c.ConvertSteps(s.StepGroup.Steps, isRollBack, groupPath),
+					Steps:  c.ConvertSteps(s.StepGroup.Steps, isRollBack, groupPath, stageID, childGroupID),
 					Inputs: c.convertVariables(s.StepGroup.Variables),
 				}
 				group.OnFailure = convert_helpers.ConvertFailureStrategies(s.StepGroup.FailureStrategies)
@@ -66,7 +101,7 @@ func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, baseP
 	return dst
 }
 
-func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, basePath string) *v1.Step {
+func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, basePath, stageID, groupID string) *v1.Step {
 	if src == nil {
 		return nil
 	}
@@ -76,13 +111,15 @@ func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, bas
 		Name: src.Name,
 	}
 
-	// Track step ID to v0 step type and path mapping
+	// Track step ID to v0 step type and FQN mapping
 	if src.ID != "" && src.Type != "" {
 		v0Path := basePath + "." + src.ID
-		c.stepTypeMap[src.ID] = &StepInfo{
-			Type:   src.Type,
-			V0Path: v0Path,
-			V1Path: convertV0PathToV1Path(v0Path),
+		v1Path := convertV0PathToV1Path(v0Path)
+		c.stepInfoByFQN[v1Path] = &convertexpressions.StepInfoFQN{
+			Type:    src.Type,
+			StageID: stageID,
+			Chain:   splitGroupChain(groupID),
+			StepID:  src.ID,
 		}
 	}
 
@@ -304,12 +341,11 @@ func convertCommonStepSettings(src *v0.Step, dst *v1.Step) {
 }
 
 // convertV0PathToV1Path converts a v0 FQN step path to a v1 FQN step path.
-// It removes "spec.execution" segments from the path.
-// Example: "pipeline.stages.build.spec.execution.steps.compile" -> "pipeline.stages.build.steps.compile"
+// It removes "spec.execution" segments and renames "rollbackSteps" to "rollback".
+// Example: "pipeline.stages.build.spec.execution.rollbackSteps.step1" -> "pipeline.stages.build.rollback.step1"
 func convertV0PathToV1Path(v0Path string) string {
-	// Remove "spec.execution" segments
 	result := strings.ReplaceAll(v0Path, ".spec.execution.", ".")
-	// Also handle if it starts with spec.execution (unlikely but safe)
 	result = strings.TrimPrefix(result, "spec.execution.")
+	result = strings.ReplaceAll(result, ".rollbackSteps.", ".rollback.")
 	return result
 }

--- a/convert/v0tov1/pipeline_converter/convert_template.go
+++ b/convert/v0tov1/pipeline_converter/convert_template.go
@@ -20,7 +20,7 @@ func (c *PipelineConverter) ConvertTemplate(src *v0.Template) *v1.Template {
 		}
 	case "Step":
 		if spec, ok := src.Spec.(*v0.Step); ok {
-			dst.Step = c.ConvertSingleStep(spec, false, "")
+			dst.Step = c.ConvertSingleStep(spec, false, "", "", "")
 		}
 	case "StepGroup":
 		if spec, ok := src.Spec.(*v0.StepGroup); ok {
@@ -29,7 +29,7 @@ func (c *PipelineConverter) ConvertTemplate(src *v0.Template) *v1.Template {
 				Id:   spec.ID,
 				Env:  spec.Env,
 				Group: &v1.StepGroup{
-					Steps:  c.ConvertSteps(spec.Steps, false, ""),
+					Steps:  c.ConvertSteps(spec.Steps, false, "", "", ""),
 					Inputs: c.convertVariables(spec.Variables),
 				},
 				OnFailure: convert_helpers.ConvertFailureStrategies(spec.FailureStrategies),

--- a/convert/v0tov1/pipeline_converter/convert_trigger.go
+++ b/convert/v0tov1/pipeline_converter/convert_trigger.go
@@ -17,6 +17,7 @@ package pipelineconverter
 import (
 	"strings"
 
+	convertexpressions "github.com/drone/go-convert/convert/convertexpressions"
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
 )
@@ -24,7 +25,7 @@ import (
 // ConvertTrigger converts a v0 Trigger to v1 Trigger format.
 // The trigger structure remains mostly unchanged, only the inputYaml
 // content is converted from v0 to v1 format.
-func (c *PipelineConverter) ConvertTrigger(src *v0.Trigger, stepTypeMap map[string]*StepInfo, useFQN bool) *v1.Trigger {
+func (c *PipelineConverter) ConvertTrigger(src *v0.Trigger, stepInfoByFQN map[string]*convertexpressions.StepInfoFQN, useFQN bool) *v1.Trigger {
 	if src == nil {
 		return nil
 	}
@@ -51,7 +52,7 @@ func (c *PipelineConverter) ConvertTrigger(src *v0.Trigger, stepTypeMap map[stri
 	// Convert inputYaml if present
 	// The inputYaml contains a v0 pipeline YAML that needs to be converted to v1 format
 	if src.InputYaml != "" {
-		convertedInputYaml := c.convertInputYaml(src.InputYaml, stepTypeMap, useFQN)
+		convertedInputYaml := c.convertInputYaml(src.InputYaml, stepInfoByFQN, useFQN)
 		dst.InputYaml = convertedInputYaml
 	}
 
@@ -90,7 +91,7 @@ func convertTriggerSource(src *v0.TriggerSource) *v1.TriggerSource {
 // On any failure (parse, conversion, marshal) the original v0 inputYaml is
 // returned unchanged AND a structured ERROR message is logged via the
 // MessageLogger so the surface area shows up in summaries and API reports.
-func (c *PipelineConverter) convertInputYaml(inputYaml string, stepTypeMap map[string]*StepInfo, useFQN bool) string {
+func (c *PipelineConverter) convertInputYaml(inputYaml string, stepInfoByFQN map[string]*convertexpressions.StepInfoFQN, useFQN bool) string {
 	if inputYaml == "" {
 		return ""
 	}
@@ -119,7 +120,7 @@ func (c *PipelineConverter) convertInputYaml(inputYaml string, stepTypeMap map[s
 		return inputYaml
 	}
 
-	PostProcessExpressions(v1Pipeline, stepTypeMap, useFQN)
+	PostProcessExpressions(v1Pipeline, stepInfoByFQN, useFQN)
 
 	// Create the v1 InputSet structure with the converted pipeline as overlay
 	v1InputSet := &v1.InputSet{

--- a/convert/v0tov1/pipeline_converter/expression_logger.go
+++ b/convert/v0tov1/pipeline_converter/expression_logger.go
@@ -9,15 +9,15 @@ import (
 	"github.com/drone/go-convert/convert/convertexpressions"
 )
 
-// ConversionContextLog is a JSON-serializable version of ConversionContext
+// ConversionContextLog is the per-expression, JSON-serializable subset of
+// ConversionContext. Pipeline-wide fields (UseFQN) live on FileExpressionLog
+// to avoid repeating them on every entry; only per-expression context is here.
 type ConversionContextLog struct {
-	StepID            string            `json:"step_id,omitempty"`
-	StepType          string            `json:"step_type,omitempty"`
-	CurrentStepType   string            `json:"current_step_type,omitempty"`
-	CurrentStepV1Path string            `json:"current_step_v1_path,omitempty"`
-	UseFQN            bool              `json:"use_fqn"`
-	StepTypeMap       map[string]string `json:"step_type_map,omitempty"`
-	StepV1PathMap     map[string]string `json:"step_v1_path_map,omitempty"`
+	StepID          string `json:"step_id,omitempty"`
+	StepType        string `json:"step_type,omitempty"`
+	CurrentStepType string `json:"current_step_type,omitempty"`
+	CurrentFQN      string `json:"current_fqn,omitempty"`
+	CurrentStageID  string `json:"current_stage_id,omitempty"`
 }
 
 // ExpressionLogEntry represents a single expression conversion log entry
@@ -27,10 +27,16 @@ type ExpressionLogEntry struct {
 	Context   *ConversionContextLog `json:"context,omitempty"`
 }
 
-// FileExpressionLog represents all expression conversions for a single file
+// FileExpressionLog represents all expression conversions for a single file.
+// UseFQN is pipeline-wide and recorded once per file (on the first expression
+// logged) rather than duplicated on every entry.
 type FileExpressionLog struct {
-	FilePath    string               `json:"file_path"`
-	Expressions []ExpressionLogEntry `json:"expressions"`
+	FilePath string `json:"file_path"`
+	UseFQN   bool   `json:"use_fqn,omitempty"`
+	// StepInfoByFQN is the pipeline-wide FQN-keyed step-info map used for this
+	// file's resolution, captured once (like UseFQN).
+	StepInfoByFQN map[string]*convertexpressions.StepInfoFQN `json:"step_info_by_fqn,omitempty"`
+	Expressions   []ExpressionLogEntry                       `json:"expressions"`
 }
 
 // conversionKey is used for deduplication of original-converted pairs per file
@@ -155,18 +161,26 @@ func (l *ExpressionLogger) LogConversion(original, converted string, ctx *conver
 	// Include context if enabled and context is provided
 	if l.includeContext && ctx != nil {
 		entry.Context = &ConversionContextLog{
-			StepID:            ctx.StepID,
-			StepType:          ctx.StepType,
-			CurrentStepType:   ctx.CurrentStepType,
-			CurrentStepV1Path: ctx.CurrentStepV1Path,
-			UseFQN:            ctx.UseFQN,
-			StepTypeMap:       ctx.StepTypeMap,
-			StepV1PathMap:     ctx.StepV1PathMap,
+			StepID:          ctx.CurrentStepID,
+			StepType:        ctx.StepType,
+			CurrentStepType: ctx.CurrentStepType,
+			CurrentFQN:      ctx.CurrentFQN,
+			CurrentStageID:  ctx.CurrentStageID,
 		}
 	}
 
 	if l.currentFile != "" {
 		if fileLog, exists := l.fileLogs[l.currentFile]; exists {
+			// Capture UseFQN and the FQN-keyed map once per file, on the first
+			// logged expression that carries context.
+			if l.includeContext && ctx != nil {
+				if !fileLog.UseFQN && ctx.UseFQN {
+					fileLog.UseFQN = ctx.UseFQN
+				}
+				if fileLog.StepInfoByFQN == nil && len(ctx.StepInfoByFQN) > 0 {
+					fileLog.StepInfoByFQN = ctx.StepInfoByFQN
+				}
+			}
 			fileLog.Expressions = append(fileLog.Expressions, entry)
 		}
 	}
@@ -251,4 +265,37 @@ func (l *ExpressionLogger) GetLogFilePath() string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.logFilePath
+}
+
+// FlushForFiles writes expression logs for the given input file paths to
+// destPath. This is used by --account_dir mode to produce per-project
+// v1/expressions.json files alongside the account-level aggregate.
+func (l *ExpressionLogger) FlushForFiles(inputPaths []string, destPath string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var subset []FileExpressionLog
+	for _, p := range inputPaths {
+		if fl, ok := l.fileLogs[p]; ok && len(fl.Expressions) > 0 {
+			subset = append(subset, *fl)
+		}
+	}
+	if len(subset) == 0 {
+		return nil
+	}
+
+	dir := filepath.Dir(destPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	file, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(subset)
 }

--- a/convert/v0tov1/pipeline_converter/postprocess.go
+++ b/convert/v0tov1/pipeline_converter/postprocess.go
@@ -11,27 +11,28 @@ import (
 // expressionProcessor walks v1 pipeline structs and converts Harness expressions
 // using context-aware trie-based matching.
 type expressionProcessor struct {
-	stepTypeMap       map[string]*StepInfo // step ID → {Type, V0Path, V1Path}
-	currentStepID     string               // set when inside a v1.Step
-	currentStepType   string               // set when inside a v1.Step
-	currentStepV1Path string               // set when inside a v1.Step
-	useFQN            bool                 // whether to use fully qualified names for step expressions
+	currentStepID      string // set when inside a v1.Step
+	currentStepType    string // set when inside a v1.Step
+	currentStepV1Path  string // set when inside a v1.Step (the step's full v1 FQN)
+	currentStageID     string // set when inside a v1.Stage
+	currentStepGroupID string // ">"-joined ancestor group chain of the current scope
+	inRollback         bool   // true while walking a stage's rollback steps
+	useFQN             bool   // whether to use fully qualified names for step expressions
 
-	// Cached derived maps, built lazily on first processString call.
-	flatTypeMap   map[string]string // step ID → type
-	stepV1PathMap map[string]string // step ID → v1 path
-	mapsBuilt     bool
+	// stepInfoByFQN is the sole step (and step group) registry, keyed by each
+	// step's full v1 FQN. nil when no pipeline-level context is available.
+	stepInfoByFQN map[string]*convertexpressions.StepInfoFQN
 }
 
 // PostProcessExpressions walks the converted v1 entity (Pipeline, Template,
 // InputSet, Trigger, etc.) and converts all Harness expressions in string and
 // flexible.Field values using ConvertExpressionWithTrie.
 //
-// stepTypeMap may be nil when no pipeline-level step context is available
+// stepInfoByFQN may be nil when no pipeline-level step context is available
 // (e.g. for Template/InputSet/Trigger wrappers). useFQN controls whether to
 // use fully qualified names for step expressions; pass false for context-free
 // conversion of non-pipeline entities.
-func PostProcessExpressions(target any, stepTypeMap map[string]*StepInfo, useFQN bool) {
+func PostProcessExpressions(target any, stepInfoByFQN map[string]*convertexpressions.StepInfoFQN, useFQN bool) {
 	if target == nil {
 		return
 	}
@@ -44,8 +45,8 @@ func PostProcessExpressions(target any, stepTypeMap map[string]*StepInfo, useFQN
 	}
 
 	p := &expressionProcessor{
-		stepTypeMap: stepTypeMap,
-		useFQN:      useFQN,
+		stepInfoByFQN: stepInfoByFQN,
+		useFQN:        useFQN,
 	}
 
 	// Logger context flag is set once for the duration of the walk rather
@@ -58,7 +59,7 @@ func PostProcessExpressions(target any, stepTypeMap map[string]*StepInfo, useFQN
 // tryConvertString checks if s contains a Harness expression and, if so, converts it.
 // Returns the converted string and true if a conversion was made, or the original string and false otherwise.
 func (p *expressionProcessor) tryConvertString(s string) (string, bool) {
-	if !strings.Contains(s, "<+") {
+	if !strings.Contains(s, "<+") && !strings.Contains(s, "${{") {
 		return s, false
 	}
 	converted := p.processString(s)
@@ -103,15 +104,84 @@ func (p *expressionProcessor) processValue(val reflect.Value) {
 	}
 }
 
+// withStageContext saves/restores current stage context around fn.
+func (p *expressionProcessor) withStageContext(stageID string, fn func()) {
+	saved := p.currentStageID
+	p.currentStageID = stageID
+	fn()
+	p.currentStageID = saved
+}
+
+// withStepGroupContext saves/restores the current step group context around fn.
+// It accumulates a chain (e.g. "A>B>C") matching the chain-based key used
+// during step registration in ConvertSteps.
+func (p *expressionProcessor) withStepGroupContext(groupID string, fn func()) {
+	saved := p.currentStepGroupID
+	if p.currentStepGroupID != "" {
+		p.currentStepGroupID = p.currentStepGroupID + ">" + groupID
+	} else {
+		p.currentStepGroupID = groupID
+	}
+	fn()
+	p.currentStepGroupID = saved
+}
+
+// withRollbackContext marks the current scope as a stage's rollback steps so
+// step FQNs are reconstructed with a "rollback" first segment.
+func (p *expressionProcessor) withRollbackContext(fn func()) {
+	saved := p.inRollback
+	p.inRollback = true
+	fn()
+	p.inRollback = saved
+}
+
+// stepFQN reconstructs a step's full v1 FQN from its stage, ">"-joined ancestor
+// group chain, and leaf ID. Rollback steps use a "rollback" first segment
+// (matching convertV0PathToV1Path); deeper levels use "steps". "" if stage unknown.
+func stepFQN(stageID, groupChain, stepID string, rollback bool) string {
+	if stageID == "" {
+		return ""
+	}
+	root := "steps"
+	if rollback {
+		root = "rollback"
+	}
+	var b strings.Builder
+	b.WriteString("pipeline.stages.")
+	b.WriteString(stageID)
+	groups := splitGroupChain(groupChain)
+	if len(groups) > 0 {
+		b.WriteString(".")
+		b.WriteString(root)
+		b.WriteString(".")
+		b.WriteString(groups[0])
+		for _, g := range groups[1:] {
+			b.WriteString(".steps.")
+			b.WriteString(g)
+		}
+		b.WriteString(".steps.")
+		b.WriteString(stepID)
+	} else {
+		b.WriteString(".")
+		b.WriteString(root)
+		b.WriteString(".")
+		b.WriteString(stepID)
+	}
+	return b.String()
+}
+
 // withStepContext saves the current step context, sets it from the given step ID,
 // executes fn, then restores the previous context.
 func (p *expressionProcessor) withStepContext(stepID string, fn func()) {
 	savedID, savedType, savedPath := p.currentStepID, p.currentStepType, p.currentStepV1Path
 
 	p.currentStepID = stepID
-	if info, ok := p.stepTypeMap[stepID]; ok {
+	// Reconstruct the FQN and look up the step type; leave empty for untyped or
+	// template steps (matching prior behavior).
+	fqn := stepFQN(p.currentStageID, p.currentStepGroupID, stepID, p.inRollback)
+	if info, ok := p.stepInfoByFQN[fqn]; ok {
 		p.currentStepType = info.Type
-		p.currentStepV1Path = info.V1Path
+		p.currentStepV1Path = fqn
 	} else {
 		p.currentStepType = ""
 		p.currentStepV1Path = ""
@@ -135,13 +205,39 @@ func (p *expressionProcessor) processStruct(val reflect.Value) {
 		return
 	}
 
-	// Check if this is a v1.Step — set step context
-	if t == reflect.TypeOf(v1.Step{}) {
+	// Check if this is a v1.Stage — set stage context
+	if t == reflect.TypeOf(v1.Stage{}) {
 		idField := val.FieldByName("Id")
 		if idField.IsValid() && idField.Kind() == reflect.String && idField.String() != "" {
-			p.withStepContext(idField.String(), func() {
+			p.withStageContext(idField.String(), func() {
 				p.processStructFields(val)
 			})
+			return
+		}
+	}
+
+	// Check if this is a v1.Step — set step context (and group context if it has a Group)
+	if t == reflect.TypeOf(v1.Step{}) {
+		idField := val.FieldByName("Id")
+		groupField := val.FieldByName("Group")
+		hasGroup := groupField.IsValid() && groupField.Kind() == reflect.Ptr && !groupField.IsNil()
+		stepID := ""
+		if idField.IsValid() && idField.Kind() == reflect.String {
+			stepID = idField.String()
+		}
+		if stepID != "" {
+			if hasGroup {
+				// Step group: set both step context and group context
+				p.withStepContext(stepID, func() {
+					p.withStepGroupContext(stepID, func() {
+						p.processStructFields(val)
+					})
+				})
+			} else {
+				p.withStepContext(stepID, func() {
+					p.processStructFields(val)
+				})
+			}
 			return
 		}
 	}
@@ -169,6 +265,15 @@ func (p *expressionProcessor) processStructFields(val reflect.Value) {
 		// Skip Trigger.InputYaml: it holds an already-converted v1 YAML
 		// document; re-walking its raw text could mangle structure.
 		if fieldType.Name == "InputYaml" {
+			continue
+		}
+
+		// Stage.Rollback steps live under a "rollback" FQN segment; mark the
+		// scope so step FQNs are reconstructed correctly while walking them.
+		if fieldType.Name == "Rollback" {
+			p.withRollbackContext(func() {
+				p.processValue(field)
+			})
 			continue
 		}
 
@@ -277,9 +382,8 @@ func (p *expressionProcessor) processString(s string) string {
 		return s
 	}
 
-	// Build ConversionContext directly from stepTypeMap — avoids redundant derived maps.
-	// The trie will resolve step types only when needed (at step.spec nodes).
-	// FQN mode replaces v1Path at step_node with the step's v1 FQN base path.
+	// Build the ConversionContext; the trie resolves step types lazily at
+	// step.spec nodes and, in FQN mode, expands v1Path to the step's FQN base.
 	ctx := p.buildConversionContext()
 
 	// Get expression logger for logging conversions. The IncludeContext flag
@@ -307,30 +411,20 @@ func (p *expressionProcessor) processString(s string) string {
 	return b.String()
 }
 
-// ensureDerivedMaps builds flatTypeMap and stepV1PathMap once from stepTypeMap.
-func (p *expressionProcessor) ensureDerivedMaps() {
-	if p.mapsBuilt {
-		return
-	}
-	p.flatTypeMap = make(map[string]string, len(p.stepTypeMap))
-	p.stepV1PathMap = make(map[string]string, len(p.stepTypeMap))
-	for id, info := range p.stepTypeMap {
-		p.flatTypeMap[id] = info.Type
-		p.stepV1PathMap[id] = info.V1Path
-	}
-	p.mapsBuilt = true
-}
-
 // buildConversionContext creates a ConversionContext for the current step scope.
 func (p *expressionProcessor) buildConversionContext() *convertexpressions.ConversionContext {
-	p.ensureDerivedMaps()
+	var chain []string
+	if p.currentStepGroupID != "" {
+		chain = strings.Split(p.currentStepGroupID, ">")
+	}
 	return &convertexpressions.ConversionContext{
-		StepID:            p.currentStepID,
-		CurrentStepType:   p.currentStepType,
-		CurrentStepV1Path: p.currentStepV1Path,
-		StepTypeMap:       p.flatTypeMap,
-		StepV1PathMap:     p.stepV1PathMap,
-		UseFQN:            p.useFQN,
+		CurrentStepID:         p.currentStepID,
+		CurrentStepType:       p.currentStepType,
+		UseFQN:                p.useFQN,
+		CurrentStageID:        p.currentStageID,
+		StepInfoByFQN:         p.stepInfoByFQN,
+		CurrentStepGroupChain: chain,
+		CurrentFQN:            p.currentStepV1Path,
 	}
 }
 

--- a/convert/v0tov1/pipeline_converter/postprocess_test.go
+++ b/convert/v0tov1/pipeline_converter/postprocess_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	convertexpressions "github.com/drone/go-convert/convert/convertexpressions"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
 	"github.com/drone/go-convert/internal/flexible"
 )
@@ -32,10 +33,6 @@ func TestIsFlexibleField(t *testing.T) {
 
 func TestProcessString_SingleExpression(t *testing.T) {
 	p := &expressionProcessor{
-		stepTypeMap: map[string]*StepInfo{
-			"runStep1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.runStep1"},
-		},
-		flatTypeMap:     map[string]string{"runStep1": "Run"},
 		currentStepID:   "runStep1",
 		currentStepType: "Run",
 	}
@@ -49,10 +46,7 @@ func TestProcessString_SingleExpression(t *testing.T) {
 }
 
 func TestProcessString_NoExpression(t *testing.T) {
-	p := &expressionProcessor{
-		stepTypeMap: map[string]*StepInfo{},
-		flatTypeMap: map[string]string{},
-	}
+	p := &expressionProcessor{}
 
 	// Plain string should be returned as-is
 	result := p.processString("hello world")
@@ -63,10 +57,6 @@ func TestProcessString_NoExpression(t *testing.T) {
 
 func TestProcessString_MixedContent(t *testing.T) {
 	p := &expressionProcessor{
-		stepTypeMap: map[string]*StepInfo{
-			"runStep1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.runStep1"},
-		},
-		flatTypeMap:     map[string]string{"runStep1": "Run"},
 		currentStepID:   "runStep1",
 		currentStepType: "Run",
 	}
@@ -80,8 +70,8 @@ func TestProcessString_MixedContent(t *testing.T) {
 }
 
 func TestPostProcessExpressions_Pipeline(t *testing.T) {
-	stepTypeMap := map[string]*StepInfo{
-		"runStep1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.runStep1"},
+	stepTypeMap := map[string]*convertexpressions.StepInfoFQN{
+		"pipeline.stages.build.steps.runStep1": {Type: "Run", StageID: "build", StepID: "runStep1"},
 	}
 
 	pipeline := &v1.Pipeline{
@@ -113,9 +103,9 @@ func TestPostProcessExpressions_Pipeline(t *testing.T) {
 }
 
 func TestPostProcessExpressions_FlexibleFieldExpression(t *testing.T) {
-	stepTypeMap := map[string]*StepInfo{
-		"runStep1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.runStep1"},
-		"step2":    {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.step2"},
+	stepTypeMap := map[string]*convertexpressions.StepInfoFQN{
+		"pipeline.stages.build.steps.runStep1": {Type: "Run", StageID: "build", StepID: "runStep1"},
+		"pipeline.stages.build.steps.step2":    {Type: "Run", StageID: "build", StepID: "step2"},
 	}
 
 	envField := &flexible.Field[map[string]string]{}
@@ -149,8 +139,8 @@ func TestPostProcessExpressions_FlexibleFieldExpression(t *testing.T) {
 }
 
 func TestPostProcessExpressions_MapStringValues(t *testing.T) {
-	stepTypeMap := map[string]*StepInfo{
-		"runStep1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.runStep1"},
+	stepTypeMap := map[string]*convertexpressions.StepInfoFQN{
+		"pipeline.stages.build.steps.runStep1": {Type: "Run", StageID: "build", StepID: "runStep1"},
 	}
 
 	pipeline := &v1.Pipeline{
@@ -189,8 +179,8 @@ func TestPostProcessExpressions_NilPipeline(t *testing.T) {
 }
 
 func TestPostProcessExpressions_StageIdentifier(t *testing.T) {
-	stepTypeMap := map[string]*StepInfo{
-		"step1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.step1"},
+	stepTypeMap := map[string]*convertexpressions.StepInfoFQN{
+		"pipeline.stages.build.steps.step1": {Type: "Run", StageID: "build", StepID: "step1"},
 	}
 
 	pipeline := &v1.Pipeline{
@@ -204,6 +194,9 @@ func TestPostProcessExpressions_StageIdentifier(t *testing.T) {
 
 	PostProcessExpressions(pipeline, stepTypeMap, true)
 
+	// stage.-rooted reference: FQN override is suppressed (stage and its
+	// ancestors are flagged WithNoFQNOverride), so it converts structurally
+	// to the "stage" self-reference keyword rather than the absolute FQN.
 	expected := "<+stage.steps.step1.output>"
 	if pipeline.Stages[0].If != expected {
 		t.Errorf("stage.If: expected %q, got %q", expected, pipeline.Stages[0].If)
@@ -212,9 +205,9 @@ func TestPostProcessExpressions_StageIdentifier(t *testing.T) {
 
 func TestPostProcessExpressions_StringorsliceScript(t *testing.T) {
 	// Test that expressions in Stringorslice ([]string) are converted
-	stepTypeMap := map[string]*StepInfo{
-		"runStep1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.runStep1"},
-		"runStep2": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.runStep2"},
+	stepTypeMap := map[string]*convertexpressions.StepInfoFQN{
+		"pipeline.stages.build.steps.runStep1": {Type: "Run", StageID: "build", StepID: "runStep1"},
+		"pipeline.stages.build.steps.runStep2": {Type: "Run", StageID: "build", StepID: "runStep2"},
 	}
 
 	pipeline := &v1.Pipeline{
@@ -259,9 +252,9 @@ func TestPostProcessExpressions_StringorsliceScript(t *testing.T) {
 
 func TestPostProcessExpressions_StepNeeds(t *testing.T) {
 	// Test that expressions in Step.Needs (Stringorslice) are converted
-	stepTypeMap := map[string]*StepInfo{
-		"step1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.step1"},
-		"step2": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.step2"},
+	stepTypeMap := map[string]*convertexpressions.StepInfoFQN{
+		"pipeline.stages.build.steps.step1": {Type: "Run", StageID: "build", StepID: "step1"},
+		"pipeline.stages.build.steps.step2": {Type: "Run", StageID: "build", StepID: "step2"},
 	}
 
 	pipeline := &v1.Pipeline{
@@ -282,7 +275,9 @@ func TestPostProcessExpressions_StepNeeds(t *testing.T) {
 
 	PostProcessExpressions(pipeline, stepTypeMap, true)
 
-	// Needs should have spec.execution.steps → steps converted
+	// Needs should have spec.execution.steps → steps converted. The .status
+	// field is not a spec/output node, so FQN substitution is suppressed and
+	// the relative "stage" alias is preserved (structural conversion only).
 	expected := "<+stage.steps.step1.status>"
 	if pipeline.Stages[0].Steps[0].Needs[0] != expected {
 		t.Errorf("needs[0]: expected %q, got %q", expected, pipeline.Stages[0].Steps[0].Needs[0])
@@ -291,8 +286,8 @@ func TestPostProcessExpressions_StepNeeds(t *testing.T) {
 
 func TestPostProcessExpressions_InterfaceSlice(t *testing.T) {
 	// Test expressions in []interface{} slices
-	stepTypeMap := map[string]*StepInfo{
-		"step1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.step1"},
+	stepTypeMap := map[string]*convertexpressions.StepInfoFQN{
+		"pipeline.stages.build.steps.step1": {Type: "Run", StageID: "build", StepID: "step1"},
 	}
 
 	pipeline := &v1.Pipeline{
@@ -326,6 +321,7 @@ func TestPostProcessExpressions_InterfaceSlice(t *testing.T) {
 		t.Errorf("items[1]: expected 'plain-value', got %v", items[1])
 	}
 
+	// stage.-rooted reference stays structural (FQN override suppressed).
 	expected2 := "<+stage.steps.step1.output>"
 	if items[2] != expected2 {
 		t.Errorf("items[2]: expected %q, got %v", expected2, items[2])
@@ -334,9 +330,9 @@ func TestPostProcessExpressions_InterfaceSlice(t *testing.T) {
 
 func TestPostProcessExpressions_NestedMapInterface(t *testing.T) {
 	// Test deeply nested map[string]interface{} with expressions
-	stepTypeMap := map[string]*StepInfo{
-		"step1": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.step1"},
-		"step2": {Type: "Run", V0Path: "pipeline.stages.build.spec.execution.steps.step2"},
+	stepTypeMap := map[string]*convertexpressions.StepInfoFQN{
+		"pipeline.stages.build.steps.step1": {Type: "Run", StageID: "build", StepID: "step1"},
+		"pipeline.stages.build.steps.step2": {Type: "Run", StageID: "build", StepID: "step2"},
 	}
 
 	pipeline := &v1.Pipeline{
@@ -362,6 +358,7 @@ func TestPostProcessExpressions_NestedMapInterface(t *testing.T) {
 
 	// Check direct value
 	if direct, ok := pipeline.Stages[0].Steps[0].With["direct"].(string); ok {
+		// stage.-rooted reference stays structural (FQN override suppressed).
 		expected := "<+stage.steps.step2.output>"
 		if direct != expected {
 			t.Errorf("with.direct: expected %q, got %q", expected, direct)

--- a/convert/v0tov1/yaml/input.go
+++ b/convert/v0tov1/yaml/input.go
@@ -18,7 +18,7 @@ package yaml
 
 type Input struct {
 	Default        interface{} `json:"default,omitempty" yaml:"default,omitempty"`
-	Desc           string      `json:"desc,omitempty" yaml:"desc,omitempty"`
+	Description    string      `json:"description,omitempty" yaml:"description,omitempty"`
 	Enum           interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
 	ExecutionInput bool        `json:"execution_input,omitempty" yaml:"execution_input,omitempty"`
 	Items          interface{} `json:"items,omitempty" yaml:"items,omitempty"`

--- a/convert/v0tov1/yaml/pipeline.go
+++ b/convert/v0tov1/yaml/pipeline.go
@@ -19,6 +19,7 @@ package yaml
 import "github.com/drone/go-convert/internal/flexible"
 
 type Pipeline struct {
+	AllowStageExecutions *flexible.Field[bool] `json:"allow-stage-executions,omitempty" yaml:"allow-stage-executions,omitempty"` 
 	Barriers      []string          `json:"barriers,omitempty" yaml:"barriers,omitempty"`
 	Clone         *Clone            `json:"clone,omitempty" yaml:"clone,omitempty"`
 	Concurrency   *Concurrency      `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`

--- a/convert/v0tov1/yaml/stage.go
+++ b/convert/v0tov1/yaml/stage.go
@@ -30,6 +30,7 @@ type Stage struct {
 	Chain             *Chain                              `json:"chain,omitempty" yaml:"chain,omitempty"`
 	Concurrency       *Concurrency                        `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`
 	Delegate          *flexible.Field[*Delegate]          `json:"delegate,omitempty" yaml:"delegate,omitempty"`
+	Description       string                              `json:"description,omitempty" yaml:"description,omitempty"`
 	Env               map[string]interface{}              `json:"env,omitempty" yaml:"env,omitempty"`
 	Environment       *EnvironmentRef                     `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Group             *StageGroup                         `json:"group,omitempty" yaml:"group,omitempty"`
@@ -52,6 +53,7 @@ type Stage struct {
 	Status            *Status                             `json:"status,omitempty" yaml:"status,omitempty"`
 	Steps             []*Step                             `json:"steps" yaml:"steps"`
 	Strategy          *Strategy                           `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Tags              *flexible.Field[map[string]string]  `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Template          *StageTemplate                      `json:"template,omitempty" yaml:"template,omitempty"`
 	Timeout           string                              `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	Volumes           []*Volume                           `json:"volumes,omitempty" yaml:"volumes,omitempty"`

--- a/proto/go_convert_service.pb.go
+++ b/proto/go_convert_service.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        v7.34.1
-// source: proto/go_convert_service.proto
+// source: go_convert_service.proto
 
 package proto
 
@@ -57,11 +57,11 @@ func (x EntityType) String() string {
 }
 
 func (EntityType) Descriptor() protoreflect.EnumDescriptor {
-	return file_proto_go_convert_service_proto_enumTypes[0].Descriptor()
+	return file_go_convert_service_proto_enumTypes[0].Descriptor()
 }
 
 func (EntityType) Type() protoreflect.EnumType {
-	return &file_proto_go_convert_service_proto_enumTypes[0]
+	return &file_go_convert_service_proto_enumTypes[0]
 }
 
 func (x EntityType) Number() protoreflect.EnumNumber {
@@ -70,7 +70,7 @@ func (x EntityType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use EntityType.Descriptor instead.
 func (EntityType) EnumDescriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{0}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{0}
 }
 
 // Severity classifies a converter message.
@@ -107,11 +107,11 @@ func (x Severity) String() string {
 }
 
 func (Severity) Descriptor() protoreflect.EnumDescriptor {
-	return file_proto_go_convert_service_proto_enumTypes[1].Descriptor()
+	return file_go_convert_service_proto_enumTypes[1].Descriptor()
 }
 
 func (Severity) Type() protoreflect.EnumType {
-	return &file_proto_go_convert_service_proto_enumTypes[1]
+	return &file_go_convert_service_proto_enumTypes[1]
 }
 
 func (x Severity) Number() protoreflect.EnumNumber {
@@ -120,7 +120,7 @@ func (x Severity) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Severity.Descriptor instead.
 func (Severity) EnumDescriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{1}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{1}
 }
 
 // ConversionStatus indicates whether an expression was converted.
@@ -154,11 +154,11 @@ func (x ConversionStatus) String() string {
 }
 
 func (ConversionStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_proto_go_convert_service_proto_enumTypes[2].Descriptor()
+	return file_go_convert_service_proto_enumTypes[2].Descriptor()
 }
 
 func (ConversionStatus) Type() protoreflect.EnumType {
-	return &file_proto_go_convert_service_proto_enumTypes[2]
+	return &file_go_convert_service_proto_enumTypes[2]
 }
 
 func (x ConversionStatus) Number() protoreflect.EnumNumber {
@@ -167,7 +167,7 @@ func (x ConversionStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ConversionStatus.Descriptor instead.
 func (ConversionStatus) EnumDescriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{2}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{2}
 }
 
 type ConvertRequest struct {
@@ -176,14 +176,14 @@ type ConvertRequest struct {
 	Yaml                string                 `protobuf:"bytes,2,opt,name=yaml,proto3" json:"yaml,omitempty"`
 	TemplateRefMapping  map[string]string      `protobuf:"bytes,3,rep,name=template_ref_mapping,json=templateRefMapping,proto3" json:"template_ref_mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	PipelineRefMapping  map[string]string      `protobuf:"bytes,4,rep,name=pipeline_ref_mapping,json=pipelineRefMapping,proto3" json:"pipeline_ref_mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	ContextPipelineYaml string                 `protobuf:"bytes,5,opt,name=context_pipeline_yaml,json=contextPipelineYaml,proto3" json:"context_pipeline_yaml,omitempty"` // Optional v0 pipeline YAML for expression post-processing context for inputset/trigger conversion
+	ContextPipelineYaml string                 `protobuf:"bytes,5,opt,name=context_pipeline_yaml,json=contextPipelineYaml,proto3" json:"context_pipeline_yaml,omitempty"` // Optional v1 pipeline YAML for expression post-processing context for template/inputset/trigger conversion
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ConvertRequest) Reset() {
 	*x = ConvertRequest{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[0]
+	mi := &file_go_convert_service_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -195,7 +195,7 @@ func (x *ConvertRequest) String() string {
 func (*ConvertRequest) ProtoMessage() {}
 
 func (x *ConvertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[0]
+	mi := &file_go_convert_service_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -208,7 +208,7 @@ func (x *ConvertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConvertRequest.ProtoReflect.Descriptor instead.
 func (*ConvertRequest) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{0}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ConvertRequest) GetEntityType() EntityType {
@@ -259,7 +259,7 @@ type ConverterMessage struct {
 
 func (x *ConverterMessage) Reset() {
 	*x = ConverterMessage{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[1]
+	mi := &file_go_convert_service_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -271,7 +271,7 @@ func (x *ConverterMessage) String() string {
 func (*ConverterMessage) ProtoMessage() {}
 
 func (x *ConverterMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[1]
+	mi := &file_go_convert_service_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -284,7 +284,7 @@ func (x *ConverterMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConverterMessage.ProtoReflect.Descriptor instead.
 func (*ConverterMessage) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{1}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *ConverterMessage) GetSeverity() Severity {
@@ -327,7 +327,7 @@ type ExpressionEntry struct {
 
 func (x *ExpressionEntry) Reset() {
 	*x = ExpressionEntry{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[2]
+	mi := &file_go_convert_service_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -339,7 +339,7 @@ func (x *ExpressionEntry) String() string {
 func (*ExpressionEntry) ProtoMessage() {}
 
 func (x *ExpressionEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[2]
+	mi := &file_go_convert_service_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -352,7 +352,7 @@ func (x *ExpressionEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpressionEntry.ProtoReflect.Descriptor instead.
 func (*ExpressionEntry) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{2}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ExpressionEntry) GetOriginal() string {
@@ -390,7 +390,7 @@ type ConversionReport struct {
 
 func (x *ConversionReport) Reset() {
 	*x = ConversionReport{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[3]
+	mi := &file_go_convert_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -402,7 +402,7 @@ func (x *ConversionReport) String() string {
 func (*ConversionReport) ProtoMessage() {}
 
 func (x *ConversionReport) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[3]
+	mi := &file_go_convert_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -415,7 +415,7 @@ func (x *ConversionReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConversionReport.ProtoReflect.Descriptor instead.
 func (*ConversionReport) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{3}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ConversionReport) GetMessages() []*ConverterMessage {
@@ -450,7 +450,7 @@ type ConvertResponse struct {
 
 func (x *ConvertResponse) Reset() {
 	*x = ConvertResponse{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[4]
+	mi := &file_go_convert_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -462,7 +462,7 @@ func (x *ConvertResponse) String() string {
 func (*ConvertResponse) ProtoMessage() {}
 
 func (x *ConvertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[4]
+	mi := &file_go_convert_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -475,7 +475,7 @@ func (x *ConvertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConvertResponse.ProtoReflect.Descriptor instead.
 func (*ConvertResponse) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{4}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ConvertResponse) GetYaml() string {
@@ -508,7 +508,7 @@ type ChecksumRequest struct {
 
 func (x *ChecksumRequest) Reset() {
 	*x = ChecksumRequest{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[5]
+	mi := &file_go_convert_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -520,7 +520,7 @@ func (x *ChecksumRequest) String() string {
 func (*ChecksumRequest) ProtoMessage() {}
 
 func (x *ChecksumRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[5]
+	mi := &file_go_convert_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -533,7 +533,7 @@ func (x *ChecksumRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChecksumRequest.ProtoReflect.Descriptor instead.
 func (*ChecksumRequest) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{5}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ChecksumRequest) GetYaml() string {
@@ -552,7 +552,7 @@ type ChecksumResponse struct {
 
 func (x *ChecksumResponse) Reset() {
 	*x = ChecksumResponse{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[6]
+	mi := &file_go_convert_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -564,7 +564,7 @@ func (x *ChecksumResponse) String() string {
 func (*ChecksumResponse) ProtoMessage() {}
 
 func (x *ChecksumResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[6]
+	mi := &file_go_convert_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -577,7 +577,7 @@ func (x *ChecksumResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChecksumResponse.ProtoReflect.Descriptor instead.
 func (*ChecksumResponse) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{6}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ChecksumResponse) GetChecksum() string {
@@ -588,18 +588,25 @@ func (x *ChecksumResponse) GetChecksum() string {
 }
 
 // ExpressionConvertRequest is the request for ConvertExpression.
+//
+// Expression conversion is FQN-only: context is supplied as a v1 pipeline YAML
+// (context_pipeline_yaml) which the server walks into the FQN-keyed step lookup,
+// plus an optional current_fqn that anchors the call-site for step-group
+// chaining. There are no manual step maps.
 type ExpressionConvertRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// A single expression to convert (use this OR expressions, not both).
 	Expression string `protobuf:"bytes,1,opt,name=expression,proto3" json:"expression,omitempty"`
 	// Multiple expressions to convert (use this OR expression, not both).
 	Expressions []string `protobuf:"bytes,2,rep,name=expressions,proto3" json:"expressions,omitempty"`
-	// Optional v0 pipeline YAML. When provided the server structurally
-	// converts this pipeline to derive step-type and v1-path maps
-	// automatically. Supersedes manual context fields.
+	// Optional v1 pipeline YAML. When provided the server walks this pipeline
+	// into the FQN-keyed step lookup and resolves step references against it.
 	ContextPipelineYaml string `protobuf:"bytes,3,opt,name=context_pipeline_yaml,json=contextPipelineYaml,proto3" json:"context_pipeline_yaml,omitempty"`
-	// Optional manual context (ignored when context_pipeline_yaml is provided).
-	Context *ExpressionContext `protobuf:"bytes,4,opt,name=context,proto3" json:"context,omitempty"`
+	// Optional full v1 FQN of the step the expression lives in, e.g.
+	// "pipeline.stages.prod.steps.G1.steps.deploy". Used to derive the call-site
+	// stage and enclosing step-group chain so references resolve with step-group
+	// chaining. Only meaningful alongside context_pipeline_yaml.
+	CurrentFqn string `protobuf:"bytes,4,opt,name=current_fqn,json=currentFqn,proto3" json:"current_fqn,omitempty"`
 	// Raw contents of a remote file (manifest, values.yaml, config, etc.)
 	// containing embedded <+...> expressions. The server scans the string
 	// and converts every expression found, returning the file with all
@@ -611,7 +618,7 @@ type ExpressionConvertRequest struct {
 
 func (x *ExpressionConvertRequest) Reset() {
 	*x = ExpressionConvertRequest{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[7]
+	mi := &file_go_convert_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -623,7 +630,7 @@ func (x *ExpressionConvertRequest) String() string {
 func (*ExpressionConvertRequest) ProtoMessage() {}
 
 func (x *ExpressionConvertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[7]
+	mi := &file_go_convert_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -636,7 +643,7 @@ func (x *ExpressionConvertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpressionConvertRequest.ProtoReflect.Descriptor instead.
 func (*ExpressionConvertRequest) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{7}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ExpressionConvertRequest) GetExpression() string {
@@ -660,11 +667,11 @@ func (x *ExpressionConvertRequest) GetContextPipelineYaml() string {
 	return ""
 }
 
-func (x *ExpressionConvertRequest) GetContext() *ExpressionContext {
+func (x *ExpressionConvertRequest) GetCurrentFqn() string {
 	if x != nil {
-		return x.Context
+		return x.CurrentFqn
 	}
-	return nil
+	return ""
 }
 
 func (x *ExpressionConvertRequest) GetRemoteFile() string {
@@ -672,91 +679,6 @@ func (x *ExpressionConvertRequest) GetRemoteFile() string {
 		return x.RemoteFile
 	}
 	return ""
-}
-
-// ExpressionContext holds manual metadata for expression conversion.
-type ExpressionContext struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	CurrentStepId     string                 `protobuf:"bytes,1,opt,name=current_step_id,json=currentStepId,proto3" json:"current_step_id,omitempty"`
-	CurrentStepType   string                 `protobuf:"bytes,2,opt,name=current_step_type,json=currentStepType,proto3" json:"current_step_type,omitempty"`
-	CurrentStepV1Path string                 `protobuf:"bytes,3,opt,name=current_step_v1_path,json=currentStepV1Path,proto3" json:"current_step_v1_path,omitempty"`
-	StepTypeMap       map[string]string      `protobuf:"bytes,4,rep,name=step_type_map,json=stepTypeMap,proto3" json:"step_type_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	StepV1PathMap     map[string]string      `protobuf:"bytes,5,rep,name=step_v1_path_map,json=stepV1PathMap,proto3" json:"step_v1_path_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	UseFqn            bool                   `protobuf:"varint,6,opt,name=use_fqn,json=useFqn,proto3" json:"use_fqn,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
-}
-
-func (x *ExpressionContext) Reset() {
-	*x = ExpressionContext{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[8]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ExpressionContext) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ExpressionContext) ProtoMessage() {}
-
-func (x *ExpressionContext) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[8]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ExpressionContext.ProtoReflect.Descriptor instead.
-func (*ExpressionContext) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{8}
-}
-
-func (x *ExpressionContext) GetCurrentStepId() string {
-	if x != nil {
-		return x.CurrentStepId
-	}
-	return ""
-}
-
-func (x *ExpressionContext) GetCurrentStepType() string {
-	if x != nil {
-		return x.CurrentStepType
-	}
-	return ""
-}
-
-func (x *ExpressionContext) GetCurrentStepV1Path() string {
-	if x != nil {
-		return x.CurrentStepV1Path
-	}
-	return ""
-}
-
-func (x *ExpressionContext) GetStepTypeMap() map[string]string {
-	if x != nil {
-		return x.StepTypeMap
-	}
-	return nil
-}
-
-func (x *ExpressionContext) GetStepV1PathMap() map[string]string {
-	if x != nil {
-		return x.StepV1PathMap
-	}
-	return nil
-}
-
-func (x *ExpressionContext) GetUseFqn() bool {
-	if x != nil {
-		return x.UseFqn
-	}
-	return false
 }
 
 // ExpressionConvertResponse is the response for ConvertExpression.
@@ -769,14 +691,17 @@ type ExpressionConvertResponse struct {
 	// SHA-256 checksum of the converted output.
 	Checksum string `protobuf:"bytes,3,opt,name=checksum,proto3" json:"checksum,omitempty"`
 	// The remote file contents with all embedded expressions converted.
-	RemoteFile    string `protobuf:"bytes,4,opt,name=remote_file,json=remoteFile,proto3" json:"remote_file,omitempty"`
+	RemoteFile string `protobuf:"bytes,4,opt,name=remote_file,json=remoteFile,proto3" json:"remote_file,omitempty"`
+	// Non-fatal diagnostics, e.g. ambiguous step types resolved via best-match
+	// fallback or unmapped template/approval uses.
+	Warnings      []string `protobuf:"bytes,5,rep,name=warnings,proto3" json:"warnings,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExpressionConvertResponse) Reset() {
 	*x = ExpressionConvertResponse{}
-	mi := &file_proto_go_convert_service_proto_msgTypes[9]
+	mi := &file_go_convert_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -788,7 +713,7 @@ func (x *ExpressionConvertResponse) String() string {
 func (*ExpressionConvertResponse) ProtoMessage() {}
 
 func (x *ExpressionConvertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_go_convert_service_proto_msgTypes[9]
+	mi := &file_go_convert_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -801,7 +726,7 @@ func (x *ExpressionConvertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpressionConvertResponse.ProtoReflect.Descriptor instead.
 func (*ExpressionConvertResponse) Descriptor() ([]byte, []int) {
-	return file_proto_go_convert_service_proto_rawDescGZIP(), []int{9}
+	return file_go_convert_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ExpressionConvertResponse) GetExpression() string {
@@ -832,11 +757,18 @@ func (x *ExpressionConvertResponse) GetRemoteFile() string {
 	return ""
 }
 
-var File_proto_go_convert_service_proto protoreflect.FileDescriptor
+func (x *ExpressionConvertResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
+}
 
-const file_proto_go_convert_service_proto_rawDesc = "" +
+var File_go_convert_service_proto protoreflect.FileDescriptor
+
+const file_go_convert_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1eproto/go_convert_service.proto\x12\x1fio.harness.pms.conversion.proto\"\xaa\x04\n" +
+	"\x18go_convert_service.proto\x12\x1fio.harness.pms.conversion.proto\"\xaa\x04\n" +
 	"\x0eConvertRequest\x12L\n" +
 	"\ventity_type\x18\x01 \x01(\x0e2+.io.harness.pms.conversion.proto.EntityTypeR\n" +
 	"entityType\x12\x12\n" +
@@ -873,29 +805,17 @@ const file_proto_go_convert_service_proto_rawDesc = "" +
 	"\x0fChecksumRequest\x12\x12\n" +
 	"\x04yaml\x18\x01 \x01(\tR\x04yaml\".\n" +
 	"\x10ChecksumResponse\x12\x1a\n" +
-	"\bchecksum\x18\x01 \x01(\tR\bchecksum\"\xff\x01\n" +
+	"\bchecksum\x18\x01 \x01(\tR\bchecksum\"\xd2\x01\n" +
 	"\x18ExpressionConvertRequest\x12\x1e\n" +
 	"\n" +
 	"expression\x18\x01 \x01(\tR\n" +
 	"expression\x12 \n" +
 	"\vexpressions\x18\x02 \x03(\tR\vexpressions\x122\n" +
-	"\x15context_pipeline_yaml\x18\x03 \x01(\tR\x13contextPipelineYaml\x12L\n" +
-	"\acontext\x18\x04 \x01(\v22.io.harness.pms.conversion.proto.ExpressionContextR\acontext\x12\x1f\n" +
+	"\x15context_pipeline_yaml\x18\x03 \x01(\tR\x13contextPipelineYaml\x12\x1f\n" +
+	"\vcurrent_fqn\x18\x04 \x01(\tR\n" +
+	"currentFqn\x12\x1f\n" +
 	"\vremote_file\x18\x05 \x01(\tR\n" +
-	"remoteFile\"\x8c\x04\n" +
-	"\x11ExpressionContext\x12&\n" +
-	"\x0fcurrent_step_id\x18\x01 \x01(\tR\rcurrentStepId\x12*\n" +
-	"\x11current_step_type\x18\x02 \x01(\tR\x0fcurrentStepType\x12/\n" +
-	"\x14current_step_v1_path\x18\x03 \x01(\tR\x11currentStepV1Path\x12g\n" +
-	"\rstep_type_map\x18\x04 \x03(\v2C.io.harness.pms.conversion.proto.ExpressionContext.StepTypeMapEntryR\vstepTypeMap\x12n\n" +
-	"\x10step_v1_path_map\x18\x05 \x03(\v2E.io.harness.pms.conversion.proto.ExpressionContext.StepV1PathMapEntryR\rstepV1PathMap\x12\x17\n" +
-	"\ause_fqn\x18\x06 \x01(\bR\x06useFqn\x1a>\n" +
-	"\x10StepTypeMapEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a@\n" +
-	"\x12StepV1PathMapEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xa7\x02\n" +
+	"remoteFile\"\xc3\x02\n" +
 	"\x19ExpressionConvertResponse\x12\x1e\n" +
 	"\n" +
 	"expression\x18\x01 \x01(\tR\n" +
@@ -903,7 +823,8 @@ const file_proto_go_convert_service_proto_rawDesc = "" +
 	"\vexpressions\x18\x02 \x03(\v2K.io.harness.pms.conversion.proto.ExpressionConvertResponse.ExpressionsEntryR\vexpressions\x12\x1a\n" +
 	"\bchecksum\x18\x03 \x01(\tR\bchecksum\x12\x1f\n" +
 	"\vremote_file\x18\x04 \x01(\tR\n" +
-	"remoteFile\x1a>\n" +
+	"remoteFile\x12\x1a\n" +
+	"\bwarnings\x18\x05 \x03(\tR\bwarnings\x1a>\n" +
 	"\x10ExpressionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*D\n" +
@@ -930,20 +851,20 @@ const file_proto_go_convert_service_proto_rawDesc = "" +
 	"\x1fio.harness.pms.conversion.protoP\x01Z!github.com/drone/go-convert/protob\x06proto3"
 
 var (
-	file_proto_go_convert_service_proto_rawDescOnce sync.Once
-	file_proto_go_convert_service_proto_rawDescData []byte
+	file_go_convert_service_proto_rawDescOnce sync.Once
+	file_go_convert_service_proto_rawDescData []byte
 )
 
-func file_proto_go_convert_service_proto_rawDescGZIP() []byte {
-	file_proto_go_convert_service_proto_rawDescOnce.Do(func() {
-		file_proto_go_convert_service_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_proto_go_convert_service_proto_rawDesc), len(file_proto_go_convert_service_proto_rawDesc)))
+func file_go_convert_service_proto_rawDescGZIP() []byte {
+	file_go_convert_service_proto_rawDescOnce.Do(func() {
+		file_go_convert_service_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_go_convert_service_proto_rawDesc), len(file_go_convert_service_proto_rawDesc)))
 	})
-	return file_proto_go_convert_service_proto_rawDescData
+	return file_go_convert_service_proto_rawDescData
 }
 
-var file_proto_go_convert_service_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_proto_go_convert_service_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
-var file_proto_go_convert_service_proto_goTypes = []any{
+var file_go_convert_service_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_go_convert_service_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_go_convert_service_proto_goTypes = []any{
 	(EntityType)(0),                   // 0: io.harness.pms.conversion.proto.EntityType
 	(Severity)(0),                     // 1: io.harness.pms.conversion.proto.Severity
 	(ConversionStatus)(0),             // 2: io.harness.pms.conversion.proto.ConversionStatus
@@ -955,69 +876,63 @@ var file_proto_go_convert_service_proto_goTypes = []any{
 	(*ChecksumRequest)(nil),           // 8: io.harness.pms.conversion.proto.ChecksumRequest
 	(*ChecksumResponse)(nil),          // 9: io.harness.pms.conversion.proto.ChecksumResponse
 	(*ExpressionConvertRequest)(nil),  // 10: io.harness.pms.conversion.proto.ExpressionConvertRequest
-	(*ExpressionContext)(nil),         // 11: io.harness.pms.conversion.proto.ExpressionContext
-	(*ExpressionConvertResponse)(nil), // 12: io.harness.pms.conversion.proto.ExpressionConvertResponse
-	nil,                               // 13: io.harness.pms.conversion.proto.ConvertRequest.TemplateRefMappingEntry
-	nil,                               // 14: io.harness.pms.conversion.proto.ConvertRequest.PipelineRefMappingEntry
-	nil,                               // 15: io.harness.pms.conversion.proto.ConverterMessage.ContextEntry
-	nil,                               // 16: io.harness.pms.conversion.proto.ExpressionContext.StepTypeMapEntry
-	nil,                               // 17: io.harness.pms.conversion.proto.ExpressionContext.StepV1PathMapEntry
-	nil,                               // 18: io.harness.pms.conversion.proto.ExpressionConvertResponse.ExpressionsEntry
+	(*ExpressionConvertResponse)(nil), // 11: io.harness.pms.conversion.proto.ExpressionConvertResponse
+	nil,                               // 12: io.harness.pms.conversion.proto.ConvertRequest.TemplateRefMappingEntry
+	nil,                               // 13: io.harness.pms.conversion.proto.ConvertRequest.PipelineRefMappingEntry
+	nil,                               // 14: io.harness.pms.conversion.proto.ConverterMessage.ContextEntry
+	nil,                               // 15: io.harness.pms.conversion.proto.ExpressionConvertResponse.ExpressionsEntry
 }
-var file_proto_go_convert_service_proto_depIdxs = []int32{
+var file_go_convert_service_proto_depIdxs = []int32{
 	0,  // 0: io.harness.pms.conversion.proto.ConvertRequest.entity_type:type_name -> io.harness.pms.conversion.proto.EntityType
-	13, // 1: io.harness.pms.conversion.proto.ConvertRequest.template_ref_mapping:type_name -> io.harness.pms.conversion.proto.ConvertRequest.TemplateRefMappingEntry
-	14, // 2: io.harness.pms.conversion.proto.ConvertRequest.pipeline_ref_mapping:type_name -> io.harness.pms.conversion.proto.ConvertRequest.PipelineRefMappingEntry
+	12, // 1: io.harness.pms.conversion.proto.ConvertRequest.template_ref_mapping:type_name -> io.harness.pms.conversion.proto.ConvertRequest.TemplateRefMappingEntry
+	13, // 2: io.harness.pms.conversion.proto.ConvertRequest.pipeline_ref_mapping:type_name -> io.harness.pms.conversion.proto.ConvertRequest.PipelineRefMappingEntry
 	1,  // 3: io.harness.pms.conversion.proto.ConverterMessage.severity:type_name -> io.harness.pms.conversion.proto.Severity
-	15, // 4: io.harness.pms.conversion.proto.ConverterMessage.context:type_name -> io.harness.pms.conversion.proto.ConverterMessage.ContextEntry
+	14, // 4: io.harness.pms.conversion.proto.ConverterMessage.context:type_name -> io.harness.pms.conversion.proto.ConverterMessage.ContextEntry
 	2,  // 5: io.harness.pms.conversion.proto.ExpressionEntry.status:type_name -> io.harness.pms.conversion.proto.ConversionStatus
 	4,  // 6: io.harness.pms.conversion.proto.ConversionReport.messages:type_name -> io.harness.pms.conversion.proto.ConverterMessage
 	5,  // 7: io.harness.pms.conversion.proto.ConversionReport.expressions:type_name -> io.harness.pms.conversion.proto.ExpressionEntry
 	6,  // 8: io.harness.pms.conversion.proto.ConvertResponse.report:type_name -> io.harness.pms.conversion.proto.ConversionReport
-	11, // 9: io.harness.pms.conversion.proto.ExpressionConvertRequest.context:type_name -> io.harness.pms.conversion.proto.ExpressionContext
-	16, // 10: io.harness.pms.conversion.proto.ExpressionContext.step_type_map:type_name -> io.harness.pms.conversion.proto.ExpressionContext.StepTypeMapEntry
-	17, // 11: io.harness.pms.conversion.proto.ExpressionContext.step_v1_path_map:type_name -> io.harness.pms.conversion.proto.ExpressionContext.StepV1PathMapEntry
-	18, // 12: io.harness.pms.conversion.proto.ExpressionConvertResponse.expressions:type_name -> io.harness.pms.conversion.proto.ExpressionConvertResponse.ExpressionsEntry
-	3,  // 13: io.harness.pms.conversion.proto.GoConvertService.ConvertPipeline:input_type -> io.harness.pms.conversion.proto.ConvertRequest
-	3,  // 14: io.harness.pms.conversion.proto.GoConvertService.ConvertTemplate:input_type -> io.harness.pms.conversion.proto.ConvertRequest
-	3,  // 15: io.harness.pms.conversion.proto.GoConvertService.ConvertInputSet:input_type -> io.harness.pms.conversion.proto.ConvertRequest
-	3,  // 16: io.harness.pms.conversion.proto.GoConvertService.ConvertTrigger:input_type -> io.harness.pms.conversion.proto.ConvertRequest
-	10, // 17: io.harness.pms.conversion.proto.GoConvertService.ConvertExpression:input_type -> io.harness.pms.conversion.proto.ExpressionConvertRequest
-	8,  // 18: io.harness.pms.conversion.proto.GoConvertService.GetChecksum:input_type -> io.harness.pms.conversion.proto.ChecksumRequest
-	7,  // 19: io.harness.pms.conversion.proto.GoConvertService.ConvertPipeline:output_type -> io.harness.pms.conversion.proto.ConvertResponse
-	7,  // 20: io.harness.pms.conversion.proto.GoConvertService.ConvertTemplate:output_type -> io.harness.pms.conversion.proto.ConvertResponse
-	7,  // 21: io.harness.pms.conversion.proto.GoConvertService.ConvertInputSet:output_type -> io.harness.pms.conversion.proto.ConvertResponse
-	7,  // 22: io.harness.pms.conversion.proto.GoConvertService.ConvertTrigger:output_type -> io.harness.pms.conversion.proto.ConvertResponse
-	12, // 23: io.harness.pms.conversion.proto.GoConvertService.ConvertExpression:output_type -> io.harness.pms.conversion.proto.ExpressionConvertResponse
-	9,  // 24: io.harness.pms.conversion.proto.GoConvertService.GetChecksum:output_type -> io.harness.pms.conversion.proto.ChecksumResponse
-	19, // [19:25] is the sub-list for method output_type
-	13, // [13:19] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	15, // 9: io.harness.pms.conversion.proto.ExpressionConvertResponse.expressions:type_name -> io.harness.pms.conversion.proto.ExpressionConvertResponse.ExpressionsEntry
+	3,  // 10: io.harness.pms.conversion.proto.GoConvertService.ConvertPipeline:input_type -> io.harness.pms.conversion.proto.ConvertRequest
+	3,  // 11: io.harness.pms.conversion.proto.GoConvertService.ConvertTemplate:input_type -> io.harness.pms.conversion.proto.ConvertRequest
+	3,  // 12: io.harness.pms.conversion.proto.GoConvertService.ConvertInputSet:input_type -> io.harness.pms.conversion.proto.ConvertRequest
+	3,  // 13: io.harness.pms.conversion.proto.GoConvertService.ConvertTrigger:input_type -> io.harness.pms.conversion.proto.ConvertRequest
+	10, // 14: io.harness.pms.conversion.proto.GoConvertService.ConvertExpression:input_type -> io.harness.pms.conversion.proto.ExpressionConvertRequest
+	8,  // 15: io.harness.pms.conversion.proto.GoConvertService.GetChecksum:input_type -> io.harness.pms.conversion.proto.ChecksumRequest
+	7,  // 16: io.harness.pms.conversion.proto.GoConvertService.ConvertPipeline:output_type -> io.harness.pms.conversion.proto.ConvertResponse
+	7,  // 17: io.harness.pms.conversion.proto.GoConvertService.ConvertTemplate:output_type -> io.harness.pms.conversion.proto.ConvertResponse
+	7,  // 18: io.harness.pms.conversion.proto.GoConvertService.ConvertInputSet:output_type -> io.harness.pms.conversion.proto.ConvertResponse
+	7,  // 19: io.harness.pms.conversion.proto.GoConvertService.ConvertTrigger:output_type -> io.harness.pms.conversion.proto.ConvertResponse
+	11, // 20: io.harness.pms.conversion.proto.GoConvertService.ConvertExpression:output_type -> io.harness.pms.conversion.proto.ExpressionConvertResponse
+	9,  // 21: io.harness.pms.conversion.proto.GoConvertService.GetChecksum:output_type -> io.harness.pms.conversion.proto.ChecksumResponse
+	16, // [16:22] is the sub-list for method output_type
+	10, // [10:16] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
-func init() { file_proto_go_convert_service_proto_init() }
-func file_proto_go_convert_service_proto_init() {
-	if File_proto_go_convert_service_proto != nil {
+func init() { file_go_convert_service_proto_init() }
+func file_go_convert_service_proto_init() {
+	if File_go_convert_service_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_go_convert_service_proto_rawDesc), len(file_proto_go_convert_service_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_go_convert_service_proto_rawDesc), len(file_go_convert_service_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   16,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_proto_go_convert_service_proto_goTypes,
-		DependencyIndexes: file_proto_go_convert_service_proto_depIdxs,
-		EnumInfos:         file_proto_go_convert_service_proto_enumTypes,
-		MessageInfos:      file_proto_go_convert_service_proto_msgTypes,
+		GoTypes:           file_go_convert_service_proto_goTypes,
+		DependencyIndexes: file_go_convert_service_proto_depIdxs,
+		EnumInfos:         file_go_convert_service_proto_enumTypes,
+		MessageInfos:      file_go_convert_service_proto_msgTypes,
 	}.Build()
-	File_proto_go_convert_service_proto = out.File
-	file_proto_go_convert_service_proto_goTypes = nil
-	file_proto_go_convert_service_proto_depIdxs = nil
+	File_go_convert_service_proto = out.File
+	file_go_convert_service_proto_goTypes = nil
+	file_go_convert_service_proto_depIdxs = nil
 }

--- a/proto/go_convert_service.proto
+++ b/proto/go_convert_service.proto
@@ -18,7 +18,7 @@ message ConvertRequest {
   string yaml = 2;
   map<string, string> template_ref_mapping = 3;
   map<string, string> pipeline_ref_mapping = 4;
-  string context_pipeline_yaml = 5; // Optional v0 pipeline YAML for expression post-processing context for inputset/trigger conversion
+  string context_pipeline_yaml = 5; // Optional v1 pipeline YAML for expression post-processing context for template/inputset/trigger conversion
 }
 
 // Severity classifies a converter message.
@@ -73,6 +73,11 @@ message ChecksumResponse {
 }
 
 // ExpressionConvertRequest is the request for ConvertExpression.
+//
+// Expression conversion is FQN-only: context is supplied as a v1 pipeline YAML
+// (context_pipeline_yaml) which the server walks into the FQN-keyed step lookup,
+// plus an optional current_fqn that anchors the call-site for step-group
+// chaining. There are no manual step maps.
 message ExpressionConvertRequest {
   // A single expression to convert (use this OR expressions, not both).
   string expression = 1;
@@ -80,29 +85,21 @@ message ExpressionConvertRequest {
   // Multiple expressions to convert (use this OR expression, not both).
   repeated string expressions = 2;
 
-  // Optional v0 pipeline YAML. When provided the server structurally
-  // converts this pipeline to derive step-type and v1-path maps
-  // automatically. Supersedes manual context fields.
+  // Optional v1 pipeline YAML. When provided the server walks this pipeline
+  // into the FQN-keyed step lookup and resolves step references against it.
   string context_pipeline_yaml = 3;
 
-  // Optional manual context (ignored when context_pipeline_yaml is provided).
-  ExpressionContext context = 4;
+  // Optional full v1 FQN of the step the expression lives in, e.g.
+  // "pipeline.stages.prod.steps.G1.steps.deploy". Used to derive the call-site
+  // stage and enclosing step-group chain so references resolve with step-group
+  // chaining. Only meaningful alongside context_pipeline_yaml.
+  string current_fqn = 4;
 
   // Raw contents of a remote file (manifest, values.yaml, config, etc.)
   // containing embedded <+...> expressions. The server scans the string
   // and converts every expression found, returning the file with all
   // expressions replaced.
   string remote_file = 5;
-}
-
-// ExpressionContext holds manual metadata for expression conversion.
-message ExpressionContext {
-  string current_step_id = 1;
-  string current_step_type = 2;
-  string current_step_v1_path = 3;
-  map<string, string> step_type_map = 4;
-  map<string, string> step_v1_path_map = 5;
-  bool use_fqn = 6;
 }
 
 // ExpressionConvertResponse is the response for ConvertExpression.
@@ -118,6 +115,10 @@ message ExpressionConvertResponse {
 
   // The remote file contents with all embedded expressions converted.
   string remote_file = 4;
+
+  // Non-fatal diagnostics, e.g. ambiguous step types resolved via best-match
+  // fallback or unmapped template/approval uses.
+  repeated string warnings = 5;
 }
 
 service GoConvertService {

--- a/proto/go_convert_service_grpc.pb.go
+++ b/proto/go_convert_service_grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.6.2
 // - protoc             v7.34.1
-// source: proto/go_convert_service.proto
+// source: go_convert_service.proto
 
 package proto
 
@@ -307,5 +307,5 @@ var GoConvertService_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "proto/go_convert_service.proto",
+	Metadata: "go_convert_service.proto",
 }

--- a/service/converter/context_v1.go
+++ b/service/converter/context_v1.go
@@ -1,0 +1,137 @@
+package converter
+
+import (
+	"strings"
+
+	convertexpressions "github.com/drone/go-convert/convert/convertexpressions"
+	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
+)
+
+// buildStepInfoByFQNFromV1 walks a parsed v1 pipeline and produces the
+// FQN-keyed step-info map consumed by the new ResolveStepFQN lookup. 
+func buildStepInfoByFQNFromV1(p *v1.Pipeline) map[string]*convertexpressions.StepInfoFQN {
+	if p == nil {
+		return nil
+	}
+	out := make(map[string]*convertexpressions.StepInfoFQN)
+	for _, stage := range p.Stages {
+		walkV1Stage(stage, out)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// walkV1Stage registers all steps under a single stage and recurses into
+// container stages (group / parallel) which themselves hold nested stages.
+func walkV1Stage(stage *v1.Stage, out map[string]*convertexpressions.StepInfoFQN) {
+	if stage == nil {
+		return
+	}
+	// Container stages hold nested stages rather than steps.
+	if stage.Group != nil {
+		for _, s := range stage.Group.Stages {
+			walkV1Stage(s, out)
+		}
+	}
+	if stage.Parallel != nil {
+		for _, s := range stage.Parallel.Stages {
+			walkV1Stage(s, out)
+		}
+	}
+	if stage.Id == "" {
+		return
+	}
+	base := "pipeline.stages." + stage.Id + ".steps."
+	for _, step := range stage.Steps {
+		walkV1Step(step, stage.Id, nil, base, out)
+	}
+}
+
+// walkV1Step registers a single step (or step group) and recurses into nested
+// group/parallel steps. prefix is the FQN up to and including the trailing
+// ".steps." for this level; chain is the ancestor step-group ID list.
+func walkV1Step(step *v1.Step, stageID string, chain []string, prefix string, out map[string]*convertexpressions.StepInfoFQN) {
+	if step == nil || step.Id == "" {
+		return
+	}
+	fqn := prefix + step.Id
+	info := &convertexpressions.StepInfoFQN{
+		StageID: stageID,
+		Chain:   append([]string(nil), chain...),
+		StepID:  step.Id,
+	}
+	// A single v0 type (Type) when unambiguous; a candidate list (Types) when
+	// one v1 field maps to several v0 types (e.g. step.run).
+	if types := v1StepTypes(step); len(types) == 1 {
+		info.Type = types[0]
+	} else if len(types) > 1 {
+		info.Types = types
+	}
+	out[fqn] = info
+
+	// Recurse into step groups (group / parallel both hold child steps).
+	childChain := append(append([]string(nil), chain...), step.Id)
+	childPrefix := fqn + ".steps."
+	if step.Group != nil {
+		for _, child := range step.Group.Steps {
+			walkV1Step(child, stageID, childChain, childPrefix, out)
+		}
+	}
+	if step.Parallel != nil {
+		for _, child := range step.Parallel.Steps {
+			walkV1Step(child, stageID, childChain, childPrefix, out)
+		}
+	}
+}
+
+// v1StepTypes derives the candidate v0 step type(s) from which v1 field is set.
+func v1StepTypes(step *v1.Step) []string {
+	switch {
+	case step.Group != nil:
+		return []string{"StepGroup"}
+	case step.Run != nil:
+		// HTTP converts to step.run but has a distinct, recoverable signature
+		// (hardcoded plugin image / PLUGIN_URL); all other run-family types
+		// share a clash-free rule set.
+		if isHTTPRunStep(step.Run) {
+			return []string{convertexpressions.StepTypeHTTP}
+		}
+		return convertexpressions.RunCandidateTypes
+	case step.RunTest != nil:
+		return convertexpressions.RunTestCandidateTypes
+	case step.Background != nil:
+		return []string{convertexpressions.StepTypeBackground}
+	case step.Approval != nil:
+		if t := convertexpressions.ApprovalUsesToV0Type[step.Approval.Uses]; t != "" {
+			return []string{t}
+		}
+		return nil
+	case step.Barrier != nil:
+		return []string{convertexpressions.StepTypeBarrier}
+	case step.Queue != nil:
+		return []string{convertexpressions.StepTypeQueue}
+	case step.Wait != nil:
+		return []string{convertexpressions.StepTypeWait}
+	case step.Template != nil:
+		if t := convertexpressions.TemplateUsesToV0Type[step.Template.Uses]; t != "" {
+			return []string{t}
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// isHTTPRunStep reports whether a step.run was produced from a v0 HTTP step,
+// detected by the hardcoded harness-http plugin image or its PLUGIN_URL env.
+func isHTTPRunStep(run *v1.StepRun) bool {
+	if run == nil {
+		return false
+	}
+	if run.Container != nil && strings.Contains(run.Container.Image, "harnessdev/harness-http") {
+		return true
+	}
+	return false
+}

--- a/service/converter/expression.go
+++ b/service/converter/expression.go
@@ -6,57 +6,52 @@ import (
 	convertexpressions "github.com/drone/go-convert/convert/convertexpressions"
 )
 
-// ExpressionContext holds the context needed for expression conversion.
-// This mirrors the ConversionContext from the convertexpressions package
-// but is exposed as a public API type for the service layer.
+// ExpressionContext is the FQN-only conversion context: a v1 pipeline YAML
+// plus an optional call-site FQN.
 type ExpressionContext struct {
-	// CurrentStepID is the ID of the current step we're inside (optional)
-	CurrentStepID string `json:"current_step_id,omitempty"`
+	// ContextPipelineYAML is an optional v1 pipeline YAML. When set, it builds
+	// the FQN-keyed step lookup (StepInfoByFQN) and enables FQN mode.
+	ContextPipelineYAML string `json:"context_pipeline_yaml,omitempty"`
 
-	// CurrentStepType is the type of the step we're currently inside (e.g., "Run", "Action", "Plugin")
-	// Used when expression is "step.spec.*" (no explicit step ID)
-	CurrentStepType string `json:"current_step_type,omitempty"`
-
-	// CurrentStepV1Path is the v1 FQN base path to the current step
-	// Example: "pipeline.stages.build.steps.restoreCache"
-	CurrentStepV1Path string `json:"current_step_v1_path,omitempty"`
-
-	// StepTypeMap maps step ID to step type for all steps in the pipeline
-	// Example: {"step1": "Run", "step2": "Action"}
-	StepTypeMap map[string]string `json:"step_type_map,omitempty"`
-
-	// StepV1PathMap maps step ID to its v1 FQN base path
-	// Example: {"restoreCache": "pipeline.stages.build.steps.restoreCache"}
-	StepV1PathMap map[string]string `json:"step_v1_path_map,omitempty"`
-
-	// UseFQN enables fully qualified name mode for step expressions
-	// When true, step expressions are converted to their full v1 paths
-	UseFQN bool `json:"use_fqn,omitempty"`
+	// CurrentFQN is the v1 FQN of the step the expression lives in (e.g.
+	// "pipeline.stages.prod.steps.G1.steps.deploy"). The stage, step-group
+	// chain, and current step type are derived from it.
+	CurrentFQN string `json:"current_fqn,omitempty"`
 }
 
 // ConvertExpression converts a single Harness v0 expression to v1 format.
-// The expression should include the <+...> delimiters.
-// Returns the converted expression string.
+// The expression should include the <+...> / ${{...}} delimiters.
 func ConvertExpression(expression string, ctx *ExpressionContext) string {
+	out, _ := ConvertExpressionWithWarnings(expression, ctx)
+	return out
+}
+
+// ConvertExpressionWithWarnings is ConvertExpression plus any diagnostics
+// collected during conversion (e.g. ambiguous step types resolved via
+// best-match fallback, unmapped template/approval uses).
+func ConvertExpressionWithWarnings(expression string, ctx *ExpressionContext) (string, []string) {
 	if expression == "" {
-		return ""
+		return "", nil
 	}
-
-	// Check if the expression contains Harness expression markers
-	if !strings.Contains(expression, "<+") {
-		return expression
+	if !hasExpressionDelimiter(expression) {
+		return expression, nil
 	}
-
-	// Build the internal ConversionContext
 	convCtx := buildConversionContext(ctx)
-
-	// Use the trie-based expression converter
-	return convertexpressions.ConvertExpressionWithTrie(expression, convCtx, false)
+	out := convertexpressions.ConvertExpressionWithTrie(expression, convCtx, false)
+	return out, convCtx.Warnings
 }
 
 // ConvertExpressions converts multiple Harness v0 expressions to v1 format.
 // Returns a map of original expression to converted expression.
 func ConvertExpressions(expressions []string, ctx *ExpressionContext) map[string]string {
+	out, _ := ConvertExpressionsWithWarnings(expressions, ctx)
+	return out
+}
+
+// ConvertExpressionsWithWarnings is ConvertExpressions plus the aggregated
+// diagnostics collected across all expressions. Each warning embeds the
+// offending path, so a flat list stays attributable.
+func ConvertExpressionsWithWarnings(expressions []string, ctx *ExpressionContext) (map[string]string, []string) {
 	result := make(map[string]string, len(expressions))
 	convCtx := buildConversionContext(ctx)
 
@@ -65,69 +60,73 @@ func ConvertExpressions(expressions []string, ctx *ExpressionContext) map[string
 			result[expr] = ""
 			continue
 		}
-		if !strings.Contains(expr, "<+") {
+		if !hasExpressionDelimiter(expr) {
 			result[expr] = expr
 			continue
 		}
 		result[expr] = convertexpressions.ConvertExpressionWithTrie(expr, convCtx, false)
 	}
 
-	return result
+	return result, convCtx.Warnings
+}
+
+// hasExpressionDelimiter reports whether s contains a Harness expression
+// delimiter (<+...> or ${{...}}).
+func hasExpressionDelimiter(s string) bool {
+	return strings.Contains(s, "<+") || strings.Contains(s, "${{")
 }
 
 // ConvertExpressionWithPipeline converts a single expression using context
-// automatically derived from a v0 pipeline YAML. The pipeline is parsed and
-// structurally converted to harvest the step-type map and v1 path map, the
-// same way pipeline/template/input-set/trigger conversions build context.
+// automatically derived from a v1 pipeline YAML (see BuildContextFromPipeline).
 func ConvertExpressionWithPipeline(expression string, pipelineYAML string) string {
 	ctx := BuildContextFromPipeline(pipelineYAML)
 	return ConvertExpression(expression, ctx)
 }
 
 // ConvertExpressionsWithPipeline converts multiple expressions using context
-// automatically derived from a v0 pipeline YAML.
+// automatically derived from a v1 pipeline YAML.
 func ConvertExpressionsWithPipeline(expressions []string, pipelineYAML string) map[string]string {
 	ctx := BuildContextFromPipeline(pipelineYAML)
 	return ConvertExpressions(expressions, ctx)
 }
 
-// BuildContextFromPipeline parses a v0 pipeline YAML, runs structural
-// conversion to derive the step-type map and v1 path map, and returns an
-// ExpressionContext with UseFQN enabled. Returns a minimal context (no
-// FQN) when the YAML is empty or unparseable.
+// BuildContextFromPipeline returns an ExpressionContext resolving step
+// references against the v1 pipelineYAML. No call-site is supplied, so set
+// ExpressionContext.CurrentFQN to scope a reference to its enclosing group.
 func BuildContextFromPipeline(pipelineYAML string) *ExpressionContext {
-	stepInfoMap, useFQN := buildContextFromPipelineYAML(pipelineYAML)
-	if !useFQN || len(stepInfoMap) == 0 {
-		return &ExpressionContext{}
-	}
-
-	// Flatten the StepInfo map to the flat string maps needed by ExpressionContext.
-	stepTypeMap := make(map[string]string, len(stepInfoMap))
-	stepV1PathMap := make(map[string]string, len(stepInfoMap))
-	for id, info := range stepInfoMap {
-		stepTypeMap[id] = info.Type
-		stepV1PathMap[id] = info.V1Path
-	}
-
-	return &ExpressionContext{
-		StepTypeMap:   stepTypeMap,
-		StepV1PathMap: stepV1PathMap,
-		UseFQN:        true,
-	}
+	return &ExpressionContext{ContextPipelineYAML: pipelineYAML}
 }
 
-// buildConversionContext converts the public ExpressionContext to the internal ConversionContext
+// buildConversionContext maps the public ExpressionContext to the internal
+// ConversionContext, building StepInfoByFQN from the v1 YAML and deriving the
+// call-site (stage / step-group chain / step type) from CurrentFQN.
 func buildConversionContext(ctx *ExpressionContext) *convertexpressions.ConversionContext {
 	if ctx == nil {
 		return &convertexpressions.ConversionContext{}
 	}
 
-	return &convertexpressions.ConversionContext{
-		StepID:            ctx.CurrentStepID,
-		CurrentStepType:   ctx.CurrentStepType,
-		CurrentStepV1Path: ctx.CurrentStepV1Path,
-		StepTypeMap:       ctx.StepTypeMap,
-		StepV1PathMap:     ctx.StepV1PathMap,
-		UseFQN:            ctx.UseFQN,
+	cc := &convertexpressions.ConversionContext{}
+
+	// FQN lookup: build StepInfoByFQN from the v1 context pipeline.
+	if strings.TrimSpace(ctx.ContextPipelineYAML) != "" {
+		if m, ok := buildContextFromPipelineYAML(ctx.ContextPipelineYAML); ok {
+			cc.StepInfoByFQN = m
+			cc.UseFQN = true
+		}
 	}
+
+	// Derive call-site context from the current step's v1 FQN.
+	if ctx.CurrentFQN != "" {
+		if stage, chain, _, ok := convertexpressions.ParseFQN(ctx.CurrentFQN); ok {
+			cc.CurrentStageID = stage
+			cc.CurrentStepGroupChain = chain
+			cc.CurrentFQN = ctx.CurrentFQN
+			if info, found := cc.StepInfoByFQN[ctx.CurrentFQN]; found && info != nil {
+				cc.CurrentStepType = info.Type
+				cc.CurrentStepTypes = info.Types
+			}
+		}
+	}
+
+	return cc
 }

--- a/service/converter/inputset.go
+++ b/service/converter/inputset.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"fmt"
+
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
 	pipelineconverter "github.com/drone/go-convert/convert/v0tov1/pipeline_converter"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
@@ -12,9 +13,8 @@ import (
 // templateRefMapping rewrites template references in the output;
 // pipelineRefMapping rewrites pipeline identifiers (pipeline.id, chain.uses
 // pipeline segment). Either or both may be nil/empty.
-// contextPipelineYAML is an optional v0 pipeline YAML used purely as
-// expression-postprocess context (see buildContextFromPipelineYAML). Pass ""
-// to run postprocess without FQN context.
+// contextPipelineYAML is an optional v1 pipeline YAML used as FQN expression
+// context (see buildContextFromPipelineYAML); pass "" to skip it.
 //
 // Conversion strategy:
 //   - The v0 inputSet.pipeline is converted to v1 inputs.overlay using the pipeline converter
@@ -48,8 +48,8 @@ func InputSet(yamlStr string, templateRefMapping, pipelineRefMapping map[string]
 	// Single-pass expression post-process. If the caller supplied a context
 	// pipeline_yaml, derive a step-type map and walk in FQN mode; otherwise
 	// fall back to nil context (no FQN).
-	stepTypeMap, useFQN := buildContextFromPipelineYAML(contextPipelineYAML)
-	pipelineconverter.PostProcessExpressions(v1InputSet, stepTypeMap, useFQN)
+	stepInfoByFQN, useFQN := buildContextFromPipelineYAML(contextPipelineYAML)
+	pipelineconverter.PostProcessExpressions(v1InputSet, stepInfoByFQN, useFQN)
 
 	yamlBytes, err := v1.MarshalInputSet(v1InputSet)
 	if err != nil {

--- a/service/converter/pipeline.go
+++ b/service/converter/pipeline.go
@@ -5,56 +5,41 @@ import (
 	"strings"
 	"sync"
 
+	convertexpressions "github.com/drone/go-convert/convert/convertexpressions"
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
 	pipelineconverter "github.com/drone/go-convert/convert/v0tov1/pipeline_converter"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
 )
 
-// buildContextFromPipelineYAML parses contextPipelineYAML as a v0 pipeline,
-// runs structural conversion (without expression post-processing) on a fresh
-// PipelineConverter, and returns the harvested step-type map. The boolean
-// useFQN reports whether the caller should pass useFQN=true to
-// PostProcessExpressions (true iff a usable map was built).
-//
-// Diagnostic messages emitted by the structural conversion of the context
-// pipeline are intentionally suppressed via the global MessageLogger so that
-// the caller's ConversionReport reflects only the requested entity. A
-// CONTEXT_PIPELINE_PARSE_FAILED warning is added when the YAML is non-empty
-// but unparseable; in that case the function returns (nil, false) so the
-// caller falls back to postprocess without FQN context.
-func buildContextFromPipelineYAML(contextPipelineYAML string) (map[string]*pipelineconverter.StepInfo, bool) {
+// buildContextFromPipelineYAML parses contextPipelineYAML as a v1 pipeline and
+// walks it into the FQN-keyed step-info map for ResolveStepFQN. The bool
+// reports whether a usable map was built (i.e. whether to enable FQN mode).
+// On non-empty but unparseable YAML it logs CONTEXT_PIPELINE_PARSE_FAILED and
+// returns (nil, false).
+func buildContextFromPipelineYAML(contextPipelineYAML string) (map[string]*convertexpressions.StepInfoFQN, bool) {
 	if strings.TrimSpace(contextPipelineYAML) == "" {
 		return nil, false
 	}
-	cfg, _, err := v0.ParseStringWithUnknownFields(contextPipelineYAML)
-	if err != nil || cfg == nil {
+	schema, err := v1.ParseString(contextPipelineYAML)
+	if err != nil || schema == nil || schema.Pipeline == nil {
 		errMsg := ""
 		if err != nil {
 			errMsg = err.Error()
 		}
 		pipelineconverter.GetMessageLogger().LogWarning(
 			"CONTEXT_PIPELINE_PARSE_FAILED",
-			"failed to parse 'pipeline_yaml' context; postprocess will run without FQN context",
+			"failed to parse 'pipeline_yaml' context as v1 pipeline; postprocess will run without FQN context",
 			pipelineconverter.WithContext(map[string]string{"error": errMsg}),
 		)
 		return nil, false
 	}
 
-	// Suppress messages emitted while structurally converting the context
-	// pipeline — they describe a pipeline the caller did not ask to convert
-	// and would otherwise pollute the ConversionReport.
-	msg := pipelineconverter.GetMessageLogger()
-	msg.Disable()
-	defer msg.Enable("")
-
-	ctxC := pipelineconverter.NewPipelineConverter()
-	_ = ctxC.ConvertPipeline(&cfg.Pipeline)
-	stepTypeMap := ctxC.GetStepTypeMap()
-	if len(stepTypeMap) == 0 {
+	stepInfoByFQN := buildStepInfoByFQNFromV1(schema.Pipeline)
+	if len(stepInfoByFQN) == 0 {
 		// No steps means nothing useful for FQN resolution; skip FQN mode.
 		return nil, false
 	}
-	return stepTypeMap, true
+	return stepInfoByFQN, true
 }
 
 // Result is the outcome of a successful conversion. YAML carries the
@@ -173,7 +158,7 @@ func Pipeline(yamlStr string, templateRefMapping, pipelineRefMapping map[string]
 	}
 
 	// Single-pass expression post-process with full pipeline context.
-	pipelineconverter.PostProcessExpressions(v1Pipeline, c.GetStepTypeMap(), true)
+	pipelineconverter.PostProcessExpressions(v1Pipeline, c.GetStepInfoByFQN(), true)
 
 	out, err := v1.MarshalPipeline(v1Pipeline)
 	if err != nil {

--- a/service/converter/template.go
+++ b/service/converter/template.go
@@ -14,9 +14,8 @@ import (
 // templateRefMapping rewrites template references in the output;
 // pipelineRefMapping rewrites pipeline identifiers (pipeline.id, chain.uses
 // pipeline segment). Either or both may be nil/empty.
-// contextPipelineYAML is an optional v0 pipeline YAML used purely as
-// expression-postprocess context (see buildContextFromPipelineYAML). Pass ""
-// to run postprocess without FQN context.
+// contextPipelineYAML is an optional v1 pipeline YAML used as FQN expression
+// context (see buildContextFromPipelineYAML); pass "" to skip it.
 func Template(yamlStr string, templateRefMapping, pipelineRefMapping map[string]string, contextPipelineYAML string) (*Result, error) {
 	if err := validateTopLevelKey(yamlStr, "template"); err != nil {
 		return nil, err
@@ -51,8 +50,8 @@ func Template(yamlStr string, templateRefMapping, pipelineRefMapping map[string]
 	// Single-pass expression post-process. If the caller supplied a context
 	// pipeline_yaml, derive a step-type map and walk in FQN mode; otherwise
 	// fall back to nil context (no FQN).
-	stepTypeMap, useFQN := buildContextFromPipelineYAML(contextPipelineYAML)
-	pipelineconverter.PostProcessExpressions(v1Template, stepTypeMap, useFQN)
+	stepInfoByFQN, useFQN := buildContextFromPipelineYAML(contextPipelineYAML)
+	pipelineconverter.PostProcessExpressions(v1Template, stepInfoByFQN, useFQN)
 
 	yamlBytes, err := v1.MarshalTemplate(v1Template)
 	if err != nil {

--- a/service/converter/trigger.go
+++ b/service/converter/trigger.go
@@ -14,11 +14,9 @@ import (
 // pipelineRefMapping rewrites pipeline identifiers (including the
 // trigger's pipelineIdentifier and any chain.uses inside the embedded
 // inputYaml). Either or both may be nil/empty.
-// contextPipelineYAML is an optional v0 pipeline YAML used purely as
-// expression-postprocess context (see buildContextFromPipelineYAML) for the
-// trigger wrapper. Pass "" to run postprocess without FQN context. The
-// trigger's embedded inputYaml is always post-processed in FQN mode using
-// its own inner pipeline as context (independent of this argument).
+// contextPipelineYAML is an optional v1 pipeline YAML used as FQN expression
+// context (see buildContextFromPipelineYAML) for the trigger wrapper and its
+// embedded inputYaml; pass "" to skip it.
 //
 // Conversion strategy:
 //   - The trigger structure remains mostly unchanged
@@ -40,16 +38,15 @@ func Trigger(yamlStr string, templateRefMapping, pipelineRefMapping map[string]s
 		return nil, fmt.Errorf("trigger parsing returned nil")
 	}
 
-
 	// Single-pass expression post-process on the wrapper. The embedded
 	// inputYaml string is post-processed inside ConvertTrigger before
 	// marshalling (the wrapper walk skips that field). If the caller
 	// supplied a context pipeline_yaml, derive a step-type map and walk in
 	// FQN mode; otherwise fall back to nil context (no FQN).
-	stepTypeMap, useFQN := buildContextFromPipelineYAML(contextPipelineYAML)
+	stepInfoByFQN, useFQN := buildContextFromPipelineYAML(contextPipelineYAML)
 	c := pipelineconverter.NewPipelineConverter()
-	
-	v1Trigger := c.ConvertTrigger(v0Config.Trigger, stepTypeMap, useFQN)
+
+	v1Trigger := c.ConvertTrigger(v0Config.Trigger, stepInfoByFQN, useFQN)
 	if v1Trigger == nil {
 		return nil, fmt.Errorf("trigger conversion returned nil")
 	}

--- a/service/grpc_handler.go
+++ b/service/grpc_handler.go
@@ -41,43 +41,40 @@ func (h *GRPCHandler) ConvertExpression(_ context.Context, req *pb.ExpressionCon
 		return nil, status.Error(codes.InvalidArgument, "one of 'expression', 'expressions', or 'remote_file' field is required")
 	}
 
-	// Build context — from context_pipeline_yaml if provided, otherwise manual.
+	// FQN-only context: v1 pipeline YAML plus optional call-site FQN.
 	var ctx *converter.ExpressionContext
 	if pipelineYAML := strings.TrimSpace(req.GetContextPipelineYaml()); pipelineYAML != "" {
-		ctx = converter.BuildContextFromPipeline(pipelineYAML)
-	} else if reqCtx := req.GetContext(); reqCtx != nil {
 		ctx = &converter.ExpressionContext{
-			CurrentStepID:     reqCtx.GetCurrentStepId(),
-			CurrentStepType:   reqCtx.GetCurrentStepType(),
-			CurrentStepV1Path: reqCtx.GetCurrentStepV1Path(),
-			StepTypeMap:       reqCtx.GetStepTypeMap(),
-			StepV1PathMap:     reqCtx.GetStepV1PathMap(),
-			UseFQN:            reqCtx.GetUseFqn(),
+			ContextPipelineYAML: pipelineYAML,
+			CurrentFQN:          req.GetCurrentFqn(),
 		}
 	}
 
 	// Handle remote file
 	if remoteFile != "" {
-		converted := converter.ConvertExpression(remoteFile, ctx)
+		converted, warnings := converter.ConvertExpressionWithWarnings(remoteFile, ctx)
 		return &pb.ExpressionConvertResponse{
 			RemoteFile: converted,
+			Warnings:   warnings,
 			Checksum:   Checksum([]byte(converted)),
 		}, nil
 	}
 
 	// Handle single expression
 	if expr != "" {
-		converted := converter.ConvertExpression(expr, ctx)
+		converted, warnings := converter.ConvertExpressionWithWarnings(expr, ctx)
 		return &pb.ExpressionConvertResponse{
 			Expression: converted,
+			Warnings:   warnings,
 			Checksum:   Checksum([]byte(converted)),
 		}, nil
 	}
 
 	// Handle multiple expressions
-	converted := converter.ConvertExpressions(exprs, ctx)
+	converted, warnings := converter.ConvertExpressionsWithWarnings(exprs, ctx)
 	return &pb.ExpressionConvertResponse{
 		Expressions: converted,
+		Warnings:    warnings,
 		Checksum:    checksumMap(converted),
 	}, nil
 }

--- a/service/handler.go
+++ b/service/handler.go
@@ -129,27 +129,21 @@ func (h *Handler) ConvertExpression(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build the expression context — from context_pipeline_yaml if provided,
-	// otherwise from manual Context fields.
+	// FQN-only context: v1 pipeline YAML plus optional call-site FQN.
 	var ctx *converter.ExpressionContext
-	if strings.TrimSpace(req.PipelineYAML) != "" {
-		ctx = converter.BuildContextFromPipeline(req.PipelineYAML)
-	} else if req.Context != nil {
+	if y := strings.TrimSpace(req.ContextPipelineYAML); y != "" {
 		ctx = &converter.ExpressionContext{
-			CurrentStepID:     req.Context.CurrentStepID,
-			CurrentStepType:   req.Context.CurrentStepType,
-			CurrentStepV1Path: req.Context.CurrentStepV1Path,
-			StepTypeMap:       req.Context.StepTypeMap,
-			StepV1PathMap:     req.Context.StepV1PathMap,
-			UseFQN:            req.Context.UseFQN,
+			ContextPipelineYAML: y,
+			CurrentFQN:          req.CurrentFQN,
 		}
 	}
 
 	// Handle remote file — scan for all <+...> expressions and convert them
 	if req.RemoteFile != "" {
-		converted := converter.ConvertExpression(req.RemoteFile, ctx)
+		converted, warnings := converter.ConvertExpressionWithWarnings(req.RemoteFile, ctx)
 		writeJSON(w, http.StatusOK, ExpressionConvertResponse{
 			RemoteFile: converted,
+			Warnings:   warnings,
 			Checksum:   Checksum([]byte(converted)),
 		})
 		return
@@ -157,19 +151,21 @@ func (h *Handler) ConvertExpression(w http.ResponseWriter, r *http.Request) {
 
 	// Handle single expression
 	if req.Expression != "" {
-		converted := converter.ConvertExpression(req.Expression, ctx)
+		converted, warnings := converter.ConvertExpressionWithWarnings(req.Expression, ctx)
 		writeJSON(w, http.StatusOK, ExpressionConvertResponse{
 			Expression: converted,
+			Warnings:   warnings,
 			Checksum:   Checksum([]byte(converted)),
 		})
 		return
 	}
 
 	// Handle multiple expressions
-	converted := converter.ConvertExpressions(req.Expressions, ctx)
+	converted, warnings := converter.ConvertExpressionsWithWarnings(req.Expressions, ctx)
 	mapBytes, _ := json.Marshal(converted)
 	writeJSON(w, http.StatusOK, ExpressionConvertResponse{
 		Expressions: converted,
+		Warnings:    warnings,
 		Checksum:    Checksum(mapBytes),
 	})
 }

--- a/service/request.go
+++ b/service/request.go
@@ -16,14 +16,10 @@ type ConvertRequest struct {
 	// recursively to the embedded `inputYaml`.
 	PipelineRefMapping map[string]string `json:"pipeline_ref_mapping,omitempty"`
 
-	// ContextPipelineYAML is an optional raw v0 pipeline YAML used purely as
-	// expression-postprocess context for template / input-set / trigger
-	// conversions. When provided the server parses + structurally converts
-	// this pipeline (suppressing its diagnostic messages), harvests the
-	// resulting step-type map, and uses it with FQN=true when walking the
-	// requested entity for expression conversion. The pipeline endpoint
-	// ignores this field. If empty (or omitted), postprocess runs without
-	// FQN context — equivalent to the previous behaviour.
+	// ContextPipelineYAML is an optional v1 pipeline YAML used as expression
+	// context for template / input-set / trigger conversions: it builds the
+	// FQN-keyed step lookup (StepInfoByFQN) and enables FQN mode. Ignored by
+	// the pipeline endpoint; if empty, postprocess runs without FQN context.
 	ContextPipelineYAML string `json:"context_pipeline_yaml,omitempty"`
 }
 
@@ -103,45 +99,17 @@ type ExpressionConvertRequest struct {
 	// Expressions is a list of expressions to convert (use this OR Expression, not both)
 	Expressions []string `json:"expressions,omitempty"`
 
-	// RemoteFile is the raw contents of a remote file (manifest, values.yaml,
-	// config, etc.) that may contain embedded Harness v0 expressions. The
-	// server scans the string for <+...> patterns and converts each one,
-	// returning the file with all expressions replaced.
+	// RemoteFile is raw file contents (manifest, values.yaml, etc.) with
+	// embedded Harness v0 expressions. The server converts every <+...> /
+	// ${{...}} occurrence and returns the file with all expressions replaced.
 	RemoteFile string `json:"remote_file,omitempty"`
 
-	// PipelineYAML is an optional raw v0 pipeline YAML string. When provided,
-	// the server parses and structurally converts this pipeline to derive the
-	// step-type map and v1 path map automatically — the same way pipeline,
-	// template, input-set, and trigger conversions build context. This
-	// supersedes manual Context fields (step_type_map, step_v1_path_map,
-	// use_fqn) when present.
-	PipelineYAML string `json:"context_pipeline_yaml,omitempty"`
+	// ContextPipelineYAML is an optional v1 pipeline YAML. When set, it builds
+	// the FQN-keyed step lookup (StepInfoByFQN) and enables FQN mode.
+	ContextPipelineYAML string `json:"context_pipeline_yaml,omitempty"`
 
-	// Context provides optional metadata for context-aware conversion.
-	// Ignored when context_pipeline_yaml is provided (context is derived automatically).
-	Context *ExpressionContextRequest `json:"context,omitempty"`
-}
-
-// ExpressionContextRequest holds the context needed for expression conversion.
-type ExpressionContextRequest struct {
-	// CurrentStepID is the ID of the current step we're inside (optional)
-	CurrentStepID string `json:"current_step_id,omitempty"`
-
-	// CurrentStepType is the type of the step we're currently inside (e.g., "Run", "Action", "Plugin")
-	CurrentStepType string `json:"current_step_type,omitempty"`
-
-	// CurrentStepV1Path is the v1 FQN base path to the current step
-	// Example: "pipeline.stages.build.steps.restoreCache"
-	CurrentStepV1Path string `json:"current_step_v1_path,omitempty"`
-
-	// StepTypeMap maps step ID to step type for all steps in the pipeline
-	StepTypeMap map[string]string `json:"step_type_map,omitempty"`
-
-	// StepV1PathMap maps step ID to its v1 FQN base path
-	StepV1PathMap map[string]string `json:"step_v1_path_map,omitempty"`
-
-	// UseFQN enables fully qualified name mode for step expressions
-	UseFQN bool `json:"use_fqn,omitempty"`
+	// CurrentFQN is the v1 FQN of callsite of the expression.
+	CurrentFQN string `json:"current_fqn,omitempty"`
 }
 
 // ExpressionConvertResponse is the response body for POST /api/v1/convert/expression.
@@ -154,6 +122,10 @@ type ExpressionConvertResponse struct {
 
 	// RemoteFile is the file contents with all embedded expressions converted
 	RemoteFile string `json:"remote_file,omitempty"`
+
+	// Warnings holds non-fatal diagnostics, e.g. ambiguous step types resolved
+	// via best-match fallback or unmapped template/approval uses.
+	Warnings []string `json:"warnings,omitempty"`
 
 	// Checksum is the SHA-256 checksum of the converted expression(s)
 	Checksum string `json:"checksum"`


### PR DESCRIPTION
## API contract changes
- **Context is now a v1 pipeline, not v0.** `context_pipeline_yaml` (on both the entity and expression endpoints) is parsed as a **v1** pipeline and used to build the step lookup directly, instead of structurally converting a v0 pipeline first.
- **Structure trimmed.** Removed the manual `Context` block from the expression request (`ExpressionContextRequest`: `current_step_id`, `current_step_type`, `current_step_v1_path`, `step_type_map`, `step_v1_path_map`, `use_fqn`) and the separate `PipelineYAML` field. Replaced with two fields:
  - `context_pipeline_yaml` — v1 pipeline that builds the FQN step lookup and enables FQN mode.
  - `current_fqn` — the v1 FQN of the step the expression lives in; derives the call-site (stage / step-group chain / step type) for `step.spec.*` resolution.
- **Warnings added** to `ExpressionConvertResponse` (REST + proto field 5, stubs regenerated): non-fatal diagnostics such as ambiguous step types resolved via best-match or unmapped template/approval `uses`.

## FQN-keyed step model (replaces the step-type / v1-path maps)
- Single source of truth: `ConversionContext.StepInfoByFQN` maps each step/step-group's **full v1 FQN** to its metadata (`StepID`, `StageID`, `Chain`, `Type`/`Types`). Lazy indexes (`stepsByStageStep`, `flatStepIDFQN`) are built once per context.
- `ResolveStepFQN` resolves a referenced step to its FQN with a clear outcome, replacing the old flat `stepID -> type/path` maps.

### Overlap on FQN (dynamic IDs)
Reference segments are matched against registered FQNs with an overlap rule that tolerates:
  - **matrix-expansion suffixes** (`prod_0` vs `prod`),
  - **dynamic `<+...>` substitutions** inside a segment (`LZ_<+x>` vs `LZ_Page`) via boundary-respecting prefix match in either direction,
  - **pure-dynamic segments** (`steps.<+expression>`) as a wildcard that matches any registered step at that position.

## CEL `${{ ... }}` support
- The scanner/converter now recognizes both `<+ ... >` and `${{ ... }}` delimiters (incl. same-style nesting and mixed occurrences in remote files), converting the inner expression and re-wrapping in its original delimiter.

## YAML conversions & fields added
- **Pipeline:** `allowStageExecutions`, `description`, `tags` (v0 → v1 `allow-stage-executions` / `description` / `tags`).
- **Stage:** propagate `tags`, move `timeout` out of `stage.spec`.
- **Output variables:** alias (Harness key) and name (shell var) handling;
- **Build & Push Docker:** `repo` derived as `<registryRef>/<repo>` for HAR case.

## Type resolution & v0 compatibility
- v1 context derives candidate v0 type(s) per step (`v1StepTypes`): single precise type when unambiguous, a clash-free family for run / run-test, HTTP detected by image, `nil` for unmapped `uses`.