### PR TITLE
feat: [CDS-127030]: Emit parallel field in v0 to v1 deployment conversion 

### DIFF
--- a/convert/v0tov1/convert_helpers/convert_stage_deployment.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_deployment.go
@@ -126,16 +126,17 @@ func ConvertDeploymentServices(src *v0.DeploymentServices, ctx *StageConversionC
 			})
 		}
 	}
-	// by default set to true
-	var sequential *flexible.Field[bool] = &flexible.Field[bool]{Value: true}
+	// v0 defaulted to parallel execution; preserve that in v1 (which now defaults to serial)
+	// by emitting parallel: true unless v0 explicitly set parallel.
+	var parallel *flexible.Field[bool] = &flexible.Field[bool]{Value: true}
 	if src.Metadata != nil && src.Metadata.Parallel != nil {
-		sequential = flexible.NegateBool(src.Metadata.Parallel)
+		parallel = src.Metadata.Parallel
 	}
 	if len(serviceItems) > 0 {
 		return &v1.ServiceRef{
 			Items:        serviceItems,
 			MultiService: true,
-			Sequential:   sequential,
+			Parallel:     parallel,
 		}
 	}
 
@@ -291,10 +292,11 @@ func ConvertEnvironments(src *v0.Environments, ctx *StageConversionContext) *v1.
 		return nil
 	}
 
-	// by default set to true
-	var sequential *flexible.Field[bool] = &flexible.Field[bool]{Value: true}
+	// v0 defaulted to parallel execution; preserve that in v1 (which now defaults to serial)
+	// by emitting parallel: true unless v0 explicitly set parallel.
+	var parallel *flexible.Field[bool] = &flexible.Field[bool]{Value: true}
 	if src.Metadata != nil && src.Metadata.Parallel != nil {
-		sequential = flexible.NegateBool(src.Metadata.Parallel)
+		parallel = src.Metadata.Parallel
 	}
 
 	// Check if Values is nil or empty
@@ -322,8 +324,8 @@ func ConvertEnvironments(src *v0.Environments, ctx *StageConversionContext) *v1.
 		v1Filters := ConvertEnvironmentFilters(v0Filters)
 		if len(v1Filters) > 0 {
 			return &v1.EnvironmentRef{
-				Sequential: sequential,
-				Filters:    v1Filters,
+				Parallel: parallel,
+				Filters:  v1Filters,
 			}
 		}
 		return nil
@@ -359,9 +361,9 @@ func ConvertEnvironments(src *v0.Environments, ctx *StageConversionContext) *v1.
 
 	if len(items) > 0 {
 		return &v1.EnvironmentRef{
-			Items:      items,
-			Sequential: sequential,
-			MultiEnv:   true,
+			Items:    items,
+			Parallel: parallel,
+			MultiEnv: true,
 		}
 	}
 
@@ -387,10 +389,11 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 		return nil
 	}
 
-	// Compute sequential from metadata (v0 parallel: true → v1 sequential: false)
-	var seqField *flexible.Field[bool]
+	// v0 defaulted to parallel execution; preserve that in v1 (which now defaults to serial)
+	// by emitting parallel: true unless v0 explicitly set parallel.
+	var parallel *flexible.Field[bool] = &flexible.Field[bool]{Value: true}
 	if src.Metadata != nil && src.Metadata.Parallel != nil {
-		seqField = flexible.NegateBool(src.Metadata.Parallel)
+		parallel = src.Metadata.Parallel
 	}
 
 	// Case: environments is an expression (e.g., <+input>)
@@ -401,7 +404,7 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 				"id": src.EnvGroupRef,
 			}
 			return &v1.EnvironmentRef{
-				Sequential: seqField,
+				Parallel: parallel,
 				Group:      groupConfig,
 			}
 		}
@@ -414,7 +417,7 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 				"id": src.EnvGroupRef,
 			}
 			return &v1.EnvironmentRef{
-				Sequential: seqField,
+				Parallel: parallel,
 				Group:      groupConfig,
 			}
 		}
