### PR TITLE
add conversion for AWS SAM and Serverless steps

### DIFF
--- a/convert/harness/yaml/const.go
+++ b/convert/harness/yaml/const.go
@@ -79,17 +79,17 @@ const (
 	StepTypeContainer                  = "Container"
 
 	// Feature Flags
-	StepTypeHTTP               = "Http"
-	StepTypeEmail              = "Email"
-	StepTypeJiraApproval       = "JiraApproval"
-	StepTypeJiraCreate         = "JiraCreate"
-	StepTypeJiraUpdate         = "JiraUpdate"
-	StepTypeServiceNowApproval = "ServiceNowApproval"
-	StepTypeServiceNowCreate   = "ServiceNowCreate"
-	StepTypeServiceNowUpdate   = "ServiceNowUpdate"
-	StepTypeShellScript        = "ShellScript"
-	StepTypeWait               = "Wait"
-	StepTypeCustomApproval     = "CustomApproval"
+	StepTypeHTTP                 = "Http"
+	StepTypeEmail                = "Email"
+	StepTypeJiraApproval         = "JiraApproval"
+	StepTypeJiraCreate           = "JiraCreate"
+	StepTypeJiraUpdate           = "JiraUpdate"
+	StepTypeServiceNowApproval   = "ServiceNowApproval"
+	StepTypeServiceNowCreate     = "ServiceNowCreate"
+	StepTypeServiceNowUpdate     = "ServiceNowUpdate"
+	StepTypeShellScript          = "ShellScript"
+	StepTypeWait                 = "Wait"
+	StepTypeCustomApproval       = "CustomApproval"
 	StepTypeShellScriptProvision = "ShellScriptProvision"
 	StepTypeFilesUpload          = "FilesUpload"
 
@@ -119,15 +119,26 @@ const (
 	StepTypeHelmDeploy            = "HelmDeploy"
 	StepTypeHelmRollback          = "HelmRollback"
 
+	// CD / AWS SAM
+	StepTypeAwsSamBuild    = "AwsSamBuild"
+	StepTypeAwsSamDeploy   = "AwsSamDeploy"
+	StepTypeAwsSamRollback = "AwsSamRollback"
+
+	// CD / Serverless (AWS Lambda V2)
+	StepTypeServerlessAwsLambdaDeployV2          = "ServerlessAwsLambdaDeployV2"
+	StepTypeServerlessAwsLambdaPackageV2         = "ServerlessAwsLambdaPackageV2"
+	StepTypeServerlessAwsLambdaRollbackV2        = "ServerlessAwsLambdaRollbackV2"
+	StepTypeServerlessAwsLambdaPrepareRollbackV2 = "ServerlessAwsLambdaPrepareRollbackV2"
+
 	// Approval
 	StepTypeVerify = "Verify"
 
 	// IACM
 	StepTypeIACMTerraformPlugin = "IACMTerraformPlugin"
-	StepTypeIACMOpenTofuPlugin = "IACMOpenTofuPlugin"
+	StepTypeIACMOpenTofuPlugin  = "IACMOpenTofuPlugin"
 
 	// Terraform
-	StepTypeTerraformPlan = "TerraformPlan"
+	StepTypeTerraformPlan  = "TerraformPlan"
 	StepTypeTerraformApply = "TerraformApply"
 )
 

--- a/convert/harness/yaml/step.go
+++ b/convert/harness/yaml/step.go
@@ -899,6 +899,20 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 		s.Spec = new(StepContainer)
 	case StepTypeFilesUpload:
 		s.Spec = new(StepFilesUpload)
+	case StepTypeAwsSamBuild:
+		s.Spec = new(StepAwsSamBuild)
+	case StepTypeAwsSamDeploy:
+		s.Spec = new(StepAwsSamDeploy)
+	case StepTypeAwsSamRollback:
+		s.Spec = new(StepAwsSamRollback)
+	case StepTypeServerlessAwsLambdaDeployV2:
+		s.Spec = new(StepServerlessAwsLambdaDeployV2)
+	case StepTypeServerlessAwsLambdaPackageV2:
+		s.Spec = new(StepServerlessAwsLambdaPackageV2)
+	case StepTypeServerlessAwsLambdaRollbackV2:
+		s.Spec = new(StepServerlessAwsLambdaRollbackV2)
+	case StepTypeServerlessAwsLambdaPrepareRollbackV2:
+		s.Spec = new(StepServerlessAwsLambdaPrepareRollbackV2)
 	default:
 		// Preserve s.Type and leave s.Spec nil. The converter emits a
 		// pass-through step and records an UNKNOWN_STEP_TYPE warning on

--- a/convert/harness/yaml/step_serverless.go
+++ b/convert/harness/yaml/step_serverless.go
@@ -1,0 +1,109 @@
+package yaml
+
+import "github.com/drone/go-convert/internal/flexible"
+
+// v0 struct ports of the harness-core AWS SAM and Serverless (AWS Lambda V2)
+// container-based CD step specs. Field yaml tags match the authoritative
+// *StepInfo.java JSON keys.
+type (
+	// CD: AWS SAM Build (harness-core AwsSamBuildStepInfo, extends AwsSamBaseStepInfo)
+	StepAwsSamBuild struct {
+		CommonStepSpec
+		Image                              string                    `json:"image,omitempty"                              yaml:"image,omitempty"`
+		ConnectorRef                       string                    `json:"connectorRef,omitempty"                       yaml:"connectorRef,omitempty"`
+		Resources                          *Resources                `json:"resources,omitempty"                          yaml:"resources,omitempty"`
+		EnvVariables                       *flexible.Field[map[string]string] `json:"envVariables,omitempty"              yaml:"envVariables,omitempty"`
+		Privileged                         *flexible.Field[bool]     `json:"privileged,omitempty"                         yaml:"privileged,omitempty"`
+		RunAsUser                          *flexible.Field[int]      `json:"runAsUser,omitempty"                          yaml:"runAsUser,omitempty"`
+		ImagePullPolicy                    string                    `json:"imagePullPolicy,omitempty"                    yaml:"imagePullPolicy,omitempty"`
+		SamVersion                         string                    `json:"samVersion,omitempty"                         yaml:"samVersion,omitempty"`
+		PreExecution                       string                    `json:"preExecution,omitempty"                       yaml:"preExecution,omitempty"`
+		BuildCommandOptions                *flexible.Field[[]string] `json:"buildCommandOptions,omitempty"                yaml:"buildCommandOptions,omitempty"`
+		SamBuildDockerRegistryConnectorRef string                    `json:"samBuildDockerRegistryConnectorRef,omitempty" yaml:"samBuildDockerRegistryConnectorRef,omitempty"`
+	}
+
+	// CD: AWS SAM Deploy (harness-core AwsSamDeployStepInfo, extends AwsSamBaseStepInfo)
+	StepAwsSamDeploy struct {
+		CommonStepSpec
+		Image                string                             `json:"image,omitempty"                yaml:"image,omitempty"`
+		ConnectorRef         string                             `json:"connectorRef,omitempty"         yaml:"connectorRef,omitempty"`
+		Resources            *Resources                         `json:"resources,omitempty"            yaml:"resources,omitempty"`
+		EnvVariables         *flexible.Field[map[string]string] `json:"envVariables,omitempty"         yaml:"envVariables,omitempty"`
+		Privileged           *flexible.Field[bool]              `json:"privileged,omitempty"           yaml:"privileged,omitempty"`
+		RunAsUser            *flexible.Field[int]               `json:"runAsUser,omitempty"            yaml:"runAsUser,omitempty"`
+		ImagePullPolicy      string                             `json:"imagePullPolicy,omitempty"      yaml:"imagePullPolicy,omitempty"`
+		SamVersion           string                             `json:"samVersion,omitempty"           yaml:"samVersion,omitempty"`
+		PreExecution         string                             `json:"preExecution,omitempty"         yaml:"preExecution,omitempty"`
+		DeployCommandOptions *flexible.Field[[]string]          `json:"deployCommandOptions,omitempty" yaml:"deployCommandOptions,omitempty"`
+		StackName            string                             `json:"stackName,omitempty"            yaml:"stackName,omitempty"`
+	}
+
+	// CD: AWS SAM Rollback (harness-core AwsSamRollbackStepInfo, extends AwsSamRollbackBaseStepInfo).
+	// Only delegateSelectors (handled via CommonStepSpec) is a YAML field.
+	StepAwsSamRollback struct {
+		CommonStepSpec
+	}
+
+	// CD: Serverless AWS Lambda Deploy V2 (harness-core ServerlessAwsLambdaDeployV2StepInfo,
+	// extends ServerlessAwsLambdaV2BaseStepInfo)
+	StepServerlessAwsLambdaDeployV2 struct {
+		CommonStepSpec
+		Image                string                             `json:"image,omitempty"                yaml:"image,omitempty"`
+		ConnectorRef         string                             `json:"connectorRef,omitempty"         yaml:"connectorRef,omitempty"`
+		Resources            *Resources                         `json:"resources,omitempty"            yaml:"resources,omitempty"`
+		EnvVariables         *flexible.Field[map[string]string] `json:"envVariables,omitempty"         yaml:"envVariables,omitempty"`
+		Privileged           *flexible.Field[bool]              `json:"privileged,omitempty"           yaml:"privileged,omitempty"`
+		RunAsUser            *flexible.Field[int]               `json:"runAsUser,omitempty"            yaml:"runAsUser,omitempty"`
+		ImagePullPolicy      string                             `json:"imagePullPolicy,omitempty"      yaml:"imagePullPolicy,omitempty"`
+		ServerlessVersion    string                             `json:"serverlessVersion,omitempty"    yaml:"serverlessVersion,omitempty"`
+		PreExecution         string                             `json:"preExecution,omitempty"         yaml:"preExecution,omitempty"`
+		DeployCommandOptions *flexible.Field[[]string]          `json:"deployCommandOptions,omitempty" yaml:"deployCommandOptions,omitempty"`
+	}
+
+	// CD: Serverless AWS Lambda Package V2 (harness-core ServerlessAwsLambdaPackageV2StepInfo,
+	// extends ServerlessAwsLambdaV2BaseStepInfo)
+	StepServerlessAwsLambdaPackageV2 struct {
+		CommonStepSpec
+		Image                 string                             `json:"image,omitempty"                 yaml:"image,omitempty"`
+		ConnectorRef          string                             `json:"connectorRef,omitempty"          yaml:"connectorRef,omitempty"`
+		Resources             *Resources                         `json:"resources,omitempty"             yaml:"resources,omitempty"`
+		EnvVariables          *flexible.Field[map[string]string] `json:"envVariables,omitempty"          yaml:"envVariables,omitempty"`
+		Privileged            *flexible.Field[bool]              `json:"privileged,omitempty"            yaml:"privileged,omitempty"`
+		RunAsUser             *flexible.Field[int]               `json:"runAsUser,omitempty"             yaml:"runAsUser,omitempty"`
+		ImagePullPolicy       string                             `json:"imagePullPolicy,omitempty"       yaml:"imagePullPolicy,omitempty"`
+		ServerlessVersion     string                             `json:"serverlessVersion,omitempty"     yaml:"serverlessVersion,omitempty"`
+		PreExecution          string                             `json:"preExecution,omitempty"          yaml:"preExecution,omitempty"`
+		PackageCommandOptions *flexible.Field[[]string]          `json:"packageCommandOptions,omitempty" yaml:"packageCommandOptions,omitempty"`
+	}
+
+	// CD: Serverless AWS Lambda Prepare Rollback V2 (harness-core
+	// ServerlessAwsLambdaPrepareRollbackV2StepInfo, extends ServerlessAwsLambdaV2BaseStepInfo).
+	// Same v0 YAML fields as the Rollback V2 step; differs only by type + internal FQN.
+	StepServerlessAwsLambdaPrepareRollbackV2 struct {
+		CommonStepSpec
+		Image             string                             `json:"image,omitempty"             yaml:"image,omitempty"`
+		ConnectorRef      string                             `json:"connectorRef,omitempty"      yaml:"connectorRef,omitempty"`
+		Resources         *Resources                         `json:"resources,omitempty"         yaml:"resources,omitempty"`
+		EnvVariables      *flexible.Field[map[string]string] `json:"envVariables,omitempty"      yaml:"envVariables,omitempty"`
+		Privileged        *flexible.Field[bool]              `json:"privileged,omitempty"        yaml:"privileged,omitempty"`
+		RunAsUser         *flexible.Field[int]               `json:"runAsUser,omitempty"         yaml:"runAsUser,omitempty"`
+		ImagePullPolicy   string                             `json:"imagePullPolicy,omitempty"   yaml:"imagePullPolicy,omitempty"`
+		ServerlessVersion string                             `json:"serverlessVersion,omitempty" yaml:"serverlessVersion,omitempty"`
+		PreExecution      string                             `json:"preExecution,omitempty"      yaml:"preExecution,omitempty"`
+	}
+
+	// CD: Serverless AWS Lambda Rollback V2 (harness-core ServerlessAwsLambdaRollbackV2StepInfo,
+	// extends ServerlessAwsLambdaV2BaseStepInfo)
+	StepServerlessAwsLambdaRollbackV2 struct {
+		CommonStepSpec
+		Image             string                             `json:"image,omitempty"             yaml:"image,omitempty"`
+		ConnectorRef      string                             `json:"connectorRef,omitempty"      yaml:"connectorRef,omitempty"`
+		Resources         *Resources                         `json:"resources,omitempty"         yaml:"resources,omitempty"`
+		EnvVariables      *flexible.Field[map[string]string] `json:"envVariables,omitempty"      yaml:"envVariables,omitempty"`
+		Privileged        *flexible.Field[bool]              `json:"privileged,omitempty"        yaml:"privileged,omitempty"`
+		RunAsUser         *flexible.Field[int]               `json:"runAsUser,omitempty"         yaml:"runAsUser,omitempty"`
+		ImagePullPolicy   string                             `json:"imagePullPolicy,omitempty"   yaml:"imagePullPolicy,omitempty"`
+		ServerlessVersion string                             `json:"serverlessVersion,omitempty" yaml:"serverlessVersion,omitempty"`
+		PreExecution      string                             `json:"preExecution,omitempty"      yaml:"preExecution,omitempty"`
+	}
+)

--- a/convert/v0tov1/convert_helpers/convert_container_resources.go
+++ b/convert/v0tov1/convert_helpers/convert_container_resources.go
@@ -6,16 +6,47 @@ import (
 	"github.com/drone/go-convert/internal/flexible"
 )
 
-// ConvertTemplateContainer builds a v1.Container for template steps
-// from v0 RunAsUser and Resources fields. Returns nil if both are empty.
-func ConvertTemplateContainer(runAsUser *flexible.Field[int], resources *v0.Resources) *v1.Container {
+// containerConfig holds the optional container fields configured via
+// ContainerOption. runAsUser and resources remain required positional args.
+type containerConfig struct {
+	privileged      *flexible.Field[bool]
+	imagePullPolicy string
+}
+
+// ContainerOption configures optional fields on the v1.Container built by
+// ConvertTemplateContainer.
+type ContainerOption func(*containerConfig)
+
+// WithPrivileged sets the container privileged flag.
+func WithPrivileged(v *flexible.Field[bool]) ContainerOption {
+	return func(c *containerConfig) { c.privileged = v }
+}
+
+// WithImagePullPolicy sets the v0 image pull policy; it is converted to the v1
+// pull format internally by ConvertTemplateContainer.
+func WithImagePullPolicy(v string) ContainerOption {
+	return func(c *containerConfig) { c.imagePullPolicy = v }
+}
+
+// ConvertTemplateContainer builds a v1.Container for template steps from v0
+// RunAsUser and Resources fields plus any optional fields supplied via opts.
+// Returns nil if no fields are set.
+func ConvertTemplateContainer(runAsUser *flexible.Field[int], resources *v0.Resources, opts ...ContainerOption) *v1.Container {
+	cfg := &containerConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	res := ConvertContainerResources(resources)
-	if runAsUser == nil && res == nil {
+	pull := ConvertImagePullPolicy(cfg.imagePullPolicy)
+	if runAsUser == nil && res == nil && cfg.privileged == nil && pull == "" {
 		return nil
 	}
 	return &v1.Container{
-		User:      runAsUser,
-		Resources: res,
+		User:       runAsUser,
+		Resources:  res,
+		Privileged: cfg.privileged,
+		Pull:       pull,
 	}
 }
 

--- a/convert/v0tov1/convert_helpers/convert_step_build_push_docker.go
+++ b/convert/v0tov1/convert_helpers/convert_step_build_push_docker.go
@@ -126,6 +126,10 @@ func ConvertStepBuildAndPushDockerRegistry(src *v0.Step) *v1.StepTemplate {
 	return &v1.StepTemplate{
 		Uses:      uses,
 		With:      with,
-		Container: ConvertTemplateContainer(spec.RunAsUser, spec.Resources),
+		Container: ConvertTemplateContainer(
+			spec.RunAsUser, 
+			spec.Resources,
+			WithPrivileged(spec.Privileged),
+		),
 	}
 }

--- a/convert/v0tov1/convert_helpers/convert_step_git_clone.go
+++ b/convert/v0tov1/convert_helpers/convert_step_git_clone.go
@@ -21,9 +21,11 @@ func ConvertStepGitClone(src *v0.Step) *v1.StepTemplate {
 
 	with := make(map[string]interface{})
 
+	var isExternal bool = false
 	// Connector
 	if sp.ConnRef != "" {
 		with["connector"] = sp.ConnRef
+		isExternal = true
 	}
 
 	// Repository name
@@ -32,33 +34,36 @@ func ConvertStepGitClone(src *v0.Step) *v1.StepTemplate {
 	}
 
 	// Build type - extract branch, tag, PR, or commit_sha from Build field
+	// These are nested under the "build" object to match the template inputs.
 	if sp.BuildType != nil && !sp.BuildType.IsNil() {
 		if build, ok := sp.BuildType.AsStruct(); ok {
+			buildObj := make(map[string]interface{})
 			switch build.Type {
 			case "branch":
-				with["build_target"] = "Git Branch"
+				buildObj["target"] = "Git Branch"
 			case "tag":
-				with["build_target"] = "Tag"
+				buildObj["target"] = "Tag"
 			case "PR":
-				with["build_target"] = "Pull Request"
+				buildObj["target"] = "Pull Request"
 			case "commitSha":
-				with["build_target"] = "Commit"
+				buildObj["target"] = "Commit"
 			default:
-				with["build_target"] = build.Type
+				buildObj["target"] = build.Type
 			}
 			if build.Spec.Branch != "" {
-				with["branch"] = build.Spec.Branch
+				buildObj["branch"] = build.Spec.Branch
 			} else if build.Spec.Tag != "" {
-				with["tag"] = build.Spec.Tag
+				buildObj["tag"] = build.Spec.Tag
 			} else if build.Spec.Number != nil {
 				if pr, ok := build.Spec.Number.AsString(); ok {
-					with["pr"] = pr
+					buildObj["pr"] = pr
 				} else if pr, ok := build.Spec.Number.AsStruct(); ok {
-					with["pr"] = fmt.Sprintf("%d", pr)
+					buildObj["pr"] = fmt.Sprintf("%d", pr)
 				}
 			} else if build.Spec.CommitSha != "" {
-				with["commit_sha"] = build.Spec.CommitSha
+				buildObj["commit_sha"] = build.Spec.CommitSha
 			}
+			with["build"] = buildObj
 		}
 	}
 
@@ -138,10 +143,21 @@ func ConvertStepGitClone(src *v0.Step) *v1.StepTemplate {
 	// pr_merge_strategy: no v0 StepGitClone field; template default is "Source Branch"
 	// copy_file_content: no v0 StepGitClone field; optional template input with no default
 
+	var uses string
+	if isExternal {
+		uses = "gitCloneStep"
+	} else {
+		uses = "harnessCodeCloneStep"
+	}
+
 	dst := &v1.StepTemplate{
-		Uses:      "gitCloneStep",
+		Uses:      uses,
 		With:      with,
-		Container: ConvertTemplateContainer(sp.RunAsUser, sp.Resources),
+		Container: ConvertTemplateContainer(
+			sp.RunAsUser,
+			sp.Resources,
+			WithPrivileged(sp.Privileged),
+		),
 	}
 
 	return dst

--- a/convert/v0tov1/convert_helpers/convert_step_git_clone_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_git_clone_test.go
@@ -10,9 +10,10 @@ import (
 
 func TestConvertStepGitClone(t *testing.T) {
 	tests := []struct {
-		name     string
-		step     *v0.Step
-		expected map[string]interface{}
+		name         string
+		step         *v0.Step
+		expected     map[string]interface{}
+		expectedUses string
 	}{
 		{
 			name: "branch build type",
@@ -26,9 +27,11 @@ func TestConvertStepGitClone(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"connector":    "github-connector",
-				"build_target": "Git Branch",
-				"branch":       "main",
+				"connector": "github-connector",
+				"build": map[string]interface{}{
+					"target": "Git Branch",
+					"branch": "main",
+				},
 			},
 		},
 		{
@@ -43,9 +46,11 @@ func TestConvertStepGitClone(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"connector":    "github-connector",
-				"build_target": "Tag",
-				"tag":          "v1.0.0",
+				"connector": "github-connector",
+				"build": map[string]interface{}{
+					"target": "Tag",
+					"tag":    "v1.0.0",
+				},
 			},
 		},
 		{
@@ -60,9 +65,11 @@ func TestConvertStepGitClone(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"connector":    "github-connector",
-				"build_target": "Pull Request",
-				"pr":           "42",
+				"connector": "github-connector",
+				"build": map[string]interface{}{
+					"target": "Pull Request",
+					"pr":     "42",
+				},
 			},
 		},
 		{
@@ -77,9 +84,11 @@ func TestConvertStepGitClone(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"connector":    "github-connector",
-				"build_target": "Commit",
-				"commit_sha":   "abc123def456",
+				"connector": "github-connector",
+				"build": map[string]interface{}{
+					"target":     "Commit",
+					"commit_sha": "abc123def456",
+				},
 			},
 		},
 		{
@@ -116,10 +125,12 @@ func TestConvertStepGitClone(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"connector":          "github-connector",
-				"repo_name":          "my-repo",
-				"build_target":       "Git Branch",
-				"branch":             "develop",
+				"connector": "github-connector",
+				"repo_name": "my-repo",
+				"build": map[string]interface{}{
+					"target": "Git Branch",
+					"branch": "develop",
+				},
 				"clone_directory":    "/workspace/src",
 				"depth":              "50",
 				"lfs_enabled":        true,
@@ -135,7 +146,8 @@ func TestConvertStepGitClone(t *testing.T) {
 			step: &v0.Step{
 				Spec: &v0.StepGitClone{},
 			},
-			expected: map[string]interface{}{},
+			expected:     map[string]interface{}{},
+			expectedUses: "harnessCodeCloneStep",
 		},
 		{
 			name: "expression in build type",
@@ -146,7 +158,7 @@ func TestConvertStepGitClone(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"connector":    "github-connector",
+				"connector": "github-connector",
 			},
 		},
 		{
@@ -184,8 +196,12 @@ func TestConvertStepGitClone(t *testing.T) {
 				t.Fatal("expected non-nil result")
 			}
 
-			if result.Uses != "gitCloneStep" {
-				t.Errorf("expected Uses to be gitCloneStep, got %s", result.Uses)
+			expectedUses := tt.expectedUses
+			if expectedUses == "" {
+				expectedUses = "gitCloneStep"
+			}
+			if result.Uses != expectedUses {
+				t.Errorf("expected Uses to be %s, got %s", expectedUses, result.Uses)
 			}
 
 			if diff := cmp.Diff(tt.expected, result.With); diff != "" {

--- a/convert/v0tov1/convert_helpers/convert_step_serverless.go
+++ b/convert/v0tov1/convert_helpers/convert_step_serverless.go
@@ -1,0 +1,251 @@
+package converthelpers
+
+import (
+	"strings"
+
+	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
+	"github.com/drone/go-convert/internal/flexible"
+)
+
+// joinCommandOptions renders a v0 command-options list (*flexible.Field[[]string])
+// into the single-string form expected by the template `cmd_opts` input. A list
+// value is space-joined; an expression is passed through unchanged.
+func joinCommandOptions(opts *flexible.Field[[]string]) string {
+	if opts == nil {
+		return ""
+	}
+	if list, ok := opts.AsStruct(); ok {
+		return strings.Join(list, " ")
+	}
+	if expr, ok := opts.AsString(); ok {
+		return expr
+	}
+	return ""
+}
+
+// ConvertStepAwsSamBuild converts a v0 AwsSamBuild step to the v1 awsSamBuildStep template.
+func ConvertStepAwsSamBuild(src *v0.Step) *v1.StepTemplate {
+	if src == nil || src.Spec == nil {
+		return nil
+	}
+	spec, ok := src.Spec.(*v0.StepAwsSamBuild)
+	if !ok || spec == nil {
+		return nil
+	}
+
+	with := make(map[string]interface{})
+
+	// v0 connectorRef/image identify the plugin container image + its registry connector,
+	// which map to the template container_registry/image inputs.
+	if spec.ConnectorRef != "" {
+		with["container_registry"] = spec.ConnectorRef
+	}
+	if spec.Image != "" {
+		with["image"] = spec.Image
+	}
+	if opts := joinCommandOptions(spec.BuildCommandOptions); opts != "" {
+		with["cmd_opts"] = opts
+	}
+	if spec.PreExecution != "" {
+		with["pre_exec_cmd"] = spec.PreExecution
+	}
+
+	
+	// FEATURE GAP: v0 samVersion, and samBuildDockerRegistryConnectorRef
+	// have no awsSamBuildStep template input
+	// (samBuildDockerRegistryConnectorRef is a connector, but the template exposes only
+	// registry_url/username/pwd strings). Template inputs connector (AWS), region, path,
+	// work_dir, timeout, docker_retry_count, registry_url/username/pwd, and log_level are
+	// derived from infra/service or defaulted by the template, so they have no v0
+	// step-level source.
+
+	return &v1.StepTemplate{
+		Uses:      v1.StepTypeAwsSamBuild,
+		With:      with,
+		Container: ConvertTemplateContainer(
+			spec.RunAsUser,
+			spec.Resources,
+			WithPrivileged(spec.Privileged),
+			WithImagePullPolicy(spec.ImagePullPolicy),
+		),
+	}
+}
+
+// ConvertStepAwsSamDeploy converts a v0 AwsSamDeploy step to the v1 awsSamDeployStep template.
+func ConvertStepAwsSamDeploy(src *v0.Step) *v1.StepTemplate {
+	if src == nil || src.Spec == nil {
+		return nil
+	}
+	spec, ok := src.Spec.(*v0.StepAwsSamDeploy)
+	if !ok || spec == nil {
+		return nil
+	}
+
+	with := make(map[string]interface{})
+
+	// v0 connectorRef/image identify the plugin container image + its registry connector,
+	// which map to the template container_registry/image inputs.
+	if spec.ConnectorRef != "" {
+		with["container_registry"] = spec.ConnectorRef
+	}
+	if spec.Image != "" {
+		with["image"] = spec.Image
+	}
+	// stack is a required template input (maps from v0 stackName).
+	if spec.StackName != "" {
+		with["stack"] = spec.StackName
+	}
+	if opts := joinCommandOptions(spec.DeployCommandOptions); opts != "" {
+		with["cmd_opts"] = opts
+	}
+	if spec.PreExecution != "" {
+		with["pre_exec_cmd"] = spec.PreExecution
+	}
+
+	
+	// FEATURE GAP: v0 samVersion have no
+	// awsSamDeployStep template input. Template inputs connector (AWS), region, path,
+	// work_dir, timeout, registry_url/username/pwd, and log_level are derived from
+	// infra/service or defaulted by the template.
+
+	return &v1.StepTemplate{
+		Uses:      v1.StepTypeAwsSamDeploy,
+		With:      with,
+		Container: ConvertTemplateContainer(
+			spec.RunAsUser,
+			spec.Resources,
+			WithPrivileged(spec.Privileged),
+			WithImagePullPolicy(spec.ImagePullPolicy),
+		),
+	}
+}
+
+// ConvertStepServerlessAwsLambdaDeployV2 converts a v0 ServerlessAwsLambdaDeployV2 step
+// to the v1 serverlessDeployStep template.
+func ConvertStepServerlessAwsLambdaDeployV2(src *v0.Step) *v1.StepTemplate {
+	if src == nil || src.Spec == nil {
+		return nil
+	}
+	spec, ok := src.Spec.(*v0.StepServerlessAwsLambdaDeployV2)
+	if !ok || spec == nil {
+		return nil
+	}
+
+	with := make(map[string]interface{})
+
+	if spec.ConnectorRef != "" {
+		with["container_registry"] = spec.ConnectorRef
+	}
+	if spec.Image != "" {
+		with["image"] = spec.Image
+	}
+	if opts := joinCommandOptions(spec.DeployCommandOptions); opts != "" {
+		with["cmd_opts"] = opts
+	}
+	if spec.PreExecution != "" {
+		with["pre_exec_cmd"] = spec.PreExecution
+	}
+
+	
+	// FEATURE GAP: v0 serverlessVersion have
+	// no serverlessDeployStep template input. Template inputs connector, region, stage,
+	// path, log_level, timeout, client_path, and work_dir are derived from infra/service
+	// or defaulted by the template.
+
+	return &v1.StepTemplate{
+		Uses:      v1.StepTypeServerlessDeploy,
+		With:      with,
+		Container: ConvertTemplateContainer(
+			spec.RunAsUser,
+			spec.Resources,
+			WithPrivileged(spec.Privileged),
+			WithImagePullPolicy(spec.ImagePullPolicy),
+		),
+	}
+}
+
+// ConvertStepServerlessAwsLambdaPackageV2 converts a v0 ServerlessAwsLambdaPackageV2 step
+// to the v1 serverlessPackageStep template.
+func ConvertStepServerlessAwsLambdaPackageV2(src *v0.Step) *v1.StepTemplate {
+	if src == nil || src.Spec == nil {
+		return nil
+	}
+	spec, ok := src.Spec.(*v0.StepServerlessAwsLambdaPackageV2)
+	if !ok || spec == nil {
+		return nil
+	}
+
+	with := make(map[string]interface{})
+
+	if spec.ConnectorRef != "" {
+		with["container_registry"] = spec.ConnectorRef
+	}
+	if spec.Image != "" {
+		with["image"] = spec.Image
+	}
+	if opts := joinCommandOptions(spec.PackageCommandOptions); opts != "" {
+		with["cmd_opts"] = opts
+	}
+	if spec.PreExecution != "" {
+		with["pre_exec_cmd"] = spec.PreExecution
+	}
+
+	
+	// FEATURE GAP: v0 serverlessVersion have
+	// no serverlessPackageStep template input. Template inputs connector, region, stage,
+	// path, log_level, timeout, client_path, and work_dir are derived from infra/service
+	// or defaulted by the template.
+
+	return &v1.StepTemplate{
+		Uses:      v1.StepTypeServerlessPackage,
+		With:      with,
+		Container: ConvertTemplateContainer(
+			spec.RunAsUser,
+			spec.Resources,
+			WithPrivileged(spec.Privileged),
+			WithImagePullPolicy(spec.ImagePullPolicy),
+		),
+	}
+}
+
+// ConvertStepServerlessAwsLambdaRollbackV2 converts a v0 ServerlessAwsLambdaRollbackV2 step
+// to the v1 serverlessRollbackStep template.
+func ConvertStepServerlessAwsLambdaRollbackV2(src *v0.Step) *v1.StepTemplate {
+	if src == nil || src.Spec == nil {
+		return nil
+	}
+	spec, ok := src.Spec.(*v0.StepServerlessAwsLambdaRollbackV2)
+	if !ok || spec == nil {
+		return nil
+	}
+
+	with := make(map[string]interface{})
+
+	if spec.ConnectorRef != "" {
+		with["container_registry"] = spec.ConnectorRef
+	}
+	if spec.Image != "" {
+		with["image"] = spec.Image
+	}
+	if spec.PreExecution != "" {
+		with["pre_exec_cmd"] = spec.PreExecution
+	}
+
+	
+	// FEATURE GAP: v0 serverlessVersion have
+	// no serverlessRollbackStep template input. Template inputs connector, region,
+	// log_level, timeout, and stack (from ${{rollback.data.PLUGIN_STACK_DETAILS}}) are
+	// derived at runtime or defaulted by the template.
+
+	return &v1.StepTemplate{
+		Uses:      v1.StepTypeServerlessRollback,
+		With:      with,
+		Container: ConvertTemplateContainer(
+			spec.RunAsUser,
+			spec.Resources,
+			WithPrivileged(spec.Privileged),
+			WithImagePullPolicy(spec.ImagePullPolicy),
+		),
+	}
+}

--- a/convert/v0tov1/convert_helpers/convert_step_serverless_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_serverless_test.go
@@ -1,0 +1,272 @@
+package converthelpers
+
+import (
+	"testing"
+
+	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
+	"github.com/drone/go-convert/internal/flexible"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertStepAwsSamBuild(t *testing.T) {
+	tests := []struct {
+		name     string
+		step     *v0.Step
+		expected *v1.StepTemplate
+	}{
+		{
+			name: "full AWS SAM build",
+			step: &v0.Step{
+				Spec: &v0.StepAwsSamBuild{
+					ConnectorRef:        "account.harnessImage",
+					Image:               "harnessdev/aws-sam-dev:0.0.12",
+					PreExecution:        "npm install",
+					BuildCommandOptions: &flexible.Field[[]string]{Value: []string{"--use-container", "--parallel"}},
+					RunAsUser:           &flexible.Field[int]{Value: 1000},
+					Privileged:          &flexible.Field[bool]{Value: true},
+					ImagePullPolicy:     "IfNotPresent",
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "awsSamBuildStep",
+				With: map[string]interface{}{
+					"container_registry": "account.harnessImage",
+					"image":              "harnessdev/aws-sam-dev:0.0.12",
+					"cmd_opts":           "--use-container --parallel",
+					"pre_exec_cmd":       "npm install",
+				},
+				Container: &v1.Container{
+					User:       &flexible.Field[int]{Value: 1000},
+					Privileged: &flexible.Field[bool]{Value: true},
+					Pull:       "if-not-exists",
+				},
+			},
+		},
+		{
+			name: "minimal AWS SAM build",
+			step: &v0.Step{
+				Spec: &v0.StepAwsSamBuild{
+					ConnectorRef: "account.harnessImage",
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "awsSamBuildStep",
+				With: map[string]interface{}{
+					"container_registry": "account.harnessImage",
+				},
+			},
+		},
+		{
+			name: "build command options as expression",
+			step: &v0.Step{
+				Spec: &v0.StepAwsSamBuild{
+					BuildCommandOptions: &flexible.Field[[]string]{Value: "<+input>"},
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "awsSamBuildStep",
+				With: map[string]interface{}{
+					"cmd_opts": "<+input>",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertStepAwsSamBuild(tt.step)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("ConvertStepAwsSamBuild() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvertStepAwsSamDeploy(t *testing.T) {
+	tests := []struct {
+		name     string
+		step     *v0.Step
+		expected *v1.StepTemplate
+	}{
+		{
+			name: "full AWS SAM deploy",
+			step: &v0.Step{
+				Spec: &v0.StepAwsSamDeploy{
+					ConnectorRef:         "account.harnessImage",
+					Image:                "harnessdev/aws-sam-dev:0.0.12",
+					StackName:            "my-sam-stack",
+					PreExecution:         "npm install",
+					DeployCommandOptions: &flexible.Field[[]string]{Value: []string{"--no-confirm-changeset"}},
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "awsSamDeployStep",
+				With: map[string]interface{}{
+					"container_registry": "account.harnessImage",
+					"image":              "harnessdev/aws-sam-dev:0.0.12",
+					"stack":              "my-sam-stack",
+					"cmd_opts":           "--no-confirm-changeset",
+					"pre_exec_cmd":       "npm install",
+				},
+			},
+		},
+		{
+			name: "minimal AWS SAM deploy with stack only",
+			step: &v0.Step{
+				Spec: &v0.StepAwsSamDeploy{
+					StackName: "my-sam-stack",
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "awsSamDeployStep",
+				With: map[string]interface{}{
+					"stack": "my-sam-stack",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertStepAwsSamDeploy(tt.step)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("ConvertStepAwsSamDeploy() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvertStepServerlessAwsLambdaDeployV2(t *testing.T) {
+	tests := []struct {
+		name     string
+		step     *v0.Step
+		expected *v1.StepTemplate
+	}{
+		{
+			name: "full serverless deploy",
+			step: &v0.Step{
+				Spec: &v0.StepServerlessAwsLambdaDeployV2{
+					ConnectorRef:         "account.harnessImage",
+					Image:                "harnessdev/serverless-plugin:0.0.2",
+					PreExecution:         "npm install",
+					DeployCommandOptions: &flexible.Field[[]string]{Value: []string{"--verbose"}},
+					RunAsUser:            &flexible.Field[int]{Value: 0},
+					Privileged:           &flexible.Field[bool]{Value: false},
+					ImagePullPolicy:      "Always",
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "serverlessDeployStep",
+				With: map[string]interface{}{
+					"container_registry": "account.harnessImage",
+					"image":              "harnessdev/serverless-plugin:0.0.2",
+					"cmd_opts":           "--verbose",
+					"pre_exec_cmd":       "npm install",
+				},
+				Container: &v1.Container{
+					User:       &flexible.Field[int]{Value: 0},
+					Privileged: &flexible.Field[bool]{Value: false},
+					Pull:       "always",
+				},
+			},
+		},
+		{
+			name: "minimal serverless deploy",
+			step: &v0.Step{
+				Spec: &v0.StepServerlessAwsLambdaDeployV2{
+					Image: "harnessdev/serverless-plugin:0.0.2",
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "serverlessDeployStep",
+				With: map[string]interface{}{
+					"image": "harnessdev/serverless-plugin:0.0.2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertStepServerlessAwsLambdaDeployV2(tt.step)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("ConvertStepServerlessAwsLambdaDeployV2() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvertStepServerlessAwsLambdaPackageV2(t *testing.T) {
+	tests := []struct {
+		name     string
+		step     *v0.Step
+		expected *v1.StepTemplate
+	}{
+		{
+			name: "full serverless package",
+			step: &v0.Step{
+				Spec: &v0.StepServerlessAwsLambdaPackageV2{
+					ConnectorRef:          "account.harnessImage",
+					Image:                 "harnessdev/serverless-plugin:0.0.2",
+					PreExecution:          "pip install",
+					PackageCommandOptions: &flexible.Field[[]string]{Value: []string{"--verbose", "--stage", "dev"}},
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "serverlessPackageStep",
+				With: map[string]interface{}{
+					"container_registry": "account.harnessImage",
+					"image":              "harnessdev/serverless-plugin:0.0.2",
+					"cmd_opts":           "--verbose --stage dev",
+					"pre_exec_cmd":       "pip install",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertStepServerlessAwsLambdaPackageV2(tt.step)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("ConvertStepServerlessAwsLambdaPackageV2() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvertStepServerlessAwsLambdaRollbackV2(t *testing.T) {
+	tests := []struct {
+		name     string
+		step     *v0.Step
+		expected *v1.StepTemplate
+	}{
+		{
+			name: "full serverless rollback",
+			step: &v0.Step{
+				Spec: &v0.StepServerlessAwsLambdaRollbackV2{
+					ConnectorRef: "account.harnessImage",
+					Image:        "harnessdev/serverless-plugin:0.0.2",
+					PreExecution: "npm install",
+				},
+			},
+			expected: &v1.StepTemplate{
+				Uses: "serverlessRollbackStep",
+				With: map[string]interface{}{
+					"container_registry": "account.harnessImage",
+					"image":              "harnessdev/serverless-plugin:0.0.2",
+					"pre_exec_cmd":       "npm install",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertStepServerlessAwsLambdaRollbackV2(tt.step)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("ConvertStepServerlessAwsLambdaRollbackV2() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/convert/v0tov1/pipeline_converter/convert_steps.go
+++ b/convert/v0tov1/pipeline_converter/convert_steps.go
@@ -187,6 +187,16 @@ func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, bas
 		step.Template = convert_helpers.ConvertStepHelmDeploy(src)
 	case v0.StepTypeHelmRollback:
 		step.Template = convert_helpers.ConvertStepHelmRollback(src)
+	case v0.StepTypeAwsSamBuild:
+		step.Template = convert_helpers.ConvertStepAwsSamBuild(src)
+	case v0.StepTypeAwsSamDeploy:
+		step.Template = convert_helpers.ConvertStepAwsSamDeploy(src)
+	case v0.StepTypeServerlessAwsLambdaDeployV2:
+		step.Template = convert_helpers.ConvertStepServerlessAwsLambdaDeployV2(src)
+	case v0.StepTypeServerlessAwsLambdaPackageV2:
+		step.Template = convert_helpers.ConvertStepServerlessAwsLambdaPackageV2(src)
+	case v0.StepTypeServerlessAwsLambdaRollbackV2:
+		step.Template = convert_helpers.ConvertStepServerlessAwsLambdaRollbackV2(src)
 	case v0.StepTypeWait:
 		step.Wait = convert_helpers.ConvertStepWait(src)
 	case v0.StepTypeHTTP:

--- a/convert/v0tov1/yaml/const.go
+++ b/convert/v0tov1/yaml/const.go
@@ -65,6 +65,15 @@ const (
 	StepTypeHelmDeploy            = "helmBasicDeployStep"
 	StepTypeHelmRollback          = "helmRollbackStep"
 
+	// CD / AWS SAM
+	StepTypeAwsSamBuild  = "awsSamBuildStep"
+	StepTypeAwsSamDeploy = "awsSamDeployStep"
+
+	// CD / Serverless (AWS Lambda V2)
+	StepTypeServerlessDeploy   = "serverlessDeployStep"
+	StepTypeServerlessPackage  = "serverlessPackageStep"
+	StepTypeServerlessRollback = "serverlessRollbackStep"
+
 	// Approval
 	StepTypeVerify = "Verify"
 


### PR DESCRIPTION
- Add conversion support for AWS Serverless and SAM steps.
- Update conversion of v0 git clone step to external and harness code git clone steps in v1 based on presence of `connectorRef`.
- Wire `privileged` field to the `template.container` for git clone, build and push to docker step conversions.