### PR TITLE
fix(jenkinsxml): prevent nil-panic and broaden job coverage

### DIFF
--- a/convert/jenkinsxml/convert.go
+++ b/convert/jenkinsxml/convert.go
@@ -20,7 +20,9 @@ import (
 	"encoding/xml"
 	"io"
 	"os"
+	"strings"
 
+	harnessconv "github.com/drone/go-convert/convert/harness"
 	jenkinsxml "github.com/drone/go-convert/convert/jenkinsxml/xml"
 	"github.com/drone/go-convert/internal/store"
 	harness "github.com/drone/spec/dist/go"
@@ -135,7 +137,21 @@ func (d *Converter) convert(ctx *context) ([]byte, error) {
 	dst.Stages = append(dst.Stages, dstStage)
 	stageSteps := make([]*harness.Step, 0)
 
-	tasks := ctx.config.Builders.Tasks
+	// emit a git clone step first when the job uses a Git SCM. The
+	// downgrader lifts this step's url into the pipeline codebase, so it
+	// must be the first step in the stage.
+	if step := convertSCMToStep(ctx.config); step != nil {
+		stageSteps = append(stageSteps, step)
+	}
+
+	// Builders is nil for job types that do not use a freestyle
+	// <builders> block (for example maven2-moduleset or scripted
+	// flow-definition pipelines). Guard against a nil dereference and
+	// emit a pipeline with no steps rather than panicking.
+	var tasks []jenkinsxml.Task
+	if ctx.config.Builders != nil {
+		tasks = ctx.config.Builders.Tasks
+	}
 	for _, task := range tasks {
 		step := &harness.Step{}
 
@@ -150,7 +166,20 @@ func (d *Converter) convert(ctx *context) ([]byte, error) {
 
 		stageSteps = append(stageSteps, step)
 	}
+
+	// maven2-moduleset jobs declare their build via top-level <goals>
+	// rather than a <builders> block. Emit an mvn step so these jobs
+	// convert to a runnable pipeline instead of an empty stage.
+	if step := convertMavenGoalsToStep(ctx.config); step != nil {
+		stageSteps = append(stageSteps, step)
+	}
+
 	dstStage.Spec.(*harness.StageCI).Steps = stageSteps
+
+	// map Jenkins string build parameters to pipeline inputs.
+	if inputs := convertParameters(ctx.config); len(inputs) > 0 {
+		dst.Inputs = inputs
+	}
 
 	// marshal the harness yaml
 	out, err := yaml.Marshal(config)
@@ -159,6 +188,77 @@ func (d *Converter) convert(ctx *context) ([]byte, error) {
 	}
 
 	return out, nil
+}
+
+// convertSCMToStep converts a Jenkins Git SCM to a Harness git clone
+// plugin step. It returns nil when the job has no Git SCM (the only SCM
+// type modelled today). The branch ref is stripped of Jenkins' "*/"
+// prefix (for example "*/master" becomes "master").
+func convertSCMToStep(project *jenkinsxml.Project) *harness.Step {
+	if project == nil || project.SCM == nil {
+		return nil
+	}
+	scm := project.SCM
+	if scm.Class != "hudson.plugins.git.GitSCM" || len(scm.RemoteURLs) == 0 {
+		return nil
+	}
+
+	with := map[string]interface{}{
+		"git_url": scm.RemoteURLs[0],
+	}
+	if len(scm.BranchNames) > 0 {
+		with["branch"] = strings.TrimPrefix(scm.BranchNames[0], "*/")
+	}
+
+	spec := &harness.StepPlugin{
+		Image: harnessconv.GitPluginImage,
+		With:  with,
+	}
+	return &harness.Step{
+		Name: "clone",
+		Type: "plugin",
+		Spec: spec,
+	}
+}
+
+// convertParameters maps Jenkins string build parameters to Harness
+// pipeline inputs. It returns nil when the job declares no parameters.
+func convertParameters(project *jenkinsxml.Project) map[string]*harness.Input {
+	if project == nil || len(project.Parameters) == 0 {
+		return nil
+	}
+
+	inputs := make(map[string]*harness.Input, len(project.Parameters))
+	for _, param := range project.Parameters {
+		if param.Name == "" {
+			continue
+		}
+		inputs[param.Name] = &harness.Input{
+			Type:        "string",
+			Description: param.Description,
+			Default:     param.DefaultValue,
+		}
+	}
+	return inputs
+}
+
+// convertMavenGoalsToStep converts the top-level <goals> of a
+// maven2-moduleset job to a Harness Run step. It returns nil when the
+// project declares no Maven goals (for example a freestyle job).
+func convertMavenGoalsToStep(project *jenkinsxml.Project) *harness.Step {
+	if project == nil || project.Goals == "" {
+		return nil
+	}
+
+	spec := new(harness.StepExec)
+	spec.Run = "mvn " + project.Goals
+	step := &harness.Step{
+		Name: "maven",
+		Type: "script",
+		Spec: spec,
+	}
+
+	return step
 }
 
 // convertAntTaskToStep converts a Jenkins Ant task to a Harness step.

--- a/convert/jenkinsxml/convert_test.go
+++ b/convert/jenkinsxml/convert_test.go
@@ -15,6 +15,7 @@
 package jenkinsxml
 
 import (
+	"bytes"
 	"encoding/xml"
 	"io/ioutil"
 	"testing"
@@ -25,6 +26,89 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
 )
+
+// TestConvertNoBuilders verifies that a job without a freestyle <builders>
+// block (for example a maven2-moduleset or scripted flow-definition) converts
+// without panicking on a nil Builders dereference.
+func TestConvertNoBuilders(t *testing.T) {
+	converter := New()
+	out, err := converter.ConvertFile("testdata/no-builders.xml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	got := map[string]interface{}{}
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Error(err)
+		return
+	}
+
+	// a builders-less job should still yield a pipeline resource.
+	if kind, _ := got["kind"].(string); kind != "pipeline" {
+		t.Errorf("expected kind: pipeline, got %q", kind)
+	}
+}
+
+// TestConvertMavenGoals verifies that a maven2-moduleset job converts its
+// top-level <goals> into an mvn step instead of an empty stage.
+func TestConvertMavenGoals(t *testing.T) {
+	out, err := New().ConvertFile("testdata/maven.xml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if !bytes.Contains(out, []byte("mvn clean install")) {
+		t.Errorf("expected an 'mvn clean install' step in the output, got:\n%s", out)
+	}
+}
+
+// TestConvertSCM verifies that a Jenkins Git SCM converts to a git clone
+// step carrying the remote url and the branch (stripped of the "*/" prefix).
+func TestConvertSCM(t *testing.T) {
+	out, err := New().ConvertFile("testdata/scm.xml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if !bytes.Contains(out, []byte("https://git.example.com/scm/team/order-service.git")) {
+		t.Errorf("expected the git url in the output, got:\n%s", out)
+	}
+	if !bytes.Contains(out, []byte("master")) || bytes.Contains(out, []byte("*/master")) {
+		t.Errorf("expected branch \"master\" (prefix stripped) in the output, got:\n%s", out)
+	}
+}
+
+// TestConvertParameters verifies that Jenkins string build parameters are
+// mapped to pipeline inputs with their default values.
+func TestConvertParameters(t *testing.T) {
+	out, err := New().ConvertFile("testdata/parameters.xml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	got := map[string]interface{}{}
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Error(err)
+		return
+	}
+
+	spec, _ := got["spec"].(map[string]interface{})
+	inputs, ok := spec["inputs"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected inputs in the converted output, got:\n%s", out)
+	}
+	release, ok := inputs["RELEASE"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a RELEASE input, got: %v", inputs)
+	}
+	if release["default"] != "master" {
+		t.Errorf("expected RELEASE default \"master\", got %q", release["default"])
+	}
+}
 
 // TODO: add more teste in subdirectories, as we have for other providers
 func TestConvert(t *testing.T) {

--- a/convert/jenkinsxml/testdata/maven.xml
+++ b/convert/jenkinsxml/testdata/maven.xml
@@ -1,0 +1,7 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<maven2-moduleset plugin="maven-plugin@3.27">
+  <description>maven module-set job</description>
+  <jdk>Linux-jdk21</jdk>
+  <goals>clean install</goals>
+  <mavenName>Maven 3.6.3</mavenName>
+</maven2-moduleset>

--- a/convert/jenkinsxml/testdata/no-builders.xml
+++ b/convert/jenkinsxml/testdata/no-builders.xml
@@ -1,0 +1,8 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<maven2-moduleset plugin="maven-plugin@3.27">
+  <actions/>
+  <description>job without a freestyle builders block</description>
+  <keepDependencies>false</keepDependencies>
+  <scm class="hudson.scm.NullSCM"/>
+  <goals>clean install</goals>
+</maven2-moduleset>

--- a/convert/jenkinsxml/testdata/parameters.xml
+++ b/convert/jenkinsxml/testdata/parameters.xml
@@ -1,0 +1,19 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>RELEASE</name>
+          <description>release branch</description>
+          <defaultValue>master</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>SRC_COMP</name>
+          <defaultValue>ms-genericconfig</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <builders/>
+</project>

--- a/convert/jenkinsxml/testdata/scm.xml
+++ b/convert/jenkinsxml/testdata/scm.xml
@@ -1,0 +1,16 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@5.7.0">
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>https://git.example.com/scm/team/order-service.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>*/master</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+  </scm>
+  <builders/>
+</project>

--- a/convert/jenkinsxml/xml/parse_test.go
+++ b/convert/jenkinsxml/xml/parse_test.go
@@ -57,6 +57,7 @@ func TestParseFile(t *testing.T) {
 
 	want = &Project{
 		Disabled: false,
+		SCM:      &SCM{Class: "hudson.scm.NullSCM"},
 		Builders: &Builders{
 			Tasks: []Task{
 				{

--- a/convert/jenkinsxml/xml/project.go
+++ b/convert/jenkinsxml/xml/project.go
@@ -22,5 +22,36 @@ type (
 		Disabled        bool `xml:"disabled,omitempty"`
 
 		Builders *Builders `xml:"builders"`
+
+		// Maven module-set jobs (<maven2-moduleset>) carry their build
+		// definition in these top-level elements rather than in a
+		// freestyle <builders> block.
+		Goals     string `xml:"goals,omitempty"`
+		MavenName string `xml:"mavenName,omitempty"`
+		JDK       string `xml:"jdk,omitempty"`
+
+		// Parameters declares the job's build parameters.
+		Parameters []StringParameter `xml:"properties>hudson.model.ParametersDefinitionProperty>parameterDefinitions>hudson.model.StringParameterDefinition"`
+
+		// SCM is the source control configuration. Only the Git SCM
+		// (hudson.plugins.git.GitSCM) is modelled today.
+		SCM *SCM `xml:"scm"`
+	}
+
+	// SCM models a Jenkins source control configuration. The XML class
+	// attribute (for example hudson.plugins.git.GitSCM) is captured so the
+	// converter can distinguish git from other SCM types.
+	SCM struct {
+		Class       string   `xml:"class,attr"`
+		RemoteURLs  []string `xml:"userRemoteConfigs>hudson.plugins.git.UserRemoteConfig>url"`
+		BranchNames []string `xml:"branches>hudson.plugins.git.BranchSpec>name"`
+	}
+
+	// StringParameter is a Jenkins string build parameter
+	// (hudson.model.StringParameterDefinition).
+	StringParameter struct {
+		Name         string `xml:"name"`
+		Description  string `xml:"description,omitempty"`
+		DefaultValue string `xml:"defaultValue,omitempty"`
 	}
 )


### PR DESCRIPTION
## Summary

The `convert/jenkinsxml` converter panicked on any Jenkins job without a freestyle `<builders>` block, and silently dropped most of the job config it did parse. This PR fixes the crash and broadens coverage for the common cases.

Found while converting real-world Jenkins jobs (Maven module-sets and scripted pipelines) that crashed the tool.

## Crash fix

`convert()` dereferenced `ctx.config.Builders.Tasks`, but `Builders` is a nil `*Builders` for any job type without a freestyle `<builders>` block, for example `<maven2-moduleset>` (Maven jobs) and `<flow-definition>` (scripted pipelines). Both panicked. Now nil-guarded; such jobs produce a valid pipeline instead of crashing.

## Coverage

The parser (`xml/project.go`) previously only unmarshalled `concurrentBuild`, `disabled`, and `builders`, so SCM, parameters, and Maven goals were never available to convert. Extended:

- **Git SCM** (`hudson.plugins.git.GitSCM`): parse `userRemoteConfigs/url` + `branches/name` and emit a git-clone plugin step first, which the downgrader lifts into the pipeline codebase. Branch refs are normalized (`*/master` -> `master`).
- **maven2-moduleset `<goals>`**: emit an `mvn <goals>` Run step instead of an empty stage.
- **`StringParameterDefinition`**: map to v1 pipeline `inputs` (type/description/default).

## Tests

Adds `TestConvertNoBuilders`, `TestConvertMavenGoals`, `TestConvertParameters`, `TestConvertSCM` and testdata. Updates the existing parse test for the newly-captured `<scm>` element. Full `go-convert` suite passes.

## Notes / out of scope

- Jenkins triggers (timer/SCM-poll/GitHub-push) are not emitted: the v1 pipeline spec has no trigger type (Harness triggers are separate entities).
- Scripted `flow-definition` jobs keep their SCM nested under `<definition><scm>`; only top-level `<scm>` is read here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)