@@ -431,7 +434,7 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 					"filters": v1Filters,
 				}
 				return &v1.EnvironmentRef{
-					Sequential: seqField,
+					Parallel: parallel,
 					Group:      groupConfig,
 				}
 			}
@@ -439,8 +442,8 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 
 		// Simple group reference format
 		return &v1.EnvironmentRef{
-			Sequential: seqField,
-			Group:      map[string]interface{}{"id": src.EnvGroupRef},
+			Parallel: parallel,
+			Group:    map[string]interface{}{"id": src.EnvGroupRef},
 		}
 	}
 
@@ -455,7 +458,7 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 					"items": items,
 				}
 				return &v1.EnvironmentRef{
-					Sequential: seqField,
+					Parallel: parallel,
 					Group:      groupConfig,
 				}
 			}

--- a/convert/v0tov1/convert_helpers/convert_stage_deployment_parallel_test.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_deployment_parallel_test.go
@@ -1,0 +1,138 @@
+// Copyright 2022 Harness, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converthelpers
+
+import (
+	"testing"
+
+	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	"github.com/drone/go-convert/internal/flexible"
+)
+
+// v0 defaulted to parallel execution, while v1 now defaults to serial. The converter
+// must therefore emit an explicit `parallel` field so a migrated pipeline keeps its
+// original v0 behaviour:
+//   - v0 parallel: true       -> v1 parallel: true
+//   - v0 parallel: false      -> v1 parallel: false
+//   - v0 parallel unspecified -> v1 parallel: true (preserve v0's parallel default)
+
+func boolPtr(b bool) *bool { return &b }
+
+// assertParallel checks that the emitted *flexible.Field[bool] carries the expected value.
+func assertParallel(t *testing.T, got *flexible.Field[bool], want *bool) {
+	t.Helper()
+	if want == nil {
+		if got != nil {
+			t.Fatalf("expected no parallel field, got %+v", got)
+		}
+		return
+	}
+	if got == nil {
+		t.Fatalf("expected parallel=%v, got nil field", *want)
+	}
+	v, ok := got.AsStruct()
+	if !ok {
+		t.Fatalf("expected parallel bool value, field was not a plain bool: %+v", got)
+	}
+	if v != *want {
+		t.Fatalf("expected parallel=%v, got parallel=%v", *want, v)
+	}
+}
+
+func TestConvertDeploymentServices_ParallelMapping(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadata     *v0.ServicesMetadata
+		wantParallel *bool
+	}{
+		{
+			name:         "v0 unspecified -> parallel true (preserve v0 default)",
+			metadata:     nil,
+			wantParallel: boolPtr(true),
+		},
+		{
+			name:         "v0 parallel true -> parallel true",
+			metadata:     &v0.ServicesMetadata{Parallel: &flexible.Field[bool]{Value: true}},
+			wantParallel: boolPtr(true),
+		},
+		{
+			name:         "v0 parallel false -> parallel false",
+			metadata:     &v0.ServicesMetadata{Parallel: &flexible.Field[bool]{Value: false}},
+			wantParallel: boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := &v0.DeploymentServices{
+				Metadata: tt.metadata,
+				Values: &flexible.Field[[]*v0.DeploymentService]{
+					Value: []*v0.DeploymentService{
+						{ServiceRef: "svc1"},
+						{ServiceRef: "svc2"},
+					},
+				},
+			}
+			got := ConvertDeploymentServices(src, NewStageConversionContext())
+			if got == nil {
+				t.Fatalf("expected a ServiceRef, got nil")
+			}
+			assertParallel(t, got.Parallel, tt.wantParallel)
+		})
+	}
+}
+
+func TestConvertEnvironments_ParallelMapping(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadata     *v0.EnvironmentMetadata
+		wantParallel *bool
+	}{
+		{
+			name:         "v0 unspecified -> parallel true (preserve v0 default)",
+			metadata:     nil,
+			wantParallel: boolPtr(true),
+		},
+		{
+			name:         "v0 parallel true -> parallel true",
+			metadata:     &v0.EnvironmentMetadata{Parallel: &flexible.Field[bool]{Value: true}},
+			wantParallel: boolPtr(true),
+		},
+		{
+			name:         "v0 parallel false -> parallel false",
+			metadata:     &v0.EnvironmentMetadata{Parallel: &flexible.Field[bool]{Value: false}},
+			wantParallel: boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := &v0.Environments{
+				Metadata: tt.metadata,
+				Values: &flexible.Field[[]*v0.Environment]{
+					Value: []*v0.Environment{
+						{EnvironmentRef: "env1"},
+						{EnvironmentRef: "env2"},
+					},
+				},
+			}
+			got := ConvertEnvironments(src, NewStageConversionContext())
+			if got == nil {
+				t.Fatalf("expected an EnvironmentRef, got nil")
+			}
+			assertParallel(t, got.Parallel, tt.wantParallel)
+		})
+	}
+}

