### PR TITLE
fix: [CI-23632]: preserve containerless Cloud steps in v0→v1 convert

### DIFF
--- a/convert/v0tov1/convert_helpers/convert_platform_test.go
+++ b/convert/v0tov1/convert_helpers/convert_platform_test.go
@@ -1,0 +1,71 @@
+// Copyright 2022 Harness, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converthelpers
+
+import (
+	"testing"
+
+	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertPlatform(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *v0.Platform
+		want *v1.Platform
+	}{
+		{
+			name: "nil platform stays nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			// The load-bearing case for CI-23632: V0 pipelines commonly declare
+			// only platform.os. PlatformV1.toPlatform() NPEs on arch.getValue()
+			// when arch is missing, so we default to amd64 here.
+			name: "os set, arch empty defaults to amd64",
+			in:   &v0.Platform{OS: "Linux"},
+			want: &v1.Platform{Os: "linux", Arch: "amd64"},
+		},
+		{
+			name: "explicit arch wins over default",
+			in:   &v0.Platform{OS: "Linux", Arch: "arm64"},
+			want: &v1.Platform{Os: "linux", Arch: "arm64"},
+		},
+		{
+			name: "os and arch both lowercased",
+			in:   &v0.Platform{OS: "MacOS", Arch: "ARM64"},
+			want: &v1.Platform{Os: "macos", Arch: "arm64"},
+		},
+		{
+			// Empty platform (both fields blank) stays empty — we don't default
+			// arch when there's no OS either. The V1 backend does not require
+			// platform at all; only when present with an OS.
+			name: "empty platform stays empty",
+			in:   &v0.Platform{},
+			want: &v1.Platform{Os: "", Arch: ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertPlatform(tt.in)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ConvertPlatform() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/convert/v0tov1/convert_helpers/convert_stage_ci.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_ci.go
@@ -293,15 +293,25 @@ func ConvertPlatform(platform *v0.Platform) *v1.Platform {
 }
 
 // ConvertServiceDependencyToBackgroundStep converts a v0 Service dependency to v1 background step
-func ConvertServiceDependencyToBackgroundStep(src *v0.Service) *v1.Step {
+func ConvertServiceDependencyToBackgroundStep(src *v0.Service, ctx *StepConvertContext) *v1.Step {
 	if src == nil || src.Spec == nil {
 		return nil
 	}
 
-	// Container mapping
+	// Container mapping. See ConvertStepRun for Cloud-containerless rationale.
 	var container *v1.Container
 	resources := ConvertContainerResources(src.Spec.Resources)
-	if src.Spec.Image != "" || src.Spec.Conn != "" || resources != nil {
+	if ctx.IsCloud() && src.Spec.Image == "" {
+		WarnDroppedContainerFieldsOnCloud(src.ID, "Service", map[string]bool{
+			"connector":    src.Spec.Conn != "",
+			"resources":    resources != nil,
+			"entrypoint":   src.Spec.Entrypoint != nil,
+			"args":         src.Spec.Args != nil,
+			"privileged":   src.Spec.Privileged != nil,
+			"portBindings": src.Spec.PortBindings != nil,
+			"runAsUser":    src.Spec.RunAsUser != nil,
+		})
+	} else if src.Spec.Image != "" || src.Spec.Conn != "" || resources != nil {
 		container = &v1.Container{
 			Image:        src.Spec.Image,
 			Connector:    src.Spec.Conn,
@@ -330,15 +340,16 @@ func ConvertServiceDependencyToBackgroundStep(src *v0.Service) *v1.Step {
 	return step
 }
 
-// ConvertServiceDependenciesToBackgroundSteps converts v0 service dependencies to v1 background steps
-func ConvertServiceDependenciesToBackgroundSteps(services []*v0.Service) []*v1.Step {
+// ConvertServiceDependenciesToBackgroundSteps converts v0 service dependencies to v1 background steps.
+// ctx carries stage-scoped facts (Cloud runtime awareness, etc.); nil is safe.
+func ConvertServiceDependenciesToBackgroundSteps(services []*v0.Service, ctx *StepConvertContext) []*v1.Step {
 	if len(services) == 0 {
 		return nil
 	}
 
 	steps := make([]*v1.Step, 0, len(services))
 	for _, service := range services {
-		if step := ConvertServiceDependencyToBackgroundStep(service); step != nil {
+		if step := ConvertServiceDependencyToBackgroundStep(service, ctx); step != nil {
 			steps = append(steps, step)
 		}
 	}

--- a/convert/v0tov1/convert_helpers/convert_stage_ci.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_ci.go
@@ -280,15 +280,29 @@ func convertTolerations(tolerations *flexible.Field[[]*v0.Toleration]) *flexible
 	return result
 }
 
-// ConvertPlatform converts v0 Platform to v1 Platform
+// ConvertPlatform converts v0 Platform to v1 Platform.
+//
+// Arch fill-in: PlatformV1.toPlatform() on the V1 backend dereferences
+// arch.getValue() unconditionally and NPEs if the platform block is
+// present but arch is missing. V0 pipelines commonly declare only
+// platform.os (arch defaults to amd64 implicitly at execution time),
+// so we must emit a concrete arch here to keep the converted V1
+// pipeline runnable. Explicit V0 arch always wins.
+//
+// Mirrors the K8s-infra fill-in in pipeline_converter/convert_stage.go
+// (case StageTypeCI, "V1 sources K8s stage OS from platform.os" block).
 func ConvertPlatform(platform *v0.Platform) *v1.Platform {
 	if platform == nil {
 		return nil
 	}
 
+	arch := strings.ToLower(platform.Arch)
+	if arch == "" && platform.OS != "" {
+		arch = "amd64"
+	}
 	return &v1.Platform{
 		Os:   strings.ToLower(platform.OS),
-		Arch: strings.ToLower(platform.Arch),
+		Arch: arch,
 	}
 }
 

--- a/convert/v0tov1/convert_helpers/convert_stage_ci_test.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_ci_test.go
@@ -288,7 +288,7 @@ func TestConvertServiceDependencyToBackgroundStep(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ConvertServiceDependencyToBackgroundStep(tt.input)
+			result := ConvertServiceDependencyToBackgroundStep(tt.input, nil)
 			if diff := cmp.Diff(tt.expected, result); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -382,7 +382,7 @@ func TestConvertServiceDependenciesToBackgroundSteps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ConvertServiceDependenciesToBackgroundSteps(tt.input)
+			result := ConvertServiceDependenciesToBackgroundSteps(tt.input, nil)
 			if diff := cmp.Diff(tt.expected, result); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}

--- a/convert/v0tov1/convert_helpers/convert_step_background.go
+++ b/convert/v0tov1/convert_helpers/convert_step_background.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ConvertStepBackground converts a v0 Background step to v1 background spec
-func ConvertStepBackground(src *v0.Step) *v1.StepRun {
+func ConvertStepBackground(src *v0.Step, ctx *StepConvertContext) *v1.StepRun {
 	if src == nil || src.Spec == nil {
 		return nil
 	}
@@ -31,10 +31,20 @@ func ConvertStepBackground(src *v0.Step) *v1.StepRun {
 		return nil
 	}
 
-	// Container mapping
+	// Container mapping. See ConvertStepRun for Cloud-containerless rationale.
 	var container *v1.Container
 	resources := ConvertContainerResources(sp.Resources)
-	if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
+	if ctx.IsCloud() && sp.Image == "" {
+		WarnDroppedContainerFieldsOnCloud(src.ID, src.Type, map[string]bool{
+			"connectorRef": sp.ConnRef != "",
+			"registryRef":  sp.RegistryRef != "",
+			"privileged":   sp.Privileged != nil,
+			"resources":    resources != nil,
+			"entrypoint":   sp.Entrypoint != nil,
+			"runAsUser":    sp.RunAsUser != nil,
+			"portBindings": sp.PortBindings != nil,
+		})
+	} else if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
 		pull := ConvertImagePullPolicy(sp.ImagePullPolicy)
 
 		container = &v1.Container{

--- a/convert/v0tov1/convert_helpers/convert_step_background_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_background_test.go
@@ -143,7 +143,7 @@ func TestConvertStepBackground(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ConvertStepBackground(tt.step)
+			result := ConvertStepBackground(tt.step, nil)
 			if result == nil {
 				t.Fatal("expected non-nil result")
 			}
@@ -180,7 +180,7 @@ func TestConvertStepBackground_NilCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ConvertStepBackground(tt.step)
+			result := ConvertStepBackground(tt.step, nil)
 			if result != nil {
 				t.Errorf("expected nil result, got %v", result)
 			}

--- a/convert/v0tov1/convert_helpers/convert_step_container.go
+++ b/convert/v0tov1/convert_helpers/convert_step_container.go
@@ -10,7 +10,7 @@ import (
 
 // ConvertStepContainer converts a v0 Container step to v1 run step
 // Container steps are converted to Run steps
-func ConvertStepContainer(src *v0.Step) *v1.StepRun {
+func ConvertStepContainer(src *v0.Step, ctx *StepConvertContext) *v1.StepRun {
 	if src == nil || src.Spec == nil {
 		return nil
 	}
@@ -30,9 +30,17 @@ func ConvertStepContainer(src *v0.Step) *v1.StepRun {
 
 	script := sp.Command
 
-	// Container mapping
+	// Container mapping. See ConvertStepRun for Cloud-containerless rationale.
 	var container *v1.Container
-	if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || sp.RunAsUser != nil {
+	if ctx.IsCloud() && sp.Image == "" {
+		WarnDroppedContainerFieldsOnCloud(src.ID, src.Type, map[string]bool{
+			"connectorRef": sp.ConnRef != "",
+			"registryRef":  sp.RegistryRef != "",
+			"privileged":   sp.Privileged != nil,
+			"entrypoint":   sp.Entrypoint != nil,
+			"runAsUser":    sp.RunAsUser != nil,
+		})
+	} else if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || sp.RunAsUser != nil {
 		pull := ConvertImagePullPolicy(sp.ImagePullPolicy)
 
 		container = &v1.Container{

--- a/convert/v0tov1/convert_helpers/convert_step_containerless_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_containerless_test.go
@@ -1,0 +1,406 @@
+// Copyright 2022 Harness, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converthelpers
+
+import (
+	"strings"
+	"testing"
+
+	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	"github.com/drone/go-convert/convert/v0tov1/messagelog"
+	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
+	"github.com/drone/go-convert/internal/flexible"
+)
+
+// Cloud runtime context: container-block should be suppressed when the v0
+// spec has no image. This test suite covers each of the seven step helpers
+// that emit container blocks, plus the ConvertServiceDependency helper.
+
+const testLogFile = "containerless_test"
+
+// cloudCtx builds a StepConvertContext whose runtime is Cloud (hosted VM).
+func cloudCtx() *StepConvertContext {
+	return &StepConvertContext{Runtime: &v1.Runtime{Cloud: &v1.RuntimeCloud{}}}
+}
+
+// k8sCtx builds a StepConvertContext whose runtime is Kubernetes (containers required).
+func k8sCtx() *StepConvertContext {
+	return &StepConvertContext{Runtime: &v1.Runtime{Kubernetes: &v1.RuntimeKubernetes{}}}
+}
+
+// resetLog wipes and re-enables the message logger, returning a cleanup func.
+func resetLog(t *testing.T) func() {
+	t.Helper()
+	messagelog.ResetMessageLogger()
+	messagelog.GetMessageLogger().Enable("")
+	messagelog.GetMessageLogger().SetCurrentFile(testLogFile)
+	return func() { messagelog.ResetMessageLogger() }
+}
+
+// assertContainerlessWarn asserts exactly one WARN with the containerless code
+// was recorded and that its message names the expected dropped fields.
+func assertContainerlessWarn(t *testing.T, wantFields ...string) {
+	t.Helper()
+	fl := messagelog.GetMessageLogger().GetFileLog(testLogFile)
+	if fl == nil {
+		t.Fatalf("no file log recorded")
+	}
+	var warns []messagelog.Message
+	for _, m := range fl.Messages {
+		if m.Code == "CLOUD_CONTAINERLESS_FIELDS_DROPPED" {
+			warns = append(warns, m)
+		}
+	}
+	if len(warns) != 1 {
+		t.Fatalf("expected 1 CLOUD_CONTAINERLESS_FIELDS_DROPPED warn, got %d (messages: %+v)", len(warns), fl.Messages)
+	}
+	for _, f := range wantFields {
+		if !strings.Contains(warns[0].Message, f) {
+			t.Errorf("warn message %q missing expected field %q", warns[0].Message, f)
+		}
+	}
+}
+
+// assertNoContainerlessWarn asserts no containerless-drop warning was recorded.
+func assertNoContainerlessWarn(t *testing.T) {
+	t.Helper()
+	fl := messagelog.GetMessageLogger().GetFileLog(testLogFile)
+	if fl == nil {
+		return
+	}
+	for _, m := range fl.Messages {
+		if m.Code == "CLOUD_CONTAINERLESS_FIELDS_DROPPED" {
+			t.Fatalf("did not expect CLOUD_CONTAINERLESS_FIELDS_DROPPED, got %+v", m)
+		}
+	}
+}
+
+// --- ConvertStepRun ----------------------------------------------------------
+
+func TestConvertStepRun_CloudContainerlessDropsBlock(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "run1",
+		Type: v0.StepTypeRun,
+		Spec: &v0.StepRun{
+			Command:    "echo hi",
+			Resources:  &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+			ConnRef:    "docker-connector",
+			Privileged: &flexible.Field[bool]{Value: true},
+			RunAsUser:  &flexible.Field[int]{Value: 1000},
+		},
+	}
+	got := ConvertStepRun(step, cloudCtx())
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.Container != nil {
+		t.Errorf("expected Container=nil on Cloud+no-image, got %+v", got.Container)
+	}
+	if len(got.Script) == 0 || got.Script[0] != "echo hi" {
+		t.Errorf("script not preserved: %+v", got.Script)
+	}
+	assertContainerlessWarn(t, "resources", "connectorRef", "privileged", "runAsUser")
+}
+
+func TestConvertStepRun_CloudWithImagePreservesContainer(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "run2",
+		Type: v0.StepTypeRun,
+		Spec: &v0.StepRun{
+			Image:   "alpine",
+			Command: "echo hi",
+		},
+	}
+	got := ConvertStepRun(step, cloudCtx())
+	if got == nil || got.Container == nil || got.Container.Image != "alpine" {
+		t.Fatalf("expected Container.Image=alpine on Cloud+image, got %+v", got)
+	}
+	assertNoContainerlessWarn(t)
+}
+
+func TestConvertStepRun_NonCloudPreservesTodayBehavior(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "run3",
+		Type: v0.StepTypeRun,
+		Spec: &v0.StepRun{
+			Command:   "echo hi",
+			Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+		},
+	}
+	// nil ctx and k8s ctx both must preserve today's behavior: container emitted.
+	for _, name := range []string{"nil", "k8s"} {
+		var ctx *StepConvertContext
+		if name == "k8s" {
+			ctx = k8sCtx()
+		}
+		t.Run(name, func(t *testing.T) {
+			got := ConvertStepRun(step, ctx)
+			if got == nil || got.Container == nil {
+				t.Fatalf("expected Container preserved on non-Cloud, got %+v", got)
+			}
+			if got.Container.Image != "" {
+				t.Errorf("expected empty image in container, got %q", got.Container.Image)
+			}
+		})
+	}
+	assertNoContainerlessWarn(t)
+}
+
+// --- ConvertStepBackground ---------------------------------------------------
+
+func TestConvertStepBackground_CloudContainerlessDropsBlock(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "bg1",
+		Type: v0.StepTypeBackground,
+		Spec: &v0.StepBackground{
+			Command:      "redis-server",
+			Resources:    &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "500m"}}},
+			Entrypoint:   &flexible.Field[[]string]{Value: []string{"/bin/sh"}},
+			PortBindings: &flexible.Field[map[string]string]{Value: map[string]string{"6379": "6379"}},
+		},
+	}
+	got := ConvertStepBackground(step, cloudCtx())
+	if got == nil || got.Container != nil {
+		t.Fatalf("expected Container=nil on Cloud+no-image, got %+v", got)
+	}
+	assertContainerlessWarn(t, "resources", "entrypoint", "portBindings")
+}
+
+func TestConvertStepBackground_NonCloudPreservesTodayBehavior(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "bg2",
+		Type: v0.StepTypeBackground,
+		Spec: &v0.StepBackground{
+			Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "500m"}}},
+		},
+	}
+	got := ConvertStepBackground(step, nil)
+	if got == nil || got.Container == nil {
+		t.Fatalf("expected Container preserved on nil-ctx, got %+v", got)
+	}
+	assertNoContainerlessWarn(t)
+}
+
+// --- ConvertStepPlugin -------------------------------------------------------
+
+func TestConvertStepPlugin_CloudContainerlessDropsBlock(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "plugin1",
+		Type: v0.StepTypePlugin,
+		Spec: &v0.StepPlugin{
+			ConnRef:    "connector",
+			Resources:  &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+			Entrypoint: &flexible.Field[[]string]{Value: []string{"/plugin"}},
+			RunAsUser:  &flexible.Field[int]{Value: 999},
+		},
+	}
+	got := ConvertStepPlugin(step, cloudCtx())
+	if got == nil || got.Container != nil {
+		t.Fatalf("expected Container=nil on Cloud+no-image, got %+v", got)
+	}
+	assertContainerlessWarn(t, "connectorRef", "resources", "entrypoint", "runAsUser")
+}
+
+func TestConvertStepPlugin_NonCloudPreservesTodayBehavior(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "plugin2",
+		Type: v0.StepTypePlugin,
+		Spec: &v0.StepPlugin{
+			Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+		},
+	}
+	got := ConvertStepPlugin(step, k8sCtx())
+	if got == nil || got.Container == nil {
+		t.Fatalf("expected Container preserved on K8s, got %+v", got)
+	}
+	assertNoContainerlessWarn(t)
+}
+
+// --- ConvertStepRunTests -----------------------------------------------------
+
+func TestConvertStepRunTests_CloudContainerlessDropsBlock(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "runtests1",
+		Type: v0.StepTypeRunTests,
+		Spec: &v0.StepRunTests{
+			Language:     "java",
+			BuildTool:    "maven",
+			ConnectorRef: "docker-conn",
+			Resources:    &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "2"}}},
+			RunAsUser:    &flexible.Field[int]{Value: 1001},
+		},
+	}
+	got := ConvertStepRunTests(step, cloudCtx())
+	if got == nil || got.Container != nil {
+		t.Fatalf("expected Container=nil on Cloud+no-image, got %+v", got)
+	}
+	assertContainerlessWarn(t, "connectorRef", "resources", "runAsUser")
+}
+
+func TestConvertStepRunTests_NonCloudPreservesTodayBehavior(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "runtests2",
+		Type: v0.StepTypeRunTests,
+		Spec: &v0.StepRunTests{
+			Language:  "java",
+			BuildTool: "maven",
+			Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "2"}}},
+		},
+	}
+	got := ConvertStepRunTests(step, nil)
+	if got == nil || got.Container == nil {
+		t.Fatalf("expected Container preserved on nil-ctx, got %+v", got)
+	}
+	assertNoContainerlessWarn(t)
+}
+
+// --- ConvertStepTestIntelligence ---------------------------------------------
+
+func TestConvertStepTestIntelligence_CloudContainerlessDropsBlock(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "ti1",
+		Type: v0.StepTypeTest,
+		Spec: &v0.StepTestIntelligence{
+			Command:   "pytest",
+			ConnRef:   "conn",
+			Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+		},
+	}
+	got := ConvertStepTestIntelligence(step, cloudCtx())
+	if got == nil || got.Container != nil {
+		t.Fatalf("expected Container=nil on Cloud+no-image, got %+v", got)
+	}
+	assertContainerlessWarn(t, "connectorRef", "resources")
+}
+
+func TestConvertStepTestIntelligence_NonCloudPreservesTodayBehavior(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "ti2",
+		Type: v0.StepTypeTest,
+		Spec: &v0.StepTestIntelligence{
+			Command:   "pytest",
+			Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+		},
+	}
+	got := ConvertStepTestIntelligence(step, nil)
+	if got == nil || got.Container == nil {
+		t.Fatalf("expected Container preserved on nil-ctx, got %+v", got)
+	}
+	assertNoContainerlessWarn(t)
+}
+
+// --- ConvertStepContainer ----------------------------------------------------
+
+func TestConvertStepContainer_CloudContainerlessDropsBlock(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "container1",
+		Type: v0.StepTypeContainer,
+		Spec: &v0.StepContainer{
+			Command:    "echo hi",
+			ConnRef:    "conn",
+			Privileged: &flexible.Field[bool]{Value: true},
+			Entrypoint: &flexible.Field[[]string]{Value: []string{"/bin/sh"}},
+		},
+	}
+	got := ConvertStepContainer(step, cloudCtx())
+	if got == nil || got.Container != nil {
+		t.Fatalf("expected Container=nil on Cloud+no-image, got %+v", got)
+	}
+	assertContainerlessWarn(t, "connectorRef", "privileged", "entrypoint")
+}
+
+func TestConvertStepContainer_NonCloudPreservesTodayBehavior(t *testing.T) {
+	defer resetLog(t)()
+	step := &v0.Step{
+		ID:   "container2",
+		Type: v0.StepTypeContainer,
+		Spec: &v0.StepContainer{
+			Command:    "echo hi",
+			Privileged: &flexible.Field[bool]{Value: true},
+		},
+	}
+	got := ConvertStepContainer(step, nil)
+	if got == nil || got.Container == nil {
+		t.Fatalf("expected Container preserved on nil-ctx, got %+v", got)
+	}
+	assertNoContainerlessWarn(t)
+}
+
+// --- ConvertServiceDependencyToBackgroundStep --------------------------------
+
+func TestConvertServiceDependency_CloudContainerlessDropsBlock(t *testing.T) {
+	defer resetLog(t)()
+	svc := &v0.Service{
+		ID: "svc1",
+		Spec: &v0.ServiceSpec{
+			Conn:      "connector",
+			Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+		},
+	}
+	got := ConvertServiceDependencyToBackgroundStep(svc, cloudCtx())
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.Background == nil || got.Background.Container != nil {
+		t.Fatalf("expected Background.Container=nil on Cloud+no-image, got %+v", got.Background)
+	}
+	assertContainerlessWarn(t, "connector", "resources")
+}
+
+func TestConvertServiceDependency_NonCloudPreservesTodayBehavior(t *testing.T) {
+	defer resetLog(t)()
+	svc := &v0.Service{
+		ID: "svc2",
+		Spec: &v0.ServiceSpec{
+			Conn:      "connector",
+			Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+		},
+	}
+	got := ConvertServiceDependencyToBackgroundStep(svc, nil)
+	if got == nil || got.Background == nil || got.Background.Container == nil {
+		t.Fatalf("expected Background.Container preserved on nil-ctx, got %+v", got)
+	}
+	assertNoContainerlessWarn(t)
+}
+
+// --- StepConvertContext.IsCloud (nil-safety) ---------------------------------
+
+func TestStepConvertContext_IsCloud_NilSafe(t *testing.T) {
+	var ctx *StepConvertContext
+	if ctx.IsCloud() {
+		t.Fatal("nil ctx must not be Cloud")
+	}
+	if (&StepConvertContext{}).IsCloud() {
+		t.Fatal("ctx with nil runtime must not be Cloud")
+	}
+	if (&StepConvertContext{Runtime: &v1.Runtime{}}).IsCloud() {
+		t.Fatal("ctx with runtime but no Cloud subfield must not be Cloud")
+	}
+	if !cloudCtx().IsCloud() {
+		t.Fatal("cloudCtx() must be Cloud")
+	}
+}

