### PR TITLE
Pipeline chain ref support and scoped clone ref: <+input> to chain stage

### DIFF
--- a/convert/harness/yaml/stage.go
+++ b/convert/harness/yaml/stage.go
@@ -56,6 +56,7 @@ type (
 		Inputs       *Pipeline                 `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 		Outputs      []*Output                 `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 		InputSetRefs *flexible.Field[[]string] `json:"inputSetReferences,omitempty" yaml:"inputSetReferences,omitempty"`
+		GitBranch    string                    `json:"gitBranch,omitempty" yaml:"gitBranch,omitempty"`
 	}
 
 	StageCustom struct {

--- a/convert/v0tov1/pipeline_converter/convert_pipeline.go
+++ b/convert/v0tov1/pipeline_converter/convert_pipeline.go
@@ -50,7 +50,7 @@ func (c *PipelineConverter) ConvertPipeline(src *v0.Pipeline) *v1.Pipeline {
 	inputs := c.convertVariables(src.Variables)
 	stages := c.convertStages(src.Stages, "pipeline")
 
-	clone := c.convertCodebase(src.Props.CI.Codebase)
+	clone := c.convertCodebase(src.Props.CI.Codebase, false)
 	dst.Inputs = inputs
 	dst.Stages = stages
 	dst.Barriers = barriers
@@ -66,7 +66,7 @@ func (c *PipelineConverter) ConvertPipeline(src *v0.Pipeline) *v1.Pipeline {
 	return dst
 }
 
-func (c *PipelineConverter) convertCodebase(src *v0.Codebase) *v1.Clone {
+func (c *PipelineConverter) convertCodebase(src *v0.Codebase, emitInputRef bool) *v1.Clone {
 	if src == nil {
 		return &v1.Clone{
 			Enabled: false,
@@ -102,7 +102,9 @@ func (c *PipelineConverter) convertCodebase(src *v0.Codebase) *v1.Clone {
 
 			clone.Ref = &flexible.Field[v1.CloneRef]{Value: cloneRef}
 		} else if build, ok := src.Build.AsString(); ok && build == "<+input>" {
-			clone.Ref = &flexible.Field[v1.CloneRef]{Value: "<+input>"}
+			if emitInputRef {
+				clone.Ref = &flexible.Field[v1.CloneRef]{Value: "<+input>"}
+			}
 		}
 	} 
 	clone.Depth = src.Depth

--- a/convert/v0tov1/pipeline_converter/convert_stage.go
+++ b/convert/v0tov1/pipeline_converter/convert_stage.go
@@ -270,6 +270,7 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 					Outputs:   outputs,
 					InputSets: spec.InputSetRefs,
 				},
+				Ref: spec.GitBranch,
 			}
 		}
 
@@ -334,7 +335,7 @@ func (c *PipelineConverter) constructChainInputs(spec *v0.StagePipeline) map[str
 		overlay["stages"] = stages
 	}
 	if spec.Inputs.Props.CI.Codebase != nil {
-		overlay["clone"] = c.convertCodebase(spec.Inputs.Props.CI.Codebase)
+		overlay["clone"] = c.convertCodebase(spec.Inputs.Props.CI.Codebase, true)
 	}
 	if spec.Inputs.DelegateSelectors != nil {
 		overlay["delegate"] = convert_helpers.ConvertDelegate(spec.Inputs.DelegateSelectors, nil)

--- a/convert/v0tov1/yaml/chain.go
+++ b/convert/v0tov1/yaml/chain.go
@@ -6,6 +6,7 @@ type (
 	Chain struct {
 		Uses string     `json:"uses,omitempty" yaml:"uses,omitempty"`
 		With *ChainWith `json:"with,omitempty" yaml:"with,omitempty"`
+		Ref  string     `json:"ref,omitempty" yaml:"ref,omitempty"`
 	}
 
 	ChainWith struct {


### PR DESCRIPTION
## Pipeline stage chain gains a `ref` (git branch)

Pipeline stages (pipeline chaining) can now carry a `ref` that maps from the v0 stage's `gitBranch`, so the referenced pipeline is resolved from a specific branch.

- `convert/harness/yaml/stage.go`: v0 `StagePipeline` gains a `GitBranch` (`gitBranch`) field.
- `convert/v0tov1/yaml/chain.go`: v1 `Chain` gains a `Ref` (`ref`) field.
- `convert/v0tov1/pipeline_converter/convert_stage.go`: when building the stage `Chain`, `Ref` is populated from `spec.GitBranch`.

```yaml
- chain:
    uses: org/project/pipeline
    ref: main
    with:
      inputs:
        # ...
```

## Clone `ref: <+input>` scoped to pipeline chaining only

When v0 codebase has `build: <+input>`, `ref: <+input>` is now emitted only inside the pipeline-chaining overlay (`chain.with.inputs.overlay.clone`). At the pipeline level the `ref` is left unset and omitted (`omitempty`). Struct-based builds (branch/tag/PR/commitSha) are unchanged in both paths.

- `convert/v0tov1/pipeline_converter/convert_pipeline.go`: `convertCodebase` takes a new `emitInputRef bool` parameter; the `build == "<+input>"` string branch only sets `clone.Ref` when `emitInputRef` is true. The pipeline-level caller passes `false`.
- `convert/v0tov1/pipeline_converter/convert_stage.go`: the chaining overlay caller (`constructChainInputs`) passes `true`.

Pipeline level (`build: <+input>`) - `ref` omitted:

```yaml
clone:
  enabled: true
  repo: my-repo
  connector: my-connector
```

Pipeline chaining overlay (`build: <+input>`) - `ref` emitted:

```yaml
chain:
  with:
    inputs:
      overlay:
        clone:
          ref: <+input>
```
