### PR TITLE
update trigger, inputset and custom approval step conversion

### DIFF
--- a/convert/harness/yaml/trigger.go
+++ b/convert/harness/yaml/trigger.go
@@ -26,6 +26,7 @@ type (
 		Org                string                 `json:"orgIdentifier,omitempty"      yaml:"orgIdentifier,omitempty"`
 		Project            string                 `json:"projectIdentifier,omitempty"  yaml:"projectIdentifier,omitempty"`
 		PipelineIdentifier string                 `json:"pipelineIdentifier,omitempty" yaml:"pipelineIdentifier,omitempty"`
+		PipelineBranchName string                 `json:"pipelineBranchName,omitempty" yaml:"pipelineBranchName,omitempty"`
 		Source             *TriggerSource         `json:"source,omitempty"             yaml:"source,omitempty"`
 		InputSetBranchName string                 `json:"inputSetBranchName,omitempty" yaml:"inputSetBranchName,omitempty"`
 		InputYaml          string                 `json:"inputYaml,omitempty"          yaml:"inputYaml,omitempty"`

--- a/convert/v0tov1/convert_helpers/convert_step_approval.go
+++ b/convert/v0tov1/convert_helpers/convert_step_approval.go
@@ -5,10 +5,9 @@ import (
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
 	"fmt"
 	"strings"
-    "github.com/drone/go-convert/internal/flexible"
 )
 
-func ConvertStepCustomApproval(src *v0.Step) *v1.StepApproval {
+func ConvertStepCustomApproval(src *v0.Step) *v1.StepTemplate {
 	if src == nil || src.Spec == nil {
 		return nil
 	}
@@ -19,49 +18,47 @@ func ConvertStepCustomApproval(src *v0.Step) *v1.StepApproval {
 		return nil
 	}
 
-	dst := &v1.StepApproval{
-		Uses: "custom",
+	dst := &v1.StepTemplate{
+		Uses: "customApproval",
 		With: make(map[string]interface{}),
 	}
 
-	dst.With["script-timeout"] = spec.ScriptTimeout
+	with := dst.With.(map[string]interface{})
+
+	if spec.Source != nil && spec.Source.Spec.Script != "" {
+		with["script"] = spec.Source.Spec.Script
+	}
+	if spec.Shell != "" {
+		with["shell"] = strings.ToLower(spec.Shell)
+	}
+	if spec.ScriptTimeout != "" {
+		with["script_timeout"] = spec.ScriptTimeout
+	}
 	if spec.RetryInterval != "" {
-        dst.With["retry"] = spec.RetryInterval
-    }
+		with["retry"] = spec.RetryInterval
+	}
+
+	if approve := convertCriteria(spec.ApprovalCriteria); approve != nil {
+		with["approve"] = approve
+	}
+	if reject := convertCriteria(spec.RejectionCriteria); reject != nil {
+		with["reject"] = reject
+	}
+
+	if outputs := ConvertOutputVariables(spec.OutputVariables); len(outputs) > 0 {
+		with["output_variables"] = outputs
+	}
 
 	env_map := make(map[string]interface{})
-    var env *flexible.Field[map[string]interface{}]
 	for _, envVar := range spec.EnvironmentVariables {
 		if envVar == nil || envVar.Name == "" || envVar.Value == "" {
 			continue
 		}
 		env_map[envVar.Name] = envVar.Value
 	}
-    if len(env_map) > 0 {
-        env = &flexible.Field[map[string]interface{}]{Value: env_map}
-    }
-
-	outputs := ConvertOutputVariables(spec.OutputVariables)
-	shell := strings.ToLower(spec.Shell)
-    script := ""
-    if spec.Source != nil {
-        script = spec.Source.Spec.Script
-    } 
-	dst.With["run"] = v1.StepRun {
-        Shell: shell,
-		Script: v1.Stringorslice{script},
-		Env: env,
-		Outputs: outputs,
+	if len(env_map) > 0 {
+		with["environment_variables"] = env_map
 	}
-
-    approve := convertCriteria(spec.ApprovalCriteria)
-    reject := convertCriteria(spec.RejectionCriteria)
-    if approve != nil {
-        dst.With["approve"] = approve
-    }
-    if reject != nil {
-        dst.With["reject"] = reject
-    }
 
 	return dst
 }

--- a/convert/v0tov1/pipeline_converter/convert_inputset.go
+++ b/convert/v0tov1/pipeline_converter/convert_inputset.go
@@ -17,7 +17,35 @@ func (c *PipelineConverter) ConvertInputSet(src *v0.InputSet) *v1.InputSet {
 	// Convert the pipeline to overlay
 	if src.Pipeline != nil {
 		dst.Overlay = c.ConvertPipeline(src.Pipeline)
+		dst.Variables = liftPipelineVariables(dst.Overlay)
 	}
 
 	return dst
+}
+
+// liftPipelineVariables pulls pipeline-level inputs out of the overlay
+// pipeline into a scalar map (name -> value) and clears them from the
+// overlay. This emits pipeline-level variables as scalar key/value pairs at
+// the top-level "inputs" map (sibling to "overlay") instead of nested
+// Input objects under overlay.inputs. Value takes precedence over Default;
+// an empty string is used as a fallback to avoid emitting null.
+func liftPipelineVariables(overlay *v1.Pipeline) map[string]interface{} {
+	if overlay == nil || len(overlay.Inputs) == 0 {
+		return nil
+	}
+	vars := make(map[string]interface{}, len(overlay.Inputs))
+	for name, in := range overlay.Inputs {
+		switch {
+		case in == nil:
+			vars[name] = ""
+		case in.Value != nil:
+			vars[name] = in.Value
+		case in.Default != nil:
+			vars[name] = in.Default
+		default:
+			vars[name] = ""
+		}
+	}
+	overlay.Inputs = nil
+	return vars
 }

--- a/convert/v0tov1/pipeline_converter/convert_pipeline.go
+++ b/convert/v0tov1/pipeline_converter/convert_pipeline.go
@@ -5,6 +5,7 @@ import (
 	v0 "github.com/drone/go-convert/convert/harness/yaml"
 	convert_helpers "github.com/drone/go-convert/convert/v0tov1/convert_helpers"
 	v1 "github.com/drone/go-convert/convert/v0tov1/yaml"
+	"github.com/drone/go-convert/internal/flexible"
 )
 
 type PipelineConverter struct {
@@ -99,9 +100,11 @@ func (c *PipelineConverter) convertCodebase(src *v0.Codebase) *v1.Clone {
 				cloneRef.Type = "commit"
 			}
 
-			clone.Ref = cloneRef
+			clone.Ref = &flexible.Field[v1.CloneRef]{Value: cloneRef}
+		} else if build, ok := src.Build.AsString(); ok && build == "<+input>" {
+			clone.Ref = &flexible.Field[v1.CloneRef]{Value: "<+input>"}
 		}
-	}
+	} 
 	clone.Depth = src.Depth
 	clone.Lfs = src.Lfs
 

--- a/convert/v0tov1/pipeline_converter/convert_steps.go
+++ b/convert/v0tov1/pipeline_converter/convert_steps.go
@@ -200,7 +200,7 @@ func (c *PipelineConverter) ConvertSingleStep(src *v0.Step, isRollback bool, bas
 	case v0.StepTypeQueue:
 		step.Queue = convert_helpers.ConvertStepQueue(src)
 	case v0.StepTypeCustomApproval:
-		step.Approval = convert_helpers.ConvertStepCustomApproval(src)
+		step.Template = convert_helpers.ConvertStepCustomApproval(src)
 	case v0.StepTypeJiraApproval:
 		step.Approval = convert_helpers.ConvertStepJiraApproval(src)
 	case v0.StepTypeServiceNowApproval:

--- a/convert/v0tov1/pipeline_converter/convert_template.go
+++ b/convert/v0tov1/pipeline_converter/convert_template.go
@@ -30,20 +30,16 @@ func (c *PipelineConverter) ConvertTemplate(src *v0.Template) *v1.Template {
 		}
 	case "StepGroup":
 		if spec, ok := src.Spec.(*v0.StepGroup); ok {
-			dst.Step = &v1.Step{
-				Name: spec.Name,
-				Id:   spec.ID,
-				Env:  spec.Env,
-				Group: &v1.StepGroup{
-					Steps:  c.ConvertSteps(spec.Steps, false, "", "", ""),
-					Inputs: c.convertVariables(spec.Variables),
-				},
-				OnFailure: convert_helpers.ConvertFailureStrategies(spec.FailureStrategies),
-				Strategy:  convert_helpers.ConvertStrategy(spec.Strategy),
-				Timeout:   spec.Timeout,
-				Delegate:  convert_helpers.ConvertDelegate(spec.DelegateSelectors, nil),
-				If:        convert_helpers.ConvertStepWhen(spec.When, spec.Skip),
+			dst.Env = spec.Env
+			dst.Group = &v1.StepGroup{
+				Steps:  c.ConvertSteps(spec.Steps, false, "", "", ""),
+				Inputs: c.convertVariables(spec.Variables),
 			}
+			dst.OnFailure = convert_helpers.ConvertFailureStrategies(spec.FailureStrategies)
+			dst.Strategy = convert_helpers.ConvertStrategy(spec.Strategy)
+			dst.Timeout = spec.Timeout
+			dst.Delegate = convert_helpers.ConvertDelegate(spec.DelegateSelectors, nil)
+			dst.If = convert_helpers.ConvertStepWhen(spec.When, spec.Skip)
 		}
 	case "Pipeline":
 		if spec, ok := src.Spec.(*v0.Pipeline); ok {

--- a/convert/v0tov1/pipeline_converter/convert_trigger.go
+++ b/convert/v0tov1/pipeline_converter/convert_trigger.go
@@ -42,6 +42,7 @@ func (c *PipelineConverter) ConvertTrigger(src *v0.Trigger, stepInfoByFQN map[st
 		PipelineIdentifier: src.PipelineIdentifier,
 		InputSetBranchName: src.InputSetBranchName,
 		InputSetReferences: src.InputSetReferences,
+		PipelineBranchName: src.PipelineBranchName,
 	}
 
 	// Convert source
@@ -122,10 +123,13 @@ func (c *PipelineConverter) convertInputYaml(inputYaml string, stepInfoByFQN map
 
 	PostProcessExpressions(v1Pipeline, stepInfoByFQN, useFQN)
 
-	// Create the v1 InputSet structure with the converted pipeline as overlay
+	// Create the v1 InputSet structure with the converted pipeline as overlay.
+	// Pipeline-level variables are lifted out of the overlay and emitted as
+	// scalar key/value pairs at the top-level inputs map.
 	v1InputSet := &v1.InputSet{
 		Overlay: v1Pipeline,
 	}
+	v1InputSet.Variables = liftPipelineVariables(v1Pipeline)
 
 	// Marshal to YAML
 	yamlBytes, err := v1.MarshalInputSet(v1InputSet)

--- a/convert/v0tov1/yaml/clone.go
+++ b/convert/v0tov1/yaml/clone.go
@@ -37,7 +37,7 @@ type Clone struct {
 	Enabled   bool   `json:"enabled"`
 	Insecure   *flexible.Field[bool]      `json:"insecure,omitempty"`
 	Lfs        *flexible.Field[bool]      `json:"lfs,omitempty"`
-	Ref        *CloneRef `json:"ref,omitempty"`
+	Ref        *flexible.Field[CloneRef] `json:"ref,omitempty"`
 	Strategy   string    `json:"strategy,omitempty"`
 	Submodules *flexible.Field[bool]      `json:"submodules,omitempty"`
 	Tags       *flexible.Field[bool]      `json:"tags,omitempty"`
@@ -60,7 +60,7 @@ func (v *Clone) UnmarshalJSON(data []byte) error {
 		Enabled   bool      `json:"enabled"`
 		Insecure   *flexible.Field[bool]      `json:"insecure,omitempty"`
 		Lfs        *flexible.Field[bool]      `json:"lfs,omitempty"`
-		Ref        *CloneRef `json:"ref,omitempty"`
+		Ref        *flexible.Field[CloneRef] `json:"ref,omitempty"`
 		Strategy   string    `json:"strategy,omitempty"`
 		Submodules *flexible.Field[bool]      `json:"submodules,omitempty"`
 		Tags       *flexible.Field[bool]      `json:"tags,omitempty"`

--- a/convert/v0tov1/yaml/inputset.go
+++ b/convert/v0tov1/yaml/inputset.go
@@ -1,9 +1,12 @@
 package yaml
 
+import "encoding/json"
+
 type (
 	// InputSet defines a v1 input set configuration.
 	InputSet struct {
-		Overlay *Pipeline `json:"overlay,omitempty" yaml:"overlay,omitempty"`
+		Overlay   *Pipeline              `json:"-" yaml:"-"`
+		Variables map[string]interface{} `json:"-" yaml:"-"`
 	}
 
 	// InputSetConfig is the root wrapper for v1 input set YAML.
@@ -11,3 +14,17 @@ type (
 		Inputs *InputSet `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	}
 )
+
+// MarshalJSON flattens the overlay and any lifted pipeline-level variables
+// into a single map so they render as siblings under the top-level "inputs"
+// key: the overlay under "overlay" and each variable as a scalar key/value.
+func (i *InputSet) MarshalJSON() ([]byte, error) {
+	m := map[string]interface{}{}
+	if i.Overlay != nil {
+		m["overlay"] = i.Overlay
+	}
+	for k, v := range i.Variables {
+		m[k] = v
+	}
+	return json.Marshal(m)
+}

--- a/convert/v0tov1/yaml/template.go
+++ b/convert/v0tov1/yaml/template.go
@@ -29,4 +29,11 @@ type Template struct {
 	Stage        *Stage                             `json:"stage,omitempty"`
 	Step         *Step                              `json:"step,omitempty"`
 	Pipeline     *Pipeline                          `json:"pipeline,omitempty"`
+	Group        *StepGroup                         `json:"group,omitempty"`
+	Env          *flexible.Field[map[string]string] `json:"env,omitempty"`
+	OnFailure    *flexible.Field[[]*FailureStrategy] `json:"on-failure,omitempty"`
+	Strategy     *Strategy                          `json:"strategy,omitempty"`
+	Timeout      string                             `json:"timeout,omitempty"`
+	Delegate     *flexible.Field[*Delegate]         `json:"delegate,omitempty"`
+	If           string                             `json:"if,omitempty"`
 }

--- a/convert/v0tov1/yaml/trigger.go
+++ b/convert/v0tov1/yaml/trigger.go
@@ -28,6 +28,7 @@ type (
 		Org                string            `json:"orgIdentifier,omitempty"      yaml:"orgIdentifier,omitempty"`
 		Project            string            `json:"projectIdentifier,omitempty"  yaml:"projectIdentifier,omitempty"`
 		PipelineIdentifier string            `json:"pipelineIdentifier,omitempty" yaml:"pipelineIdentifier,omitempty"`
+		PipelineBranchName string            `json:"pipelineBranchName,omitempty" yaml:"pipelineBranchName,omitempty"`
 		Source             *TriggerSource    `json:"source,omitempty"             yaml:"source,omitempty"`
 		InputSetBranchName string            `json:"inputSetBranchName,omitempty" yaml:"inputSetBranchName,omitempty"`
 		InputYaml          string            `json:"inputYaml,omitempty"          yaml:"inputYaml,omitempty"`

--- a/convert/v0tov1/yaml/write.go
+++ b/convert/v0tov1/yaml/write.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -202,6 +203,13 @@ func convertJSONNumbers(v interface{}) interface{} {
 		if yamlNumberLike.MatchString(val) {
 			return quotedString(val)
 		}
+		// Multi-line strings (e.g. run scripts) should render as YAML literal
+		// block scalars (|-) for readability. yaml.v3 refuses literal style and
+		// falls back to a double-quoted flow scalar when any line has trailing
+		// whitespace, so trim it per line first.
+		if strings.Contains(val, "\n") {
+			return literalString(trimTrailingSpacePerLine(val))
+		}
 		return val
 	default:
 		return v
@@ -227,6 +235,32 @@ func (q quotedString) MarshalYAML() (interface{}, error) {
 		Style: yaml.DoubleQuotedStyle,
 		Tag:   "!!str",
 	}, nil
+}
+
+// literalString is a string wrapper whose MarshalYAML method forces the YAML
+// emitter to use literal block style (|-) instead of a double-quoted flow
+// scalar for multi-line values.
+type literalString string
+
+func (l literalString) MarshalYAML() (interface{}, error) {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: string(l),
+		Style: yaml.LiteralStyle,
+		Tag:   "!!str",
+	}, nil
+}
+
+// trimTrailingSpacePerLine removes trailing spaces and tabs from each line of
+// s. Trailing whitespace is meaningless for shell scripts but prevents yaml.v3
+// from emitting literal block scalars, so stripping it lets multi-line values
+// render as |- blocks.
+func trimTrailingSpacePerLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // WriteTriggerFile writes the Trigger to the given file path.


### PR DESCRIPTION
## Custom Approval step now converts to a template

Custom Approval steps (`v0.StepTypeCustomApproval`) previously mapped to a native `StepApproval`. They now map to a `StepTemplate` that uses the `customApproval` template, with all configuration passed through `with`.

- `convert/v0tov1/convert_helpers/convert_step_approval.go`: `ConvertStepCustomApproval` now returns a `*v1.StepTemplate` (`uses: customApproval`) instead of `*v1.StepApproval`. The script, shell, timeout, retry interval, approval/rejection criteria, output variables and environment variables are emitted as `with` keys (`script`, `shell`, `script_timeout`, `retry`, `approve`, `reject`, `output_variables`, `environment_variables`).
- `convert/v0tov1/pipeline_converter/convert_steps.go`: the `StepTypeCustomApproval` case now assigns `step.Template` instead of `step.Approval`.

Before (native approval step):

```yaml
- approval:
    uses: custom
    with:
      script-timeout: 10m
      run:
        shell: bash
        script:
          - echo "checking"
```

After (template step):

```yaml
- template:
    uses: customApproval
    with:
      script: echo "checking"
      shell: bash
      script_timeout: 10m
      retry: 30s
      approve:
        # approval criteria
      reject:
        # rejection criteria
      output_variables:
        # output variables
      environment_variables:
        MY_VAR: my_value
```

## StepGroup template restructured

StepGroup templates no longer nest their contents under a `step`. The group, env, failure strategy, strategy, timeout, delegate and `if` fields are now written directly onto the `Template`.

- `convert/v0tov1/pipeline_converter/convert_template.go`: the `StepGroup` case sets `dst.Group`, `dst.Env`, `dst.OnFailure`, `dst.Strategy`, `dst.Timeout`, `dst.Delegate` and `dst.If` directly instead of wrapping everything in a `dst.Step`.
- `convert/v0tov1/yaml/template.go`: `Template` gains `Group`, `Env`, `OnFailure` (`on-failure`), `Strategy`, `Timeout`, `Delegate` and `If` fields.

Before:

```yaml
template:
  step:
    name: my-group
    group:
      steps:
        - ...
    timeout: 10m
```

After:

```yaml
template:
  group:
    steps:
      - ...
  timeout: 10m
```

## Input-set pipeline variables lifted to scalar inputs

Pipeline-level inputs were previously emitted as nested `Input` objects under `overlay.inputs`. They are now lifted out of the overlay and emitted as scalar `name: value` pairs directly under the top-level `inputs` map, as siblings of `overlay`.

- `convert/v0tov1/pipeline_converter/convert_inputset.go`: new `liftPipelineVariables` helper pulls inputs off the overlay pipeline (`Value` takes precedence over `Default`, falling back to `""` to avoid null) and clears them from the overlay.
- `convert/v0tov1/pipeline_converter/convert_trigger.go`: `convertInputYaml` also lifts pipeline variables when building the input set for a trigger's `inputYaml`.
- `convert/v0tov1/yaml/inputset.go`: `InputSet` now holds `Overlay` and `Variables` as non-serialized fields and implements `MarshalJSON` to flatten them into a single map (`overlay` plus each scalar variable).

Before:

```yaml
inputs:
  overlay:
    inputs:
      image:
        value: alpine:latest
```

After:

```yaml
inputs:
  overlay:
    # ...
  image: alpine:latest
```

## Clone `ref` supports `<+input>` and uses a flexible field

The codebase clone `ref` is now a `flexible.Field[CloneRef]`, allowing it to hold either a structured ref or a runtime-input placeholder.

- `convert/v0tov1/yaml/clone.go`: `Clone.Ref` (and its `UnmarshalJSON` shadow) changed from `*CloneRef` to `*flexible.Field[CloneRef]`.
- `convert/v0tov1/pipeline_converter/convert_pipeline.go`: `convertCodebase` wraps the built ref in a `flexible.Field`, and when `build` is the string `<+input>` it sets `clone.Ref` to the `<+input>` placeholder.

```yaml
clone:
  ref: <+input>
```

## Trigger `pipelineBranchName` propagated

- `convert/harness/yaml/trigger.go`: v0 `Trigger` gains a `PipelineBranchName` (`pipelineBranchName`) field.
- `convert/v0tov1/yaml/trigger.go`: v1 `Trigger` gains the same `PipelineBranchName` field.
- `convert/v0tov1/pipeline_converter/convert_trigger.go`: `ConvertTrigger` copies `PipelineBranchName` from source to destination.

## Multi-line strings render as YAML literal block scalars

Multi-line string values (for example run scripts) now render as YAML literal block scalars (`|-`) instead of double-quoted flow scalars.

- `convert/v0tov1/yaml/write.go`: `convertJSONNumbers` wraps multi-line strings in a new `literalString` type whose `MarshalYAML` forces `yaml.LiteralStyle`. Because yaml.v3 refuses literal style when any line has trailing whitespace, `trimTrailingSpacePerLine` strips trailing spaces/tabs per line first.

Before:

```yaml
script: "echo one\necho two"
```

After:

```yaml
script: |-
  echo one
  echo two
```