--- a/convert/v0tov1/convert_helpers/convert_step_plugin.go
+++ b/convert/v0tov1/convert_helpers/convert_step_plugin.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ConvertStepPlugin converts a v0 Plugin step to v1 run format
-func ConvertStepPlugin(src *v0.Step) *v1.StepRun {
+func ConvertStepPlugin(src *v0.Step, ctx *StepConvertContext) *v1.StepRun {
 	if src == nil || src.Spec == nil {
 		return nil
 	}
@@ -17,10 +17,19 @@ func ConvertStepPlugin(src *v0.Step) *v1.StepRun {
 		return nil
 	}
 
-	// Container mapping
+	// Container mapping. See ConvertStepRun for Cloud-containerless rationale.
 	var container *v1.Container
 	resources := ConvertContainerResources(sp.Resources)
-	if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
+	if ctx.IsCloud() && sp.Image == "" {
+		WarnDroppedContainerFieldsOnCloud(src.ID, src.Type, map[string]bool{
+			"connectorRef": sp.ConnRef != "",
+			"registryRef":  sp.RegistryRef != "",
+			"privileged":   sp.Privileged != nil,
+			"resources":    resources != nil,
+			"entrypoint":   sp.Entrypoint != nil,
+			"runAsUser":    sp.RunAsUser != nil,
+		})
+	} else if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
 		pull := ConvertImagePullPolicy(sp.ImagePullPolicy)
 		container = &v1.Container{
 			Image:      sp.Image,

--- a/convert/v0tov1/convert_helpers/convert_step_run.go
+++ b/convert/v0tov1/convert_helpers/convert_step_run.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ConvertStepRunSpec converts a v0 Run step to v1 run spec only
-func ConvertStepRun(src *v0.Step) *v1.StepRun {
+func ConvertStepRun(src *v0.Step, ctx *StepConvertContext) *v1.StepRun {
 	if src == nil || src.Spec == nil {
 		return nil
 	}
@@ -33,10 +33,21 @@ func ConvertStepRun(src *v0.Step) *v1.StepRun {
 
 	script := sp.Command
 
-	// Container mapping
+	// Container mapping. On Cloud infra a step with no image is "containerless"
+	// — it runs directly on the hosted VM — so we must NOT emit a container
+	// block even when other container-adjacent fields are set. Any such fields
+	// get dropped with a single warn per step.
 	var container *v1.Container
 	resources := ConvertContainerResources(sp.Resources)
-	if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
+	if ctx.IsCloud() && sp.Image == "" {
+		WarnDroppedContainerFieldsOnCloud(src.ID, src.Type, map[string]bool{
+			"connectorRef": sp.ConnRef != "",
+			"registryRef":  sp.RegistryRef != "",
+			"privileged":   sp.Privileged != nil,
+			"resources":    resources != nil,
+			"runAsUser":    sp.RunAsUser != nil,
+		})
+	} else if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
 		pull := ConvertImagePullPolicy(sp.ImagePullPolicy)
 		container = &v1.Container{
 			Image:      sp.Image,

--- a/convert/v0tov1/convert_helpers/convert_step_run_tests.go
+++ b/convert/v0tov1/convert_helpers/convert_step_run_tests.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ConvertStepRunTests converts a v0 RunTests step to v1 run-test step
-func ConvertStepRunTests(src *v0.Step) *v1.StepTest {
+func ConvertStepRunTests(src *v0.Step, ctx *StepConvertContext) *v1.StepTest {
 	if src == nil || src.Spec == nil {
 		return nil
 	}
@@ -23,10 +23,18 @@ func ConvertStepRunTests(src *v0.Step) *v1.StepTest {
 	// Build the script from language, buildTool, preCommand, args, postCommand
 	script := buildTestScript(sp.Language, sp.BuildTool, sp.PreCommand, sp.Args, sp.PostCommand)
 
-	// Container mapping
+	// Container mapping. See ConvertStepRun for Cloud-containerless rationale.
 	var container *v1.Container
 	resources := ConvertContainerResources(sp.Resources)
-	if sp.Image != "" || sp.ConnectorRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
+	if ctx.IsCloud() && sp.Image == "" {
+		WarnDroppedContainerFieldsOnCloud(src.ID, src.Type, map[string]bool{
+			"connectorRef": sp.ConnectorRef != "",
+			"registryRef":  sp.RegistryRef != "",
+			"privileged":   sp.Privileged != nil,
+			"resources":    resources != nil,
+			"runAsUser":    sp.RunAsUser != nil,
+		})
+	} else if sp.Image != "" || sp.ConnectorRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
 		pull := ConvertImagePullPolicy(sp.ImagePullPolicy)
 		container = &v1.Container{
 			Image:      sp.Image,

--- a/convert/v0tov1/convert_helpers/convert_step_run_tests_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_run_tests_test.go
@@ -230,7 +230,7 @@ func TestConvertStepRunTests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ConvertStepRunTests(tt.input)
+			result := ConvertStepRunTests(tt.input, nil)
 
 			if diff := cmp.Diff(tt.expected, result); diff != "" {
 				t.Errorf("ConvertStepRunTests() mismatch (-want +got):\n%s", diff)
@@ -270,7 +270,7 @@ func TestConvertStepRunTests_NilCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ConvertStepRunTests(tt.input)
+			result := ConvertStepRunTests(tt.input, nil)
 			if result != nil {
 				t.Errorf("expected nil result, got %v", result)
 			}

--- a/convert/v0tov1/convert_helpers/convert_step_test_intelligence.go
+++ b/convert/v0tov1/convert_helpers/convert_step_test_intelligence.go
@@ -8,7 +8,7 @@ import (
 	"github.com/drone/go-convert/internal/flexible"
 )
 
-func ConvertStepTestIntelligence(src *v0.Step) *v1.StepTest {
+func ConvertStepTestIntelligence(src *v0.Step, ctx *StepConvertContext) *v1.StepTest {
 	if src == nil || src.Spec == nil {
 		return nil
 	}
@@ -17,10 +17,18 @@ func ConvertStepTestIntelligence(src *v0.Step) *v1.StepTest {
 		return nil
 	}
 
-	// Container
+	// Container. See ConvertStepRun for Cloud-containerless rationale.
 	var container *v1.Container
 	resources := ConvertContainerResources(sp.Resources)
-	if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
+	if ctx.IsCloud() && sp.Image == "" {
+		WarnDroppedContainerFieldsOnCloud(src.ID, src.Type, map[string]bool{
+			"connectorRef": sp.ConnRef != "",
+			"registryRef":  sp.RegistryRef != "",
+			"privileged":   sp.Privileged != nil,
+			"resources":    resources != nil,
+			"runAsUser":    sp.RunAsUser != nil,
+		})
+	} else if sp.Image != "" || sp.ConnRef != "" || sp.Privileged != nil || resources != nil || sp.RunAsUser != nil {
 		pull := ConvertImagePullPolicy(sp.ImagePullPolicy)
 		container = &v1.Container{
 			Image:      sp.Image,

--- a/convert/v0tov1/convert_helpers/step_context.go
+++ b/convert/v0tov1/convert_helpers/step_context.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Harness, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converthelpers
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/drone/go-convert/convert/v0tov1/messagelog"
+	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
+)
+
+// StepConvertContext threads stage-scoped facts into per-step converters.
+// Only the fields the step helpers actually need live here; extend cautiously.
+type StepConvertContext struct {
+	Runtime *v1.Runtime
+}
+
+// IsCloud reports whether the enclosing stage's resolved runtime is Cloud
+// (hosted VM). Nil-safe: nil ctx or nil runtime → false, so any caller
+// without stage context transparently keeps today's behavior.
+func (c *StepConvertContext) IsCloud() bool {
+	return c != nil && IsCloudRuntime(c.Runtime)
+}
+
+// IsCloudRuntime is a nil-safe predicate for v1.Runtime.
+func IsCloudRuntime(rt *v1.Runtime) bool {
+	return rt != nil && rt.Cloud != nil
+}
+
+// WarnDroppedContainerFieldsOnCloud emits a single WARN when a Cloud
+// containerless step (image absent) drops container-only fields that would
+// otherwise have coerced it into container mode. dropped maps field name →
+// whether that field was set on the source v0 spec.
+func WarnDroppedContainerFieldsOnCloud(stepID, stepType string, dropped map[string]bool) {
+	names := make([]string, 0, len(dropped))
+	for k, set := range dropped {
+		if set {
+			names = append(names, k)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	sort.Strings(names)
+	messagelog.GetMessageLogger().LogWarning(
+		"CLOUD_CONTAINERLESS_FIELDS_DROPPED",
+		fmt.Sprintf("cloud stage: step has no image; dropping container-only fields: %s", strings.Join(names, ",")),
+		messagelog.WithStep(stepID, stepType),
+	)
+}

--- a/convert/v0tov1/pipeline_converter/convert_containerless_test.go
+++ b/convert/v0tov1/pipeline_converter/convert_containerless_test.go
@@ -1,0 +1,141 @@
+// Copyright 2022 Harness, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelineconverter
+
+import (
+	"testing"
+
+	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	"github.com/drone/go-convert/internal/flexible"
+)
+
+// Integration-level assertion: on Cloud runtime, a v0 Run step without an
+// image must produce a v1 Run step with no container block, preserving the
+// containerless execution mode. This exercises the full stage → step wiring
+// (runtime resolved before steps, ctx threaded, guard applied).
+func TestConvertCIStage_CloudRuntime_ContainerlessRunStep(t *testing.T) {
+	converter := NewPipelineConverter()
+
+	pipeline := &v0.Pipeline{
+		ID:   "p",
+		Name: "p",
+		Stages: []*v0.Stages{
+			{Stage: &v0.Stage{
+				ID:   "ci",
+				Name: "ci",
+				Type: v0.StageTypeCI,
+				Spec: &v0.StageCI{
+					Runtime: &v0.Runtime{
+						Type: "Cloud",
+						Spec: &v0.RuntimeCloudSpec{Size: "Standard"},
+					},
+					Execution: v0.Execution{
+						Steps: []*v0.Steps{
+							{Step: &v0.Step{
+								ID:   "r1",
+								Name: "r1",
+								Type: v0.StepTypeRun,
+								Spec: &v0.StepRun{
+									Command:    "echo hi",
+									Resources:  &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+									RunAsUser:  &flexible.Field[int]{Value: 1000},
+								},
+							}},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	got := converter.ConvertPipeline(pipeline)
+	if got == nil || len(got.Stages) != 1 {
+		t.Fatalf("expected 1 stage, got %+v", got)
+	}
+	stage := got.Stages[0]
+	if stage.Runtime == nil || stage.Runtime.Cloud == nil {
+		t.Fatalf("expected runtime.cloud, got %+v", stage.Runtime)
+	}
+	if len(stage.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(stage.Steps))
+	}
+	run := stage.Steps[0].Run
+	if run == nil {
+		t.Fatalf("expected Run spec, got %+v", stage.Steps[0])
+	}
+	if run.Container != nil {
+		t.Errorf("expected containerless (nil Container) on Cloud+no-image, got %+v", run.Container)
+	}
+	if len(run.Script) == 0 || run.Script[0] != "echo hi" {
+		t.Errorf("expected script preserved, got %+v", run.Script)
+	}
+}
+
+// Regression sentinel: same step body on Kubernetes infra must still emit a
+// container block (K8s behavior is byte-for-byte preserved).
+func TestConvertCIStage_KubernetesDirect_ContainerFieldsPreserved(t *testing.T) {
+	converter := NewPipelineConverter()
+
+	pipeline := &v0.Pipeline{
+		ID:   "p",
+		Name: "p",
+		Stages: []*v0.Stages{
+			{Stage: &v0.Stage{
+				ID:   "ci",
+				Name: "ci",
+				Type: v0.StageTypeCI,
+				Spec: &v0.StageCI{
+					Infrastructure: &v0.Infrastructure{
+						Type: "KubernetesDirect",
+						Spec: &v0.InfrastructureKubernetesDirectSpec{
+							Conn:      "k8s-conn",
+							Namespace: "default",
+						},
+					},
+					Execution: v0.Execution{
+						Steps: []*v0.Steps{
+							{Step: &v0.Step{
+								ID:   "r1",
+								Name: "r1",
+								Type: v0.StepTypeRun,
+								Spec: &v0.StepRun{
+									Command:   "echo hi",
+									Resources: &v0.Resources{Limits: &v0.ResourceSpec{CPU: &flexible.Field[*v0.MilliSize]{Value: "1"}}},
+									RunAsUser: &flexible.Field[int]{Value: 1000},
+								},
+							}},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	got := converter.ConvertPipeline(pipeline)
+	if got == nil || len(got.Stages) != 1 {
+		t.Fatalf("expected 1 stage, got %+v", got)
+	}
+	stage := got.Stages[0]
+	if stage.Runtime == nil || stage.Runtime.Kubernetes == nil {
+		t.Fatalf("expected runtime.kubernetes, got %+v", stage.Runtime)
+	}
+	run := stage.Steps[0].Run
+	if run == nil || run.Container == nil {
+		t.Fatalf("expected Container preserved on K8s, got %+v", run)
+	}
+	if run.Container.Image != "" {
+		t.Errorf("expected empty image (today's behavior) in container, got %q", run.Container.Image)
+	}
+}

--- a/convert/v0tov1/pipeline_converter/convert_containerless_test.go
+++ b/convert/v0tov1/pipeline_converter/convert_containerless_test.go
@@ -83,6 +83,54 @@ func TestConvertCIStage_CloudRuntime_ContainerlessRunStep(t *testing.T) {
 	}
 }
 
+// Cloud pipelines with platform.os set (a common shape — see CI-23632
+// example YAML) must emit platform.arch=amd64 by default, otherwise
+// PlatformV1.toPlatform() NPEs at plan-creation time on the V1 backend.
+func TestConvertCIStage_CloudRuntime_PlatformArchDefaultsToAmd64(t *testing.T) {
+	converter := NewPipelineConverter()
+
+	pipeline := &v0.Pipeline{
+		ID:   "p",
+		Name: "p",
+		Stages: []*v0.Stages{
+			{Stage: &v0.Stage{
+				ID:   "ci",
+				Name: "ci",
+				Type: v0.StageTypeCI,
+				Spec: &v0.StageCI{
+					Platform: &v0.Platform{OS: "Linux"},
+					Runtime:  &v0.Runtime{Type: "Cloud", Spec: &v0.RuntimeCloudSpec{}},
+					Execution: v0.Execution{
+						Steps: []*v0.Steps{
+							{Step: &v0.Step{
+								ID:   "r1",
+								Name: "r1",
+								Type: v0.StepTypeRun,
+								Spec: &v0.StepRun{Command: "echo hi"},
+							}},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	got := converter.ConvertPipeline(pipeline)
+	if got == nil || len(got.Stages) != 1 {
+		t.Fatalf("expected 1 stage, got %+v", got)
+	}
+	stage := got.Stages[0]
+	if stage.Platform == nil {
+		t.Fatalf("expected platform to be set, got nil")
+	}
+	if stage.Platform.Os != "linux" {
+		t.Errorf("expected os=linux, got %q", stage.Platform.Os)
+	}
+	if stage.Platform.Arch != "amd64" {
+		t.Errorf("expected arch=amd64 default, got %q", stage.Platform.Arch)
+	}
+}
+
 // Regression sentinel: same step body on Kubernetes infra must still emit a
 // container block (K8s behavior is byte-for-byte preserved).
 func TestConvertCIStage_KubernetesDirect_ContainerFieldsPreserved(t *testing.T) {

--- a/convert/v0tov1/pipeline_converter/convert_stage.go
+++ b/convert/v0tov1/pipeline_converter/convert_stage.go
@@ -70,15 +70,15 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 		spec, ok := src.Spec.(*v0.StageApproval)
 		if ok && spec != nil {
 			if spec.Execution != nil {
-				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
+				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "", nil)
 				if spec.Execution.RollbackSteps != nil {
-					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
+					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "", nil)
 				}
 			}
 
 			// Convert service dependencies to background steps and prepend them
 			if len(spec.Services) > 0 {
-				backgroundSteps := convert_helpers.ConvertServiceDependenciesToBackgroundSteps(spec.Services)
+				backgroundSteps := convert_helpers.ConvertServiceDependenciesToBackgroundSteps(spec.Services, nil)
 				if len(backgroundSteps) > 0 {
 					stage.Steps = append(backgroundSteps, stage.Steps...)
 				}
@@ -89,15 +89,15 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 		spec, ok := src.Spec.(*v0.StageCustom)
 		if ok && spec != nil {
 			if spec.Execution != nil {
-				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
+				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "", nil)
 				if spec.Execution.RollbackSteps != nil {
-					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
+					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "", nil)
 				}
 			}
-			
+
 			// Convert service dependencies to background steps and prepend them
 			if len(spec.Services) > 0 {
-				backgroundSteps := convert_helpers.ConvertServiceDependenciesToBackgroundSteps(spec.Services)
+				backgroundSteps := convert_helpers.ConvertServiceDependenciesToBackgroundSteps(spec.Services, nil)
 				if len(backgroundSteps) > 0 {
 					stage.Steps = append(backgroundSteps, stage.Steps...)
 				}
@@ -113,13 +113,8 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 	case v0.StageTypeIACM:
 		spec, ok := src.Spec.(*v0.StageIACM)
 		if ok && spec != nil {
-			if spec.Execution != nil {
-				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
-				if spec.Execution.RollbackSteps != nil {
-					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
-				}
-			}
-
+			// Resolve runtime BEFORE converting steps so step helpers can consult it
+			// (e.g. to preserve containerless execution on Cloud infra).
 			if spec.Infrastructure != nil {
 				stage.Runtime = convert_helpers.ConvertInfrastructureToRuntime(spec.Infrastructure, c.stageCtx)
 			} else if spec.Runtime != nil {
@@ -131,6 +126,15 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 					WithStage(src.ID, string(v0.StageTypeIACM)),
 				)
 			}
+			stepCtx := &convert_helpers.StepConvertContext{Runtime: stage.Runtime}
+
+			if spec.Execution != nil {
+				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "", stepCtx)
+				if spec.Execution.RollbackSteps != nil {
+					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "", stepCtx)
+				}
+			}
+
 			stage.Platform = convert_helpers.ConvertPlatform(spec.Platform)
 			stage.Workspace = spec.Workspace
 		}
@@ -138,24 +142,8 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 	case v0.StageTypeCI:
 		spec, ok := src.Spec.(*v0.StageCI)
 		if ok && spec != nil {
-			stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
-			if spec.Execution.RollbackSteps != nil {
-				stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
-			}
-
-			// Convert service dependencies to background steps and prepend them
-			if len(spec.Services) > 0 {
-				backgroundSteps := convert_helpers.ConvertServiceDependenciesToBackgroundSteps(spec.Services)
-				if len(backgroundSteps) > 0 {
-					stage.Steps = append(backgroundSteps, stage.Steps...)
-				}
-			}
-
-			stage.Clone = convert_helpers.ConvertCloneCodebase(spec.Clone)
-			stage.Cache = convert_helpers.ConvertCaching(spec.Cache)
-			stage.BuildIntelligence = convert_helpers.ConvertBuildIntelligence(spec.BuildIntelligence)
-
-			// Convert shared paths to volumes
+			// Resolve runtime BEFORE converting steps so step helpers can consult it
+			// (e.g. to preserve containerless execution on Cloud infra).
 			if spec.Infrastructure != nil {
 				stage.Runtime = convert_helpers.ConvertInfrastructureToRuntime(spec.Infrastructure, c.stageCtx)
 			} else if spec.Runtime != nil {
@@ -167,6 +155,25 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 					WithStage(src.ID, string(v0.StageTypeCI)),
 				)
 			}
+			stepCtx := &convert_helpers.StepConvertContext{Runtime: stage.Runtime}
+
+			stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "", stepCtx)
+			if spec.Execution.RollbackSteps != nil {
+				stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "", stepCtx)
+			}
+
+			// Convert service dependencies to background steps and prepend them
+			if len(spec.Services) > 0 {
+				backgroundSteps := convert_helpers.ConvertServiceDependenciesToBackgroundSteps(spec.Services, stepCtx)
+				if len(backgroundSteps) > 0 {
+					stage.Steps = append(backgroundSteps, stage.Steps...)
+				}
+			}
+
+			stage.Clone = convert_helpers.ConvertCloneCodebase(spec.Clone)
+			stage.Cache = convert_helpers.ConvertCaching(spec.Cache)
+			stage.BuildIntelligence = convert_helpers.ConvertBuildIntelligence(spec.BuildIntelligence)
+
 			stage.SharedPaths = spec.SharedPaths
 			stage.Platform = convert_helpers.ConvertPlatform(spec.Platform)
 			// V1 sources K8s stage OS from platform.os (not runtime.kubernetes.os). When the V0
@@ -201,9 +208,9 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 		if ok && spec != nil {
 			// Convert deployment steps
 			if spec.Execution != nil {
-				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "")
+				stage.Steps = c.ConvertSteps(spec.Execution.Steps, false, stepsPath, src.ID, "", nil)
 				if spec.Execution.RollbackSteps != nil {
-					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "")
+					stage.Rollback = c.ConvertSteps(spec.Execution.RollbackSteps, true, rollbackStepsPath, src.ID, "", nil)
 				}
 			}
 

--- a/convert/v0tov1/pipeline_converter/convert_step_template.go
+++ b/convert/v0tov1/pipeline_converter/convert_step_template.go
@@ -28,7 +28,7 @@ func (c *PipelineConverter) convertStepTemplate(src *v0.Step, isRollback bool, b
 	// If templateInputs exists, convert it to overlay.step
 	if template.TemplateInputs != nil {
 		// Convert the templateInputs (which is a *Step) directly
-		overlayStep := c.ConvertSingleStep(template.TemplateInputs, isRollback, basePath, "", "")
+		overlayStep := c.ConvertSingleStep(template.TemplateInputs, isRollback, basePath, "", "", nil)
 		if overlayStep != nil {
 			result.With = &v1.StepTemplateWith{
 				Overlay: &v1.StepTemplateOverlay{

--- a/convert/v0tov1/pipeline_converter/convert_stepgroup_template.go
+++ b/convert/v0tov1/pipeline_converter/convert_stepgroup_template.go
@@ -36,7 +36,7 @@ func (c *PipelineConverter) convertStepGroupTemplate(src *v0.StepGroup, isRollba
 		overlayStep.Group = &v1.StepGroup{Steps: make([]*v1.Step, 0)}
 
 		if inputs.Steps != nil {
-			overlayStep.Group.Steps = c.ConvertSteps(inputs.Steps, isRollback, groupPath, "", "")
+			overlayStep.Group.Steps = c.ConvertSteps(inputs.Steps, isRollback, groupPath, "", "", nil)
 		}
 
 		if inputs.Variables != nil {

--- a/convert/v0tov1/pipeline_converter/convert_steps.go
+++ b/convert/v0tov1/pipeline_converter/convert_steps.go
@@ -32,8 +32,10 @@ func splitGroupChain(groupID string) []string {
 
 // convertSteps converts a list of v0.Steps to a list of v1.Step. stageID and
 // groupID scope step registration; groupID is the ">"-joined ancestor chain
-// (e.g. "A>B>C") that disambiguates same-named groups.
-func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, basePath, stageID, groupID string) []*v1.Step {
+// (e.g. "A>B>C") that disambiguates same-named groups. stepCtx is the
+// stage-scoped context (Cloud runtime awareness, etc.) forwarded to helpers
+// that need it; nil is safe and preserves today's behavior.
+func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, basePath, stageID, groupID string, stepCtx *convert_helpers.StepConvertContext) []*v1.Step {
 	if len(src) == 0 {
 		return make([]*v1.Step, 0)
 	}
@@ -43,14 +45,14 @@ func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, baseP
 			continue
 		}
 		if s.Step != nil {
-			if step := c.ConvertSingleStep(s.Step, isRollBack, basePath, stageID, groupID); step != nil {
+			if step := c.ConvertSingleStep(s.Step, isRollBack, basePath, stageID, groupID, stepCtx); step != nil {
 				dst = append(dst, step)
 			}
 			continue
 		}
 		if s.Parallel != nil {
 			parallel_group := &v1.StepGroup{
-				Steps: c.ConvertSteps(s.Parallel, isRollBack, basePath, stageID, groupID),
+				Steps: c.ConvertSteps(s.Parallel, isRollBack, basePath, stageID, groupID, stepCtx),
 			}
 			parallel := &v1.Step{
 				Parallel: parallel_group,
@@ -86,7 +88,7 @@ func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, baseP
 				group.Env = s.StepGroup.Env
 				childGroupID := appendGroupChain(groupID, s.StepGroup.ID)
 				group.Group = &v1.StepGroup{
-					Steps:  c.ConvertSteps(s.StepGroup.Steps, isRollBack, groupPath, stageID, childGroupID),
+					Steps:  c.ConvertSteps(s.StepGroup.Steps, isRollBack, groupPath, stageID, childGroupID, stepCtx),
 					Inputs: c.convertVariables(s.StepGroup.Variables),
 				}
 				group.OnFailure = convert_helpers.ConvertFailureStrategies(s.StepGroup.FailureStrategies)
@@ -101,7 +103,7 @@ func (c *PipelineConverter) ConvertSteps(src []*v0.Steps, isRollBack bool, baseP
 	return dst
 }
 
-func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, basePath, stageID, groupID string) *v1.Step {
+func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, basePath, stageID, groupID string, stepCtx *convert_helpers.StepConvertContext) *v1.Step {
 	if src == nil {
 		return nil
 	}
@@ -138,9 +140,9 @@ func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, bas
 	case v0.StepTypeJiraUpdate:
 		step.Template = convert_helpers.ConvertStepJiraUpdate(src)
 	case v0.StepTypeRun:
-		step.Run = convert_helpers.ConvertStepRun(src)
+		step.Run = convert_helpers.ConvertStepRun(src, stepCtx)
 	case v0.StepTypeBackground:
-		step.Background = convert_helpers.ConvertStepBackground(src)
+		step.Background = convert_helpers.ConvertStepBackground(src, stepCtx)
 	case v0.StepTypeHarnessApproval:
 		step.Approval = convert_helpers.ConvertStepHarnessApproval(src)
 	case v0.StepTypeK8sRollingDeploy:
@@ -234,11 +236,11 @@ func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, bas
 	case v0.StepTypeBuildAndPushDockerRegistry:
 		step.Template = convert_helpers.ConvertStepBuildAndPushDockerRegistry(src)
 	case v0.StepTypePlugin:
-		step.Run = convert_helpers.ConvertStepPlugin(src)
+		step.Run = convert_helpers.ConvertStepPlugin(src, stepCtx)
 	case v0.StepTypeTest:
-		step.RunTest = convert_helpers.ConvertStepTestIntelligence(src)
+		step.RunTest = convert_helpers.ConvertStepTestIntelligence(src, stepCtx)
 	case v0.StepTypeRunTests:
-		step.RunTest = convert_helpers.ConvertStepRunTests(src)
+		step.RunTest = convert_helpers.ConvertStepRunTests(src, stepCtx)
 	case v0.StepTypeGitClone:
 		step.Template = convert_helpers.ConvertStepGitClone(src)
 	case v0.StepTypeIACMTerraformPlugin:
@@ -248,7 +250,7 @@ func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, bas
 	case v0.StepTypeBitrise:
 		step.Run = convert_helpers.ConvertStepBitrise(src)
 	case v0.StepTypeContainer:
-		step.Run = convert_helpers.ConvertStepContainer(src)
+		step.Run = convert_helpers.ConvertStepContainer(src, stepCtx)
 	case v0.StepTypeFilesUpload:
 		step.Upload = convert_helpers.ConvertStepFilesUpload(src)
 	default:

--- a/convert/v0tov1/pipeline_converter/convert_template.go
+++ b/convert/v0tov1/pipeline_converter/convert_template.go
@@ -26,7 +26,7 @@ func (c *PipelineConverter) ConvertTemplate(src *v0.Template) *v1.Template {
 		}
 	case "Step":
 		if spec, ok := src.Spec.(*v0.Step); ok {
-			dst.Step = c.ConvertSingleStep(spec, false, "", "", "")
+			dst.Step = c.ConvertSingleStep(spec, false, "", "", "", nil)
 		}
 	case "StepGroup":
 		if spec, ok := src.Spec.(*v0.StepGroup); ok {
@@ -35,7 +35,7 @@ func (c *PipelineConverter) ConvertTemplate(src *v0.Template) *v1.Template {
 				Id:   spec.ID,
 				Env:  spec.Env,
 				Group: &v1.StepGroup{
-					Steps:  c.ConvertSteps(spec.Steps, false, "", "", ""),
+					Steps:  c.ConvertSteps(spec.Steps, false, "", "", "", nil),
 					Inputs: c.convertVariables(spec.Variables),
 				},
 				OnFailure: convert_helpers.ConvertFailureStrategies(spec.FailureStrategies),


### PR DESCRIPTION
 ## Summary
  - On Cloud infra (`stage.spec.runtime.type: Cloud`), a v0 CI step is
    "containerless" when it omits `spec.image` — it runs directly on the
    hosted VM. The v0→v1 converter unconditionally emitted a
    `container: {...}` block whenever any container-adjacent field
    (`resources`, `runAsUser`, `privileged`, `connectorRef`) was set,
    wrapping the step as container-based on Cloud and defeating the
    intended execution mode. This change threads stage runtime awareness
    into the per-step helpers so a Cloud step with no image emits **no**
    `container` block; container-only fields are dropped with a single
    `CLOUD_CONTAINERLESS_FIELDS_DROPPED` WARN naming them. Non-Cloud infra
    (K8s / VM / Shell) and Cloud steps that DO carry an image are
    byte-for-byte unchanged.
  - Mechanically: new `StepConvertContext{Runtime}` with a nil-safe
    `IsCloud()` in `convert_helpers/step_context.go`, threaded through
    `ConvertSteps` / `ConvertSingleStep` and forwarded only to the seven
    helpers that emit container blocks (Run, Plugin, Background, RunTests,
    TestIntelligence, Container, ServiceDependency). `convertStage` for
    `StageTypeCI` and `StageTypeIACM` now resolves the stage runtime
    BEFORE converting steps so the ctx is populated when helpers run.
    Template callers pass `nil`; `IsCloud()` returns false on nil, so
    their behavior is unchanged.
  - Scope: `runtime.type: Cloud` only. `infrastructure.type: HostedVm`
    continues to return `nil` runtime