--- a/convert/v0tov1/yaml/environment_ref.go
+++ b/convert/v0tov1/yaml/environment_ref.go
@@ -21,11 +21,11 @@ import (
 
 // EnvironmentRef is the unified v1 environment configuration.
 type EnvironmentRef struct {
-	Items      []*EnvironmentItem    `json:"items,omitempty" yaml:"items,omitempty"`
-	Sequential *flexible.Field[bool] `json:"sequential,omitempty" yaml:"sequential,omitempty"`
-	Group      interface{}           `json:"group,omitempty" yaml:"group,omitempty"`
-	Filters    []*Filter             `json:"filters,omitempty" yaml:"filters,omitempty"`
-	MultiEnv   bool                  `json:"-" yaml:"-"`
+	Items    []*EnvironmentItem    `json:"items,omitempty" yaml:"items,omitempty"`
+	Parallel *flexible.Field[bool] `json:"parallel,omitempty" yaml:"parallel,omitempty"`
+	Group    interface{}           `json:"group,omitempty" yaml:"group,omitempty"`
+	Filters  []*Filter             `json:"filters,omitempty" yaml:"filters,omitempty"`
+	MultiEnv bool                  `json:"-" yaml:"-"`
 }
 
 // MarshalJSON implements json.Marshaler following the ServiceRef pattern.
@@ -44,9 +44,9 @@ func (v EnvironmentRef) MarshalJSON() ([]byte, error) {
 func (v *EnvironmentRef) UnmarshalJSON(data []byte) error {
 	var out1 string
 	var out2 = struct {
-		Items      []*EnvironmentItem    `json:"items,omitempty" yaml:"items,omitempty"`
-		Sequential *flexible.Field[bool] `json:"sequential,omitempty" yaml:"sequential,omitempty"`
-		Group      interface{}           `json:"group,omitempty" yaml:"group,omitempty"`
+		Items    []*EnvironmentItem    `json:"items,omitempty" yaml:"items,omitempty"`
+		Parallel *flexible.Field[bool] `json:"parallel,omitempty" yaml:"parallel,omitempty"`
+		Group    interface{}           `json:"group,omitempty" yaml:"group,omitempty"`
 	}{}
 
 	if err := json.Unmarshal(data, &out1); err == nil {
@@ -58,12 +58,12 @@ func (v *EnvironmentRef) UnmarshalJSON(data []byte) error {
 	}
 
 	if err := json.Unmarshal(data, &out2); err == nil {
-		v.Sequential = out2.Sequential
+		v.Parallel = out2.Parallel
 		v.Items = out2.Items
 		v.Group = out2.Group
 		// Set MultiEnv flag based on whether this is a multi-environment config
-		// MultiEnv is true if: multiple items, or has sequential/group fields
-		v.MultiEnv = len(out2.Items) > 0 || out2.Sequential != nil || out2.Group != nil
+		// MultiEnv is true if: multiple items, or has parallel/group fields
+		v.MultiEnv = len(out2.Items) > 0 || out2.Parallel != nil || out2.Group != nil
 		return nil
 	} else {
 		return err

--- a/convert/v0tov1/yaml/service_ref.go
+++ b/convert/v0tov1/yaml/service_ref.go
@@ -65,7 +65,7 @@ func (s ServiceItem) MarshalJSON() ([]byte, error) {
 type ServiceRef struct {
 	Type string `json:"type,omitempty"` // Deployment Type: Kubernetes, Helm, etc.
 	Items        []*ServiceItem        `json:"items,omitempty"`
-	Sequential   *flexible.Field[bool] `json:"sequential,omitempty"`
+	Parallel     *flexible.Field[bool] `json:"parallel,omitempty"`
 	MultiService bool                  `json:"-"` // Don't serialize this field
 }
 
@@ -73,7 +73,7 @@ type ServiceRef struct {
 // Handles:
 // - Single string: "service1"
 // - Array of strings: ["service1", "service2"]
-// - Object with items: {items: [...], sequential: true}
+// - Object with items: {items: [...], parallel: true}
 func (v *ServiceRef) UnmarshalJSON(data []byte) error {
 	// Try as single string
 	var str string
@@ -100,14 +100,14 @@ func (v *ServiceRef) UnmarshalJSON(data []byte) error {
 
 	// Try as full object with items field
 	var out = struct {
-		Items      []*ServiceItem        `json:"items,omitempty"`
-		Sequential *flexible.Field[bool] `json:"sequential,omitempty"`
+		Items    []*ServiceItem        `json:"items,omitempty"`
+		Parallel *flexible.Field[bool] `json:"parallel,omitempty"`
 	}{}
 	if err := json.Unmarshal(data, &out); err != nil {
 		return err
 	}
 	v.Items = out.Items
-	v.Sequential = out.Sequential
+	v.Parallel = out.Parallel
 	v.MultiService = len(v.Items) > 1
 	return nil
 }
@@ -115,10 +115,10 @@ func (v *ServiceRef) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements json.Marshaler for ServiceRef.
 // Outputs:
 // - Single string if one item without With and not MultiService: "service1"
-// - Object with items if MultiService: {items: [...]} or {items: [...], sequential: true}
+// - Object with items if MultiService: {items: [...]} or {items: [...], parallel: true}
 func (v *ServiceRef) MarshalJSON() ([]byte, error) {
 	// Single item without With and not forced to be multi-service
-	if len(v.Items) == 1 && !v.MultiService && v.Sequential == nil {
+	if len(v.Items) == 1 && !v.MultiService && v.Parallel == nil {
 		item := v.Items[0]
 		if item.Type == "" {
 			item.Type = v.Type

--- a/convert/v0tov1/yaml/testdata/sample.yaml
+++ b/convert/v0tov1/yaml/testdata/sample.yaml
@@ -41,7 +41,7 @@ pipeline:
       stages:
       - environment: prod
       - environment:
-          sequential: true
+          parallel: true
           items:
           - id: test
           - id: prod
@@ -57,7 +57,7 @@ pipeline:
         - petstore-frontend
         - petstore-backend
       - service:
-          sequential: true
+          parallel: true
           items:
           - petstore-frontend
           - petstore-backend

--- a/convert/v0tov1/yaml/testdata/sample.yaml.golden
+++ b/convert/v0tov1/yaml/testdata/sample.yaml.golden
@@ -47,7 +47,7 @@ pipeline:
           id: prod
         steps: []
       - environment:
-          sequential: true
+          parallel: true
           items:
           - id: test
           - id: prod
@@ -67,7 +67,7 @@ pipeline:
           - petstore-backend
         steps: []
       - service:
-          sequential: true
+          parallel: true
           items:
           - petstore-frontend
           - petstore-backend


### PR DESCRIPTION
Converted the v0 to v1 deployment converter to emit the new 'parallel' field instead of 'sequential', matching the unified v1 schema change. 
    - v0 parallel: true       :     v1 parallel: true
    - v0 parallel: false      :     v1 parallel: false
    - v0 parallel unspecified  :  v1 parallel: true

  Renames Sequential to Parallel in ServiceRef/EnvironmentRef and updates all three deployment conversion blocks. Adds a mapping unit test.