### PR TITLE
fix empty steps omitted in stage template conversion, remove omitempty for trigger enabled, update ref mapping for pipeline chaining

### DIFF
--- a/convert/v0tov1/pipeline_converter/convert_stage.go
+++ b/convert/v0tov1/pipeline_converter/convert_stage.go
@@ -44,12 +44,13 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 	stage := &v1.Stage{
 		Id:    src.ID,
 		Name:  src.Name,
-		Steps: make([]*v1.Step, 0),
 	}
 
 	// Check for Template - if template exists, set it and continue converting rest
 	if src.Template != nil {
 		stage.Template = c.convertStageTemplate(src, basePath)
+	} else {
+		stage.Steps = make([]*v1.Step, 0)
 	}
 
 	// Set common stage settings for non-template stages
@@ -208,7 +209,6 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 			}
 
 			// Convert environment configuration
-			deprecatedInfraDefinition := false
 			if spec.Environment != nil {
 				stage.Environment = convert_helpers.ConvertEnvironment(spec.Environment, c.stageCtx)
 			} else if spec.Environments != nil {
@@ -221,7 +221,6 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 					"deprecated infrastructure definition found in Deployment stage; infrastructure and service definition will be skipped",
 					WithStage(src.ID, string(v0.StageTypeDeployment)),
 				)
-				deprecatedInfraDefinition = true
 			}
 
 			// Convert service configuration
