### PR TITLE
update logging in the convert service to include entity metadata

### DIFF
--- a/convert/harness/yaml/runtime.go
+++ b/convert/harness/yaml/runtime.go
@@ -16,6 +16,8 @@ package yaml
 
 import (
 	"encoding/json"
+
+	"github.com/drone/go-convert/internal/flexible"
 )
 
 type Runtime struct {
@@ -25,13 +27,15 @@ type Runtime struct {
 
 // RuntimeCloudSpec defines the Cloud runtime spec
 type RuntimeCloudSpec struct {
-	Size      string         `json:"size,omitempty"      yaml:"size,omitempty"`
-	ImageSpec *ImageSpec     `json:"imageSpec,omitempty" yaml:"imageSpec,omitempty"`
+	Size                 string                `json:"size,omitempty"                 yaml:"size,omitempty"`
+	ImageSpec            *ImageSpec            `json:"imageSpec,omitempty"            yaml:"imageSpec,omitempty"`
+	NestedVirtualization *flexible.Field[bool] `json:"nestedVirtualization,omitempty" yaml:"nestedVirtualization,omitempty"`
 }
 
 // ImageSpec defines the image specification for Cloud runtime
 type ImageSpec struct {
 	ImageName string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	Connector string `json:"connectorRef,omitempty" yaml:"connectorRef,omitempty"`
 }
 
 // RuntimeDockerSpec defines the Docker runtime spec

--- a/convert/harness/yaml/service.go
+++ b/convert/harness/yaml/service.go
@@ -10,9 +10,10 @@ type (
 
 	// DeploymentService defines the service configuration for deployment
 	DeploymentService struct {
-		ServiceRef   string        `json:"serviceRef,omitempty"    yaml:"serviceRef,omitempty"`
-		UseFromStage *UseFromStage `json:"useFromStage,omitempty" yaml:"useFromStage,omitempty"`
-		ServiceInputs interface{} `json:"serviceInputs,omitempty" yaml:"serviceInputs,omitempty"`
+		ServiceRef    string        `json:"serviceRef,omitempty"    yaml:"serviceRef,omitempty"`
+		UseFromStage  *UseFromStage `json:"useFromStage,omitempty" yaml:"useFromStage,omitempty"`
+		ServiceInputs interface{}   `json:"serviceInputs,omitempty" yaml:"serviceInputs,omitempty"`
+		GitBranch     string        `json:"gitBranch,omitempty" yaml:"gitBranch,omitempty"`
 	}
 
 	DeploymentServiceConfig struct {

--- a/convert/harness/yaml/step.go
+++ b/convert/harness/yaml/step.go
@@ -78,11 +78,12 @@ type (
 
 	StepArtifactoryUpload struct {
 		CommonStepSpec
-		ConnRef    string               `json:"connectorRef,omitempty"    yaml:"connectorRef,omitempty"`
-		Target     string               `json:"target,omitempty"       yaml:"target,omitempty"`
-		SourcePath string               `json:"sourcePath,omitempty"   yaml:"sourcePath,omitempty"`
-		RunAsUser  *flexible.Field[int] `json:"runAsUser,omitempty"    yaml:"runAsUser,omitempty"`
-		Resources  *Resources           `json:"resources,omitempty"    yaml:"resources,omitempty"`
+		ConnRef      string                `json:"connectorRef,omitempty"    yaml:"connectorRef,omitempty"`
+		Target       string                `json:"target,omitempty"       yaml:"target,omitempty"`
+		SourcePath   string                `json:"sourcePath,omitempty"   yaml:"sourcePath,omitempty"`
+		RunAsUser    *flexible.Field[int]  `json:"runAsUser,omitempty"    yaml:"runAsUser,omitempty"`
+		UploadAsFlat *flexible.Field[bool] `json:"uploadAsFlat,omitempty" yaml:"uploadAsFlat,omitempty"`
+		Resources    *Resources            `json:"resources,omitempty"    yaml:"resources,omitempty"`
 	}
 
 	StepBarrier struct {
@@ -218,6 +219,7 @@ type (
 		ApprovalMessage                 string                `json:"approvalMessage,omitempty"                 yaml:"approvalMessage,omitempty"`
 		Approvers                       *Approvers            `json:"approvers,omitempty"                       yaml:"approvers,omitempty"`
 		ApproverInputs                  []*ApproverInput      `json:"approverInputs,omitempty"                  yaml:"approverInputs,omitempty"`
+		CallbackId                      string                `json:"callbackId,omitempty"                      yaml:"callbackId,omitempty"`
 		IncludePipelineExecutionHistory *flexible.Field[bool] `json:"includePipelineExecutionHistory,omitempty" yaml:"includePipelineExecutionHistory,omitempty"`
 		IsAutoRejectEnabled             *flexible.Field[bool] `json:"isAutoRejectEnabled,omitempty"             yaml:"isAutoRejectEnabled,omitempty"`
 		AutoApproval                    *AutoApproval         `json:"autoApproval,omitempty"                    yaml:"autoApproval,omitempty"`
@@ -259,6 +261,7 @@ type (
 		Key               string                `json:"key,omitempty"               yaml:"key,omitempty"`
 		ArchiveFormat     string                `json:"archiveFormat,omitempty"     yaml:"archiveFormat,omitempty"`
 		FailIfKeyNotFound *flexible.Field[bool] `json:"failIfKeyNotFound,omitempty" yaml:"failIfKeyNotFound,omitempty"`
+		PreserveMetadata  *flexible.Field[bool] `json:"preserveMetadata,omitempty"  yaml:"preserveMetadata,omitempty"`
 		RunAsUser         *flexible.Field[int]  `json:"runAsUser,omitempty"         yaml:"runAsUser,omitempty"`
 		Resources         *Resources            `json:"resources,omitempty"         yaml:"resources,omitempty"`
 	}
@@ -272,6 +275,7 @@ type (
 		Endpoint          string                `json:"endpoint,omitempty"          yaml:"endpoint,omitempty"`
 		ArchiveFormat     string                `json:"archiveFormat,omitempty"     yaml:"archiveFormat,omitempty"`
 		PathStyle         *flexible.Field[bool] `json:"pathStyle,omitempty"         yaml:"pathStyle,omitempty"`
+		PreserveMetadata  *flexible.Field[bool] `json:"preserveMetadata,omitempty"  yaml:"preserveMetadata,omitempty"`
 		FailIfKeyNotFound *flexible.Field[bool] `json:"failIfKeyNotFound,omitempty" yaml:"failIfKeyNotFound,omitempty"`
 		RunAsUser         *flexible.Field[int]  `json:"runAsUser,omitempty"         yaml:"runAsUser,omitempty"`
 		Resources         *Resources            `json:"resources,omitempty"         yaml:"resources,omitempty"`
@@ -349,6 +353,7 @@ type (
 		SourcePaths   *flexible.Field[[]string] `json:"sourcePaths,omitempty"   yaml:"sourcePaths,omitempty"`
 		ArchiveFormat string                    `json:"archiveFormat,omitempty" yaml:"archiveFormat,omitempty"`
 		Override      *flexible.Field[bool]     `json:"override,omitempty"      yaml:"override,omitempty"`
+		PreserveMetadata *flexible.Field[bool]  `json:"preserveMetadata,omitempty" yaml:"preserveMetadata,omitempty"`
 		RunAsUser     *flexible.Field[int]      `json:"runAsUser,omitempty"     yaml:"runAsUser,omitempty"`
 		Resources     *Resources                `json:"resources,omitempty"     yaml:"resources,omitempty"`
 	}
@@ -364,6 +369,7 @@ type (
 		ArchiveFormat string                    `json:"archiveFormat,omitempty" yaml:"archiveFormat,omitempty"`
 		Override      *flexible.Field[bool]     `json:"override,omitempty"      yaml:"override,omitempty"`
 		PathStyle     *flexible.Field[bool]     `json:"pathStyle,omitempty"     yaml:"pathStyle,omitempty"`
+		PreserveMetadata *flexible.Field[bool]  `json:"preserveMetadata,omitempty" yaml:"preserveMetadata,omitempty"`
 		RunAsUser     *flexible.Field[int]      `json:"runAsUser,omitempty"     yaml:"runAsUser,omitempty"`
 		Resources     *Resources                `json:"resources,omitempty"     yaml:"resources,omitempty"`
 	}
@@ -585,6 +591,7 @@ type (
 		Resources    *Resources           `json:"resources,omitempty"    yaml:"resources,omitempty"`
 		RunAsUser    *flexible.Field[int] `json:"runAsUser,omitempty"    yaml:"runAsUser,omitempty"`
 		SourcePath   string               `json:"sourcePath,omitempty"   yaml:"sourcePath,omitempty"`
+		StripPrefix  string    `json:"stripPrefix,omitempty"  yaml:"stripPrefix,omitempty"`
 		Target       string               `json:"target,omitempty"       yaml:"target,omitempty"`
 	}
 

--- a/convert/v0tov1/convert_helpers/convert_stage_ci.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_ci.go
@@ -57,12 +57,15 @@ func ConvertRuntime(runtime *v0.Runtime) *v1.Runtime {
 			// Convert image
 			if cloudSpec.ImageSpec != nil && cloudSpec.ImageSpec.ImageName != "" {
 				result.Cloud.Image = v1.MachineImage(cloudSpec.ImageSpec.ImageName)
+				result.Cloud.Connector = cloudSpec.ImageSpec.Connector
 			}
 
 			// Convert size - map "flex" to "xlarge" as per your example
 			if cloudSpec.Size != "" {
 				result.Cloud.Size = v1.MachineSize(cloudSpec.Size)
 			}
+
+			result.Cloud.Virtualization = cloudSpec.NestedVirtualization
 
 			return result
 		}

--- a/convert/v0tov1/convert_helpers/convert_stage_deployment.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_deployment.go
@@ -54,6 +54,7 @@ func ConvertDeploymentService(src *v0.DeploymentService, ctx *StageConversionCon
 		serviceItem := &v1.ServiceItem{
 			Id:   src.ServiceRef,
 			With: serviceWith,
+			Ref:  src.GitBranch,
 		}
 		return &v1.ServiceRef{
 			Items:        []*v1.ServiceItem{serviceItem},
@@ -121,6 +122,7 @@ func ConvertDeploymentServices(src *v0.DeploymentServices, ctx *StageConversionC
 			serviceItems = append(serviceItems, &v1.ServiceItem{
 				Id:   service.ServiceRef,
 				With: serviceWith,
+				Ref:  service.GitBranch,
 			})
 		}
 	}

--- a/convert/v0tov1/convert_helpers/convert_step_artifactory_upload.go
+++ b/convert/v0tov1/convert_helpers/convert_step_artifactory_upload.go
@@ -31,6 +31,10 @@ func ConvertStepArtifactoryUpload(src *v0.Step) *v1.StepTemplate {
 		with["source"] = spec.SourcePath
 	}
 
+	if spec.UploadAsFlat != nil {
+		with["upload_as_flat"] = *spec.UploadAsFlat
+	}
+
 	return &v1.StepTemplate{
 		Uses:      "uploadArtifactsToJfrogArtifactory",
 		With:      with,

--- a/convert/v0tov1/convert_helpers/convert_step_harness_approval.go
+++ b/convert/v0tov1/convert_helpers/convert_step_harness_approval.go
@@ -51,6 +51,11 @@ func ConvertStepHarnessApproval(src *v0.Step) *v1.StepApproval {
 	if spec.IsAutoRejectEnabled != nil {
 		dst.With["auto-reject"] = spec.IsAutoRejectEnabled
 	}
+	
+	// Map callbackId to callback
+	if spec.CallbackId != "" {
+		dst.With["callback"] = spec.CallbackId
+	}
 
 	// Map approvers fields
 	if spec.Approvers != nil {

--- a/convert/v0tov1/convert_helpers/convert_step_restore_cache_gcs.go
+++ b/convert/v0tov1/convert_helpers/convert_step_restore_cache_gcs.go
@@ -37,6 +37,10 @@ func ConvertStepRestoreCacheGCS(src *v0.Step) *v1.StepTemplate {
 		with["archive_format"] = strings.ToLower(spec.ArchiveFormat)
 	}
 
+	if spec.PreserveMetadata != nil {
+		with["preserve_metadata"] = spec.PreserveMetadata
+	}
+
 	// v1 renamed failIfKeyNotFound → fail_if_key_not_found
 	if spec.FailIfKeyNotFound != nil {
 		with["fail_if_key_not_found"] = spec.FailIfKeyNotFound

--- a/convert/v0tov1/convert_helpers/convert_step_restore_cache_s3.go
+++ b/convert/v0tov1/convert_helpers/convert_step_restore_cache_s3.go
@@ -47,6 +47,11 @@ func ConvertStepRestoreCacheS3(src *v0.Step) *v1.StepTemplate {
 	if spec.PathStyle != nil {
 		with["path_style"] = spec.PathStyle
 	}
+
+	if spec.PreserveMetadata != nil {
+		with["preserve_metadata"] = spec.PreserveMetadata
+	}
+
 	// v1 renamed failIfKeyNotFound → fail_if_key_not_found
 	if spec.FailIfKeyNotFound != nil {
 		with["fail_if_key_not_found"] = spec.FailIfKeyNotFound

--- a/convert/v0tov1/convert_helpers/convert_step_s3_upload.go
+++ b/convert/v0tov1/convert_helpers/convert_step_s3_upload.go
@@ -44,7 +44,7 @@ func ConvertStepS3Upload(src *v0.Step) *v1.StepTemplate {
 	}
 
 	if spec.StripPrefix != "" {
-		with["stripPrefix"] = spec.StripPrefix
+		with["stripprefix"] = spec.StripPrefix
 	}
 
 	return &v1.StepTemplate{

--- a/convert/v0tov1/convert_helpers/convert_step_s3_upload.go
+++ b/convert/v0tov1/convert_helpers/convert_step_s3_upload.go
@@ -43,6 +43,10 @@ func ConvertStepS3Upload(src *v0.Step) *v1.StepTemplate {
 		with["target"] = spec.Target
 	}
 
+	if spec.StripPrefix != "" {
+		with["stripPrefix"] = spec.StripPrefix
+	}
+
 	return &v1.StepTemplate{
 		Uses:      "uploadArtifactsToS3",
 		With:      with,

--- a/convert/v0tov1/convert_helpers/convert_step_save_cache_gcs.go
+++ b/convert/v0tov1/convert_helpers/convert_step_save_cache_gcs.go
@@ -45,6 +45,10 @@ func ConvertStepSaveCacheGCS(src *v0.Step) *v1.StepTemplate {
 		with["override"] = spec.Override
 	}
 
+	if spec.PreserveMetadata != nil {
+		with["preserve_metadata"] = spec.PreserveMetadata
+	}
+
 	return &v1.StepTemplate{
 		Uses:      "saveCacheToGCS",
 		With:      with,

--- a/convert/v0tov1/convert_helpers/convert_step_save_cache_s3.go
+++ b/convert/v0tov1/convert_helpers/convert_step_save_cache_s3.go
@@ -56,6 +56,10 @@ func ConvertStepSaveCacheS3(src *v0.Step) *v1.StepTemplate {
 		with["path_style"] = spec.PathStyle
 	}
 
+	if spec.PreserveMetadata != nil {
+		with["preserve_metadata"] = spec.PreserveMetadata
+	}
+
 	return &v1.StepTemplate{
 		Uses:      "saveCacheToS3",
 		With:      with,

--- a/convert/v0tov1/yaml/runtime_cloud.go
+++ b/convert/v0tov1/yaml/runtime_cloud.go
@@ -16,8 +16,12 @@
 
 package yaml
 
+import "github.com/drone/go-convert/internal/flexible"
+
 // RuntimeClone configures the cloud runtime environment.
 type RuntimeCloud struct {
-	Image MachineImage `json:"image,omitempty"`
-	Size  MachineSize  `json:"size,omitempty"`
+	Image          MachineImage          `json:"image,omitempty"`
+	Size           MachineSize           `json:"size,omitempty"`
+	Connector      string                `json:"connector,omitempty"`
+	Virtualization *flexible.Field[bool] `json:"virtualization,omitempty"`
 }

--- a/convert/v0tov1/yaml/service_ref.go
+++ b/convert/v0tov1/yaml/service_ref.go
@@ -25,6 +25,7 @@ import (
 type ServiceItem struct {
 	Id   string                 `json:"id,omitempty"`
 	With map[string]interface{} `json:"with,omitempty"`
+	Ref  string                 `json:"ref,omitempty"` // git branch reference
 }
 
 // UnmarshalJSON implements json.Unmarshaler for ServiceItem.
@@ -51,8 +52,8 @@ func (s *ServiceItem) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements json.Marshaler for ServiceItem.
 // Outputs: string "service1" if no With, or object {id: "service1", with: {...}} if With exists
 func (s ServiceItem) MarshalJSON() ([]byte, error) {
-	// If no With, marshal as simple string
-	if len(s.With) == 0 {
+	// If no With and no Ref, marshal as simple string
+	if len(s.With) == 0 && s.Ref == "" {
 		return json.Marshal(s.Id)
 	}
 	// Otherwise marshal as full object

--- a/service/grpc_handler.go
+++ b/service/grpc_handler.go
@@ -16,20 +16,20 @@ type GRPCHandler struct {
 	pb.UnimplementedGoConvertServiceServer
 }
 
-func (h *GRPCHandler) ConvertPipeline(_ context.Context, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
-	return h.convert(entityPipeline, req)
+func (h *GRPCHandler) ConvertPipeline(ctx context.Context, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
+	return h.convert(ctx, entityPipeline, req)
 }
 
-func (h *GRPCHandler) ConvertTemplate(_ context.Context, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
-	return h.convert(entityTemplate, req)
+func (h *GRPCHandler) ConvertTemplate(ctx context.Context, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
+	return h.convert(ctx, entityTemplate, req)
 }
 
-func (h *GRPCHandler) ConvertInputSet(_ context.Context, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
-	return h.convert(entityInputSet, req)
+func (h *GRPCHandler) ConvertInputSet(ctx context.Context, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
+	return h.convert(ctx, entityInputSet, req)
 }
 
-func (h *GRPCHandler) ConvertTrigger(_ context.Context, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
-	return h.convert(entityTrigger, req)
+func (h *GRPCHandler) ConvertTrigger(ctx context.Context, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
+	return h.convert(ctx, entityTrigger, req)
 }
 
 func (h *GRPCHandler) ConvertExpression(_ context.Context, req *pb.ExpressionConvertRequest) (*pb.ExpressionConvertResponse, error) {
@@ -94,10 +94,13 @@ func (h *GRPCHandler) GetChecksum(_ context.Context, req *pb.ChecksumRequest) (*
 	}, nil
 }
 
-func (h *GRPCHandler) convert(entityType string, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
+func (h *GRPCHandler) convert(ctx context.Context, entityType string, req *pb.ConvertRequest) (*pb.ConvertResponse, error) {
 	if strings.TrimSpace(req.GetYaml()) == "" {
 		return nil, status.Error(codes.InvalidArgument, "'yaml' field is required and must not be empty")
 	}
+
+	// Record entity metadata (account/org/project/id) for the gRPC log line.
+	setRequestMetadata(ctx, entityType, req.GetYaml())
 
 	res, err := dispatch(
 		entityType,

--- a/service/handler.go
+++ b/service/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -21,13 +22,19 @@ const (
 type Handler struct {
 	maxBatchSize int
 	maxYAMLBytes int64
+	logger       *slog.Logger
 }
 
-// NewHandler creates a Handler with the given limits.
-func NewHandler(maxBatchSize int, maxYAMLBytes int64) *Handler {
+// NewHandler creates a Handler with the given limits. logger may be nil, in
+// which case a no-op default logger is used.
+func NewHandler(maxBatchSize int, maxYAMLBytes int64, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Handler{
 		maxBatchSize: maxBatchSize,
 		maxYAMLBytes: maxYAMLBytes,
+		logger:       logger,
 	}
 }
 
@@ -77,6 +84,12 @@ func (h *Handler) ConvertBatch(w http.ResponseWriter, r *http.Request) {
 	results := make([]BatchResult, 0, len(req.Items))
 	for _, item := range req.Items {
 		result := BatchResult{ID: item.ID, EntityType: item.EntityType}
+
+		// Log per-item entity metadata; the request log line covers the batch
+		// as a whole but cannot represent the individual items.
+		meta := extractEntityMetadata(item.EntityType, item.YAML)
+		h.logger.Info("batch item", append([]any{"batch_item_id", item.ID}, meta.logAttrs()...)...)
+
 		res, err := dispatch(item.EntityType, item.YAML, item.TemplateRefMapping, item.PipelineRefMapping, item.ContextPipelineYAML)
 		if err != nil {
 			e := err.Error()
@@ -181,6 +194,9 @@ func (h *Handler) convertSingle(w http.ResponseWriter, r *http.Request, entityTy
 		writeError(w, http.StatusBadRequest, "MISSING_FIELD", "'yaml' field is required and must not be empty", nil)
 		return
 	}
+
+	// Record entity metadata (account/org/project/id) for the request log line.
+	setRequestMetadata(r.Context(), entityType, req.YAML)
 
 	res, err := dispatch(entityType, req.YAML, req.TemplateRefMapping, req.PipelineRefMapping, req.ContextPipelineYAML)
 	if err != nil {

--- a/service/metadata.go
+++ b/service/metadata.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"context"
+
+	"gopkg.in/yaml.v3"
+)
+
+// entityMetadata holds identifying fields parsed from an entity's YAML for
+// logging. Any field may be empty when it is absent or null in the YAML.
+type entityMetadata struct {
+	Account    string
+	Org        string
+	Project    string
+	EntityType string
+	EntityID   string
+}
+
+// metaFields captures the identifier fields common to every entity wrapper.
+// Pointers/strings default to empty when the key is absent or null.
+type metaFields struct {
+	Identifier        string `yaml:"identifier"`
+	AccountIdentifier string `yaml:"accountIdentifier"`
+	OrgIdentifier     string `yaml:"orgIdentifier"`
+	ProjectIdentifier string `yaml:"projectIdentifier"`
+}
+
+// metaEnvelope mirrors the top-level entity keys so a single lightweight parse
+// can extract metadata for any entity type without depending on the full v0
+// schema (which would fail on otherwise-recoverable YAML).
+type metaEnvelope struct {
+	Pipeline *metaFields `yaml:"pipeline"`
+	Template *metaFields `yaml:"template"`
+	InputSet *metaFields `yaml:"inputSet"`
+	Trigger  *metaFields `yaml:"trigger"`
+}
+
+// extractEntityMetadata best-effort parses yamlStr and returns the account,
+// org, project and entity identifiers for the given entity type. It never
+// fails: on a parse error or absent fields it returns whatever could be
+// determined (at minimum the entity type).
+func extractEntityMetadata(entityType, yamlStr string) entityMetadata {
+	meta := entityMetadata{EntityType: entityType}
+
+	var env metaEnvelope
+	if err := yaml.Unmarshal([]byte(yamlStr), &env); err != nil {
+		return meta
+	}
+
+	var f *metaFields
+	switch entityType {
+	case entityPipeline:
+		f = env.Pipeline
+	case entityTemplate:
+		f = env.Template
+	case entityInputSet:
+		f = env.InputSet
+	case entityTrigger:
+		f = env.Trigger
+	}
+
+	// Fallback: if the requested type wasn't present, use whichever wrapper
+	// the YAML actually contains so metadata is still captured.
+	if f == nil {
+		switch {
+		case env.Pipeline != nil:
+			f = env.Pipeline
+		case env.Template != nil:
+			f = env.Template
+		case env.InputSet != nil:
+			f = env.InputSet
+		case env.Trigger != nil:
+			f = env.Trigger
+		}
+	}
+
+	if f != nil {
+		meta.Account = f.AccountIdentifier
+		meta.Org = f.OrgIdentifier
+		meta.Project = f.ProjectIdentifier
+		meta.EntityID = f.Identifier
+	}
+	return meta
+}
+
+// logAttrs returns the metadata as slog key/value pairs. Empty values are
+// still emitted so log consumers can rely on a stable set of keys.
+func (m entityMetadata) logAttrs() []any {
+	return []any{
+		"entity_type", m.EntityType,
+		"account", m.Account,
+		"org", m.Org,
+		"project", m.Project,
+		"entity_id", m.EntityID,
+	}
+}
+
+// metadataCtxKey is the context key under which a *entityMetadata pointer is
+// stored by the logging middleware/interceptor and populated by the handler.
+const metadataCtxKey contextKey = "entityMetadata"
+
+// withMetadataSlot stores an empty metadata pointer in ctx for the handler to
+// populate, returning the new context and the pointer.
+func withMetadataSlot(ctx context.Context) (context.Context, *entityMetadata) {
+	m := &entityMetadata{}
+	return context.WithValue(ctx, metadataCtxKey, m), m
+}
+
+// setRequestMetadata populates the metadata slot in ctx (if present) with the
+// fields extracted from yamlStr for entityType.
+func setRequestMetadata(ctx context.Context, entityType, yamlStr string) {
+	m, ok := ctx.Value(metadataCtxKey).(*entityMetadata)
+	if !ok || m == nil {
+		return
+	}
+	*m = extractEntityMetadata(entityType, yamlStr)
+}

--- a/service/server.go
+++ b/service/server.go
@@ -25,7 +25,7 @@ type Server struct {
 // NewServer builds a Server that listens on the given HTTP port and gRPC port,
 // applying middleware (recovery → requestID → logging) before the HTTP handlers.
 func NewServer(port, grpcPort, maxBatchSize int, maxYAMLBytes int64, logger *slog.Logger) *Server {
-	h := NewHandler(maxBatchSize, maxYAMLBytes)
+	h := NewHandler(maxBatchSize, maxYAMLBytes, logger)
 	mux := buildMux(h)
 	wrapped := chain(mux,
 		recoveryMiddleware(logger),
@@ -185,31 +185,46 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 func grpcLoggingInterceptor(logger *slog.Logger) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		start := time.Now()
+		ctx, meta := withMetadataSlot(ctx)
 		resp, err := handler(ctx, req)
 		st, _ := status.FromError(err)
-		logger.Info("grpc request",
+		attrs := []any{
 			"method", info.FullMethod,
 			"code", st.Code().String(),
 			"latency_ms", time.Since(start).Milliseconds(),
-		)
+		}
+		if meta.EntityType != "" {
+			attrs = append(attrs, meta.logAttrs()...)
+		}
+		logger.Info("grpc request", attrs...)
 		return resp, err
 	}
 }
 
 // loggingMiddleware logs each request with method, path, status, and latency.
+// It also installs an entity-metadata slot in the request context that the
+// conversion handlers populate (account, org, project, entity type/id); those
+// fields are emitted on the request log line when present.
 func loggingMiddleware(logger *slog.Logger) middlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
-			next.ServeHTTP(rw, r)
-			logger.Info("request",
+
+			ctx, meta := withMetadataSlot(r.Context())
+			next.ServeHTTP(rw, r.WithContext(ctx))
+
+			attrs := []any{
 				"method", r.Method,
 				"path", r.URL.Path,
 				"status", rw.status,
 				"latency_ms", time.Since(start).Milliseconds(),
 				"request_id", r.Context().Value(requestIDCtxKey),
-			)
+			}
+			if meta.EntityType != "" {
+				attrs = append(attrs, meta.logAttrs()...)
+			}
+			logger.Info("request", attrs...)
 		})
 	}
 }


### PR DESCRIPTION

## Cloud runtime: connector & virtualization
v0 `runtime.spec` now carries `imageSpec.connectorRef` and `nestedVirtualization`; v1 `RuntimeCloud` gains `connector` and `virtualization`.

```yaml
# v0
runtime:
  type: Cloud
  spec:
    nestedVirtualization: true
    imageSpec: { imageName: ubuntu, connectorRef: my_conn }
# v1
clone: ...
runtime:
  cloud:
    image: ubuntu
    connector: my_conn
    virtualization: true
```

## Deployment service git branch
v0 `service.gitBranch` maps to the v1 service item `ref`. A service item with a `ref` is emitted as an object (not a bare string).

```yaml
# v0
service: { serviceRef: svc1, gitBranch: main }
# v1
services:
  - id: svc1
    ref: main
```

## New step `with` fields
Additional v0 spec fields are now passed through to the v1 template `with` map:

- **Artifactory Upload** — `uploadAsFlat` → `upload_as_flat`
- **S3 Upload** — `stripPrefix` → `stripprefix`
- **Save/Restore Cache (S3 & GCS)** — `preserveMetadata` → `preserve_metadata`
- **Harness Approval** — `callbackId` → `callback`

```yaml
# v0 RestoreCacheS3
spec: { preserveMetadata: true }
# v1
with: { preserve_metadata: true }
```

# Service: per-request entity logging

Request/gRPC log lines are now enriched with entity metadata parsed from the
submitted YAML. New `service/metadata.go` best-effort extracts `account`, `org`,
`project`, `entity_type` and `entity_id` without depending on the full v0
schema, and never fails on malformed YAML.

- Logging middleware/interceptor install a metadata slot in the request context.
- `convertSingle` / gRPC `convert` populate it via `setRequestMetadata`.
- `ConvertBatch` logs per-item metadata (`batch_item` line) since the request
  line covers the batch as a whole.
- `NewHandler` now takes a `*slog.Logger` (nil → `slog.Default()`).

```
level=INFO msg=request method=POST path=/convert/pipeline status=200 \
  latency_ms=12 request_id=... entity_type=pipeline account=acct1 \
  org=org1 project=proj1 entity_id=my_pipeline

level=INFO msg="batch item" batch_item_id=1 entity_type=template \
  account=acct1 org=org1 project=proj1 entity_id=my_template
```