### PR TITLE
fix: [CI-23140]: fix conversion of run as user for git clone

### DIFF
--- a/convert/v0tov1/convert_helpers/convert_step_git_clone.go
+++ b/convert/v0tov1/convert_helpers/convert_step_git_clone.go
@@ -135,13 +135,24 @@ func ConvertStepGitClone(src *v0.Step) *v1.StepTemplate {
 		}
 	}
 
+	// runAsUser maps to the gitCloneStep template's `user` input. A template invocation
+	// accepts only uses/with/gitBranch (no container), so the UID must go through `with`.
+	// The template input `user` is typed as string, so unwrap the v0 int/expression to a string.
+	if sp.RunAsUser != nil && !sp.RunAsUser.IsNil() {
+		if user, ok := sp.RunAsUser.AsString(); ok {
+			with["user"] = user
+		} else if user, ok := sp.RunAsUser.AsStruct(); ok {
+			with["user"] = fmt.Sprintf("%d", user)
+		}
+	}
+
 	// pr_merge_strategy: no v0 StepGitClone field; template default is "Source Branch"
 	// copy_file_content: no v0 StepGitClone field; optional template input with no default
 
 	dst := &v1.StepTemplate{
 		Uses:      "gitCloneStep",
 		With:      with,
-		Container: ConvertTemplateContainer(sp.RunAsUser, sp.Resources),
+		Container: ConvertTemplateContainer(nil, sp.Resources),
 	}
 
 	return dst

--- a/convert/v0tov1/convert_helpers/convert_step_git_clone_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_git_clone_test.go
@@ -175,6 +175,45 @@ func TestConvertStepGitClone(t *testing.T) {
 				"file_paths_content": "file1.txt,file2.txt",
 			},
 		},
+		{
+			name: "runAsUser integer value maps to with.user as string",
+			step: &v0.Step{
+				Spec: &v0.StepGitClone{
+					ConnRef:   "github-connector",
+					RunAsUser: &flexible.Field[int]{Value: 1600},
+				},
+			},
+			expected: map[string]interface{}{
+				"connector": "github-connector",
+				"user":      "1600",
+			},
+		},
+		{
+			name: "runAsUser zero (root) is preserved",
+			step: &v0.Step{
+				Spec: &v0.StepGitClone{
+					ConnRef:   "github-connector",
+					RunAsUser: &flexible.Field[int]{Value: 0},
+				},
+			},
+			expected: map[string]interface{}{
+				"connector": "github-connector",
+				"user":      "0",
+			},
+		},
+		{
+			name: "runAsUser expression passes through",
+			step: &v0.Step{
+				Spec: &v0.StepGitClone{
+					ConnRef:   "github-connector",
+					RunAsUser: &flexible.Field[int]{Value: "<+input>"},
+				},
+			},
+			expected: map[string]interface{}{
+				"connector": "github-connector",
+				"user":      "<+input>",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# fix: [CI-23140]: Convert v0 runAsUser to correct v1 format for git clone

## Summary

When converting v0 pipelines to v1, the explicit **GitClone** step dropped `runAsUser`. The converter emitted the UID under `template.container.user`, but a v1 template invocation only accepts `uses` / `with` / `gitBranch` — so `container` was ignored by the backend and the clone ran as root.

This PR routes the UID through the template's `user` input (`with.user`) instead, matching the updated `gitCloneStep` / `harnessCodeCloneStep` templates. `resources` handling is unchanged.

## Changes

- `convert/v0tov1/convert_helpers/convert_step_git_clone.go`
  - Map v0 `runAsUser` → `with.user` (string), instead of the invalid `template.container.user`.
  - Preserve `runAsUser: 0` (root) and pass expressions (e.g. `<+input>`) through unchanged.
  - `resources` continues to flow as before (no functional change to it).
- `convert/v0tov1/convert_helpers/convert_step_git_clone_test.go`
  - Added cases for integer UID, `0` (root), and expression values.

## Behavior

| Path | v0 input | v1 output |
|---|---|---|
| Implicit clone | `codebase.runAsUser: 1005` | `clone.user: 1005` (already correct) |
| Run step | `spec.runAsUser: 1600` | `run.container.user: 1600` (already correct) |
| Explicit GitClone | `GitClone spec.runAsUser: 1700` | `template.with.user: "1700"` (**fixed**) |
| Explicit GitClone (expr) | `runAsUser: <+input>` | `with.user: <+input>` (**fixed**) |

## Test plan

- [x] `go build ./...`
- [x] `go test ./convert/v0tov1/...` (all green)
- [x] Converted a sample v0 pipeline covering all three paths; verified explicit clone emits `with.user` and no `container` block on the template invocation.

[CI-23140]: https://harness.atlassian.net/browse/CI-23140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