@@ -229,7 +228,7 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 				stage.Service = convert_helpers.ConvertDeploymentService(spec.Service, c.stageCtx)
 			} else if spec.Services != nil {
 				stage.Service = convert_helpers.ConvertDeploymentServices(spec.Services, c.stageCtx)
-			} else if spec.ServiceConfig != nil && !deprecatedInfraDefinition {
+			} else if spec.ServiceConfig != nil {
 				GetMessageLogger().LogWarning(
 					"DEPRECATED_SERVICE_CONFIG",
 					"deprecated service config found in Deployment stage; service config will be skipped",

--- a/convert/v0tov1/yaml/container.go
+++ b/convert/v0tov1/yaml/container.go
@@ -49,7 +49,7 @@ type Container struct {
 	PortBindings *flexible.Field[map[string]string] `json:"port-bindings,omitempty" yaml:"port-bindings,omitempty"`
 	Privileged  *flexible.Field[bool]              `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	Pull        string            `json:"pull,omitempty" yaml:"pull,omitempty"`
-	Registry    string            `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Registry    string            `json:"registryRef,omitempty" yaml:"registryRef,omitempty"`
 	ShmSize     StringorInt       `json:"shm-size,omitempty" yaml:"shm-size,omitempty"`
 	User        *flexible.Field[int]        `json:"user,omitempty" yaml:"user,omitempty"`
 	Volumes     []*Mount          `json:"volumes,omitempty" yaml:"volumes,omitempty"`
@@ -78,7 +78,7 @@ func (v *Container) UnmarshalJSON(data []byte) error {
 		PortBindings *flexible.Field[map[string]string] `json:"port-bindings,omitempty" yaml:"port-bindings,omitempty"`
 		Privileged  *flexible.Field[bool]              `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 		Pull        string            `json:"pull,omitempty" yaml:"pull,omitempty"`
-		Registry    string            `json:"registry,omitempty" yaml:"registry,omitempty"`
+		Registry    string            `json:"registryRef,omitempty" yaml:"registryRef,omitempty"`
 		ShmSize     StringorInt       `json:"shm-size,omitempty" yaml:"shm-size,omitempty"`
 		User        *flexible.Field[int]        `json:"user,omitempty" yaml:"user,omitempty"`
 		Volumes     []*Mount          `json:"volumes,omitempty" yaml:"volumes,omitempty"`

--- a/convert/v0tov1/yaml/stage.go
+++ b/convert/v0tov1/yaml/stage.go
@@ -67,12 +67,13 @@ type Stage struct {
 
 // MarshalJSON customizes Stage serialization:
 //   - Container stages (parallel, group, chain) omit steps entirely.
+//   - Template stages omit steps entirely.
 //   - Regular stages always emit steps as [] instead of null.
 func (s Stage) MarshalJSON() ([]byte, error) {
 	type StageAlias Stage
 
-	// Container stages must NOT have a steps field (schema mutual exclusivity).
-	if s.Parallel != nil || s.Group != nil || s.Chain != nil {
+	// Container and template stages must NOT have a steps field.
+	if s.Parallel != nil || s.Group != nil || s.Chain != nil || s.Template != nil {
 		s.Steps = nil
 		data, err := json.Marshal(StageAlias(s))
 		if err != nil {

--- a/convert/v0tov1/yaml/trigger.go
+++ b/convert/v0tov1/yaml/trigger.go
@@ -21,7 +21,7 @@ type (
 	Trigger struct {
 		Name               string            `json:"name,omitempty"               yaml:"name,omitempty"`
 		ID                 string            `json:"identifier,omitempty"         yaml:"identifier,omitempty"`
-		Enabled            bool              `json:"enabled,omitempty"            yaml:"enabled,omitempty"`
+		Enabled            bool              `json:"enabled"                      yaml:"enabled"`
 		StagesToExecute    []string          `json:"stagesToExecute,omitempty"    yaml:"stagesToExecute,omitempty"`
 		Description        string            `json:"description,omitempty"        yaml:"description,omitempty"`
 		Tags               map[string]string `json:"tags,omitempty"               yaml:"tags,omitempty"`

--- a/service/converter/ref_mapping.go
+++ b/service/converter/ref_mapping.go
@@ -76,7 +76,7 @@ func applyRefsWalk(node *yaml.Node, parentKey, grandparentKey string, templateRe
 						valueNode.Value = n
 					}
 
-				case key == "pipelineIdentifier":
+				case key == "pipelineIdentifier" && parentKey == "trigger":
 					if n, ok := pipelineRefs[valueNode.Value]; ok {
 						valueNode.Value = n
 					}
@@ -127,19 +127,20 @@ func remapTemplateUses(value string, templateRefs map[string]string) string {
 // remapChainUses rewrites a chain `uses:` value of the form
 // "org/project/pipeline". A full-value match is tried first (so callers can
 // remap by fully-qualified ref); if that fails, the third segment (pipeline
-// identifier) is looked up independently.
+// identifier) is looked up independently. In both cases the mapping value is
+// used verbatim as the fully-qualified replacement (it already carries the
+// org/project prefix).
 func remapChainUses(value string, pipelineRefs map[string]string) string {
 	if len(pipelineRefs) == 0 || value == "" {
 		return value
 	}
-	if n, ok := pipelineRefs[value]; ok {
-		return n
-	}
 	parts := strings.Split(value, "/")
 	if len(parts) == 3 {
-		if n, ok := pipelineRefs[parts[2]]; ok {
-			parts[2] = n
-			return strings.Join(parts, "/")
+		if ref, ok := pipelineRefs[parts[2]]; ok {
+			// The mapping value is a fully-qualified ref (already carrying the
+			// org/project prefix), so replace the whole value rather than just
+			// the pipeline segment.
+			return ref
 		}
 	}
 	return value

--- a/service/converter/ref_mapping_test.go
+++ b/service/converter/ref_mapping_test.go
@@ -31,8 +31,11 @@ func TestApplyRefMappings_TemplateUses_RefOnly(t *testing.T) {
 
 
 func TestApplyRefMappings_ChainUses_PipelineSegment(t *testing.T) {
+	// The map is keyed by the bare pipeline segment; the value is a
+	// fully-qualified ref that replaces the whole chain uses verbatim
+	// (org/project prefix included).
 	in := []byte("pipeline:\n  stages:\n    - chain:\n        uses: org1/proj1/oldPipe\n")
-	out, err := ApplyRefMappings(in, nil, map[string]string{"oldPipe": "newPipe"})
+	out, err := ApplyRefMappings(in, nil, map[string]string{"oldPipe": "org1/proj1/newPipe"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,14 +44,16 @@ func TestApplyRefMappings_ChainUses_PipelineSegment(t *testing.T) {
 	}
 }
 
-func TestApplyRefMappings_ChainUses_FullValueMatch(t *testing.T) {
+func TestApplyRefMappings_ChainUses_FullValueKey_NotMatched(t *testing.T) {
+	// Only the pipeline segment (3rd path element) is looked up; a
+	// fully-qualified key must NOT match, so the value is left unchanged.
 	in := []byte("pipeline:\n  stages:\n    - chain:\n        uses: org1/proj1/oldPipe\n")
 	out, err := ApplyRefMappings(in, nil, map[string]string{"org1/proj1/oldPipe": "org2/proj2/newPipe"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(string(out), "uses: org2/proj2/newPipe") {
-		t.Fatalf("expected full chain uses rewritten; got:\n%s", string(out))
+	if !strings.Contains(string(out), "uses: org1/proj1/oldPipe") {
+		t.Fatalf("expected chain uses unchanged for full-value key; got:\n%s", string(out))
 	}
 }
 
@@ -86,20 +91,20 @@ func TestApplyRefMappings_TriggerPipelineIdentifier(t *testing.T) {
 }
 
 func TestApplyRefMappings_TriggerInputYamlRecurses(t *testing.T) {
-	inner := "pipeline:\n  id: oldPipe\n  stages:\n    - chain:\n        uses: org/proj/oldPipe\n"
-	in := []byte("trigger:\n  pipelineIdentifier: oldPipe\n  inputYaml: |\n    " + strings.ReplaceAll(inner, "\n", "\n    ") + "\n")
-	out, err := ApplyRefMappings(in, nil, map[string]string{"oldPipe": "newPipe"})
+	inner := "pipeline:\n  id: oldPipe1\n  stages:\n    - chain:\n        uses: org/proj/oldPipe2\n"
+	in := []byte("trigger:\n  pipelineIdentifier: oldPipe1\n  inputYaml: |\n    " + strings.ReplaceAll(inner, "\n", "\n    ") + "\n")
+	out, err := ApplyRefMappings(in, nil, map[string]string{"oldPipe1": "newPipe1", "oldPipe2": "org/proj/newPipe2"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	s := string(out)
-	if !strings.Contains(s, "pipelineIdentifier: newPipe") {
+	if !strings.Contains(s, "pipelineIdentifier: newPipe1") {
 		t.Fatalf("expected pipelineIdentifier rewritten; got:\n%s", s)
 	}
-	if !strings.Contains(s, "id: newPipe") {
+	if !strings.Contains(s, "id: newPipe1") {
 		t.Fatalf("expected embedded pipeline.id rewritten; got:\n%s", s)
 	}
-	if !strings.Contains(s, "org/proj/newPipe") {
+	if !strings.Contains(s, "uses: org/proj/newPipe2") {
 		t.Fatalf("expected embedded chain uses rewritten; got:\n%s", s)
 	}
 }


### PR DESCRIPTION
## Template stages omit `steps`

Template-based stages should not carry a `steps` field (schema mutual exclusivity, same as container stages).

- `convert/v0tov1/pipeline_converter/convert_stage.go`: `Steps` is no longer initialized unconditionally. It is only set to `make([]*v1.Step, 0)` for non-template stages; template stages leave it unset.
- `convert/v0tov1/yaml/stage.go`: `MarshalJSON` now strips `steps` for template stages in addition to container (`parallel`, `group`, `chain`) stages.

## Deprecated infrastructure / service config handling

`convert/v0tov1/pipeline_converter/convert_stage.go`: removed the `deprecatedInfraDefinition` bookkeeping. A deprecated `serviceConfig` is now always warned about and skipped, independent of whether a deprecated infrastructure definition was found.

## Trigger `enabled` always emitted

`convert/v0tov1/yaml/trigger.go`: the `Enabled` field drops `omitempty`, so `enabled: false` is now serialized explicitly instead of being omitted.

## Ref remapping fixes

`service/converter/ref_mapping.go`:

- `pipelineIdentifier` is only remapped when it appears directly under a `trigger` node (`parentKey == "trigger"`), avoiding unintended rewrites elsewhere.
- `remapChainUses` now only looks up the bare pipeline segment (3rd path element) and, on a match, replaces the entire `uses` value with the mapping value verbatim (the mapping value already carries the `org/project` prefix). Full-value key matching was removed.

Tests in `service/converter/ref_mapping_test.go` are updated accordingly: chain `uses` keys are keyed by the bare pipeline segment with fully-qualified values, a full-value key is asserted to be left unchanged, and the trigger recursion test uses distinct pipeline identifiers to verify each remap independently.
