### PR TITLE
update template conversion, add service type, HTML escaping for action step with conversion

### DIFF
--- a/convert/harness/yaml/template.go
+++ b/convert/harness/yaml/template.go
@@ -3,6 +3,8 @@ package yaml
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/drone/go-convert/internal/flexible"
 )
 
 type (
@@ -14,6 +16,8 @@ type (
 		Project      string      `json:"projectIdentifier,omitempty" yaml:"projectIdentifier,omitempty"`
 		Org          string      `json:"orgIdentifier,omitempty"     yaml:"orgIdentifier,omitempty"`
 		Spec         interface{} `json:"spec,omitempty"              yaml:"spec,omitempty"`
+		Description  string      `json:"description,omitempty"       yaml:"description,omitempty"`
+		Tags         *flexible.Field[map[string]string] `json:"tags,omitempty"                 yaml:"tags,omitempty"`
 	}
 )
 

--- a/convert/v0tov1/convert_helpers/convert_step_action.go
+++ b/convert/v0tov1/convert_helpers/convert_step_action.go
@@ -15,8 +15,11 @@
 package converthelpers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
 	"github.com/drone/go-convert/internal/flexible"
@@ -44,11 +47,17 @@ func ConvertStepAction(src *v0.Step) *v1.StepRun {
 	// forms (see drone/plugin plugin/github/env.go getWith), and the JSON
 	// form is unambiguous.
 	if len(spec.With) > 0 {
-		withJSON, err := json.Marshal(spec.With)
-		if err != nil {
+		// Disable HTML escaping so Harness expressions like
+		// <+pipeline.variables.checkLatest> aren't mangled into
+		// \u003c+...\u003e by the default json.Marshal behavior.
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(spec.With); err != nil {
 			return nil
 		}
-		env_map["PLUGIN_WITH"] = string(withJSON)
+		// Encode appends a trailing newline; trim it.
+		env_map["PLUGIN_WITH"] = strings.TrimRight(buf.String(), "\n")
 	}
 	for k, v := range spec.Envs {
 		env_map[k] = v

--- a/convert/v0tov1/convert_helpers/convert_step_action_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_action_test.go
@@ -2,6 +2,7 @@ package converthelpers
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
@@ -169,6 +170,40 @@ func TestConvertStepAction(t *testing.T) {
 				t.Errorf("Extra env mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestConvertStepAction_PluginWithNotHTMLEscaped(t *testing.T) {
+	step := &v0.Step{
+		Spec: &v0.StepAction{
+			Uses: "actions/setup-go@v4",
+			With: map[string]interface{}{
+				"check-latest": "<+pipeline.variables.checkLatest>",
+				"go-version":   "1.20.1",
+			},
+		},
+	}
+
+	result := ConvertStepAction(step)
+	if result == nil || result.Env == nil {
+		t.Fatal("expected non-nil result with Env")
+	}
+
+	got, ok := result.Env.Value.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Env.Value is %T, expected map[string]interface{}", result.Env.Value)
+	}
+
+	rawJSON, ok := got["PLUGIN_WITH"].(string)
+	if !ok {
+		t.Fatalf("expected PLUGIN_WITH string entry, got %v", got["PLUGIN_WITH"])
+	}
+
+	if strings.Contains(rawJSON, `\u003c`) || strings.Contains(rawJSON, `\u003e`) {
+		t.Errorf("PLUGIN_WITH should not HTML-escape expressions, got: %s", rawJSON)
+	}
+	if !strings.Contains(rawJSON, "<+pipeline.variables.checkLatest>") {
+		t.Errorf("PLUGIN_WITH should contain the raw expression, got: %s", rawJSON)
 	}
 }
 

--- a/convert/v0tov1/pipeline_converter/convert_stage.go
+++ b/convert/v0tov1/pipeline_converter/convert_stage.go
@@ -236,6 +236,12 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 					WithStage(src.ID, string(v0.StageTypeDeployment)),
 				)
 			}
+
+			// Map v0 deploymentType onto the v1 service ref type.
+			if stage.Service != nil && spec.DeploymentType != "" {
+				stage.Service.Type = spec.DeploymentType
+			}
+
 		}
 
 	case v0.StageTypePipeline:

--- a/convert/v0tov1/pipeline_converter/convert_template.go
+++ b/convert/v0tov1/pipeline_converter/convert_template.go
@@ -11,7 +11,13 @@ func (c *PipelineConverter) ConvertTemplate(src *v0.Template) *v1.Template {
 		return nil
 	}
 
-	dst := &v1.Template{}
+	dst := &v1.Template{
+		ID: src.ID,
+		Name: src.Name,
+		Description: src.Description,
+		Tags: src.Tags,
+		Version: src.VersionLabel,
+	}
 	// Based on the type of template, convert it
 	switch src.Type {
 	case "Stage":

--- a/convert/v0tov1/yaml/service_ref.go
+++ b/convert/v0tov1/yaml/service_ref.go
@@ -26,7 +26,8 @@ type ServiceItem struct {
 	Id   string                 `json:"id,omitempty"`
 	With map[string]interface{} `json:"with,omitempty"`
 	Ref  string                 `json:"ref,omitempty"` // git branch reference
-}
+	Type string                 `json:"type,omitempty"` // Deployment Type: Kubernetes, Helm, etc.
+}	
 
 // UnmarshalJSON implements json.Unmarshaler for ServiceItem.
 // Handles: string "service1" or object {id: "service1", with: {...}}
@@ -53,7 +54,7 @@ func (s *ServiceItem) UnmarshalJSON(data []byte) error {
 // Outputs: string "service1" if no With, or object {id: "service1", with: {...}} if With exists
 func (s ServiceItem) MarshalJSON() ([]byte, error) {
 	// If no With and no Ref, marshal as simple string
-	if len(s.With) == 0 && s.Ref == "" {
+	if len(s.With) == 0 && s.Ref == ""  && s.Type == "" {
 		return json.Marshal(s.Id)
 	}
 	// Otherwise marshal as full object
@@ -62,6 +63,7 @@ func (s ServiceItem) MarshalJSON() ([]byte, error) {
 }
 
 type ServiceRef struct {
+	Type string `json:"type,omitempty"` // Deployment Type: Kubernetes, Helm, etc.
 	Items        []*ServiceItem        `json:"items,omitempty"`
 	Sequential   *flexible.Field[bool] `json:"sequential,omitempty"`
 	MultiService bool                  `json:"-"` // Don't serialize this field
@@ -117,7 +119,11 @@ func (v *ServiceRef) UnmarshalJSON(data []byte) error {
 func (v *ServiceRef) MarshalJSON() ([]byte, error) {
 	// Single item without With and not forced to be multi-service
 	if len(v.Items) == 1 && !v.MultiService && v.Sequential == nil {
-		return json.Marshal(v.Items[0])
+		item := v.Items[0]
+		if item.Type == "" {
+			item.Type = v.Type
+		}
+		return json.Marshal(item)
 	}
 
 	// Multi-service - always use items format

--- a/convert/v0tov1/yaml/template.go
+++ b/convert/v0tov1/yaml/template.go
@@ -16,10 +16,17 @@
 
 package yaml
 
+import "github.com/drone/go-convert/internal/flexible"
+
 // Template defines a Pipeline, Stage or Step template.
 type Template struct {
-	Inputs map[string]*Input `json:"inputs,omitempty"`
-	Stage  *Stage            `json:"stage,omitempty"`
-	Step   *Step             `json:"step,omitempty"`
-	Pipeline *Pipeline       `json:"pipeline,omitempty"`
+	Description  string                             `json:"description,omitempty"`
+	Tags         *flexible.Field[map[string]string] `json:"tags,omitempty"`
+	ID           string                             `json:"id,omitempty"`
+	Name         string                             `json:"name,omitempty"`
+	Version      string                             `json:"version,omitempty"`
+	Inputs       map[string]*Input                  `json:"inputs,omitempty"`
+	Stage        *Stage                             `json:"stage,omitempty"`
+	Step         *Step                              `json:"step,omitempty"`
+	Pipeline     *Pipeline                          `json:"pipeline,omitempty"`
 }

--- a/service/converter/ref_mapping.go
+++ b/service/converter/ref_mapping.go
@@ -70,6 +70,11 @@ func applyRefsWalk(node *yaml.Node, parentKey, grandparentKey string, templateRe
 					if n, ok := pipelineRefs[valueNode.Value]; ok {
 						valueNode.Value = n
 					}
+				
+				case key == "id" && parentKey == "template":
+					if n, ok := templateRefs[valueNode.Value]; ok {
+						valueNode.Value = n
+					}
 
 				case key == "pipelineIdentifier":
 					if n, ok := pipelineRefs[valueNode.Value]; ok {


### PR DESCRIPTION
## Template metadata propagation

Template conversion now carries over the template's own metadata instead of producing a bare `Template`. `ID`, `Name`, `Description`, `Tags`, and `Version` (from `versionLabel`) are copied from the v0 template onto the v1 template.

- `convert/harness/yaml/template.go`: v0 `Template` gains `description` and `tags` (`*flexible.Field[map[string]string]`).
- `convert/v0tov1/yaml/template.go`: v1 `Template` gains `description`, `tags`, `id`, `name`, and `version`.
- `convert/v0tov1/pipeline_converter/convert_template.go`: populates these fields on the converted template.

```go
dst := &v1.Template{
    ID:          src.ID,
    Name:        src.Name,
    Description: src.Description,
    Tags:        src.Tags,
    Version:     src.VersionLabel,
}
```

## Template ref remapping

`service/converter/ref_mapping.go` now remaps `template.id` values using the template ref map, so template identifier references are rewritten consistently with other ref types.

## Service deployment type

The v0 stage `deploymentType` (Kubernetes, Helm, etc.) is now mapped onto the v1 service ref.

- `convert/v0tov1/yaml/service_ref.go`: both `ServiceItem` and `ServiceRef` gain a `type` field. When a `ServiceRef` collapses to a single item, the ref-level `type` is pushed down onto the item, and the presence of `type` forces object (not string) marshaling.
- `convert/v0tov1/pipeline_converter/convert_stage.go`: sets `stage.Service.Type = spec.DeploymentType` for deployment stages.

## Plugin `with` no longer HTML-escaped

`convert/v0tov1/convert_helpers/convert_step_action.go`: `PLUGIN_WITH` is now encoded with `json.Encoder` and `SetEscapeHTML(false)` (trailing newline trimmed) instead of `json.Marshal`. This prevents Harness expressions like `<+pipeline.variables.checkLatest>` from being mangled into `\u003c+...\u003e`. Covered by a new test, `TestConvertStepAction_PluginWithNotHTMLEscaped`.

```
# before: "check-latest":"\u003c+pipeline.variables.checkLatest\u003e"
# after:  "check-latest":"<+pipeline.variables.checkLatest>"
```
