### PR TITLE
feat: [CDS-126858]: add mapping for v0 deploymentType to v1 service.type conversion

### DIFF
--- a/convert/harness/yaml/const.go
+++ b/convert/harness/yaml/const.go
@@ -151,6 +151,35 @@ const (
 	ShellPowershell       = "Powershell"
 )
 
+// ServiceDeploymentType represents the v0 `deploymentType` values for a Deployment stage.
+type ServiceDeploymentType string
+
+const (
+	ServiceDeploymentTypeKubernetes          ServiceDeploymentType = "Kubernetes"
+	ServiceDeploymentTypeNativeHelm                                = "NativeHelm"
+	ServiceDeploymentTypeAwsSam                                    = "AWS_SAM"
+	ServiceDeploymentTypeServerlessAwsLambda                       = "ServerlessAwsLambda"
+	ServiceDeploymentTypeAwsLambda                                 = "AwsLambda"
+	ServiceDeploymentTypeGoogleCloudRun                            = "GoogleCloudRun"
+	ServiceDeploymentTypeAzureFunction                             = "AzureFunction"
+	ServiceDeploymentTypeAzureWebApp                               = "AzureWebApp"
+	ServiceDeploymentTypeAzureContainerApps                        = "AzureContainerApps"
+	ServiceDeploymentTypeECS                                       = "ECS"
+	ServiceDeploymentTypeAsg                                       = "Asg"
+	ServiceDeploymentTypeElastigroup                               = "Elastigroup"
+
+	// No semantic match in v1 ServiceType.
+	ServiceDeploymentTypeSSH                  = "Ssh"
+	ServiceDeploymentTypeWinRM                = "WinRm"
+	ServiceDeploymentTypeCustomDeployment     = "CustomDeployment"
+	ServiceDeploymentTypeTAS                  = "TAS"
+	ServiceDeploymentTypeGoogleCloudFunctions = "GoogleCloudFunctions"
+	ServiceDeploymentTypeSalesforce           = "Salesforce"
+	ServiceDeploymentTypeGoogleMIG            = "GoogleManagedInstanceGroup"
+	ServiceDeploymentTypeAiAgent              = "AiAgent"
+	ServiceDeploymentTypeServiceYamlV1        = "SERVICE_YAML_V1_TYPE"
+)
+
 type ImagePullPolicy string
 
 const (

--- a/convert/v0tov1/convert_helpers/convert_stage_deployment.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_deployment.go
@@ -91,7 +91,7 @@ func ConvertDeploymentService(src *v0.DeploymentService, ctx *StageConversionCon
 			Ref:  src.GitBranch,
 		}
 		return &v1.ServiceRef{
-			Items:        []*v1.ServiceItem{serviceItem},
+			Items:        v1.NewServiceItems([]*v1.ServiceItem{serviceItem}),
 			MultiService: false,
 		}
 	}
@@ -133,8 +133,16 @@ func ConvertDeploymentServices(src *v0.DeploymentServices, ctx *StageConversionC
 			)
 			return nil
 		}
-		// For <+input> or empty string, continue with nil values (no services)
-		return nil
+		if expr == "" {
+			return nil
+		}
+		// Runtime input: keep items as a runtime input expression in v1.
+		items := &flexible.Field[[]*v1.ServiceItem]{}
+		items.SetExpression(expr)
+		return &v1.ServiceRef{
+			Items:        items,
+			MultiService: true,
+		}
 	}
 
 	// Values is a struct (array of services)
@@ -168,7 +176,7 @@ func ConvertDeploymentServices(src *v0.DeploymentServices, ctx *StageConversionC
 	}
 	if len(serviceItems) > 0 {
 		return &v1.ServiceRef{
-			Items:        serviceItems,
+			Items:        v1.NewServiceItems(serviceItems),
 			MultiService: true,
 			Parallel:     parallel,
 		}
@@ -248,7 +256,7 @@ func ConvertEnvironment(src *v0.Environment, ctx *StageConversionContext) *v1.En
 	}
 
 	return &v1.EnvironmentRef{
-		Items:    []*v1.EnvironmentItem{item},
+		Items:    v1.NewEnvironmentItems([]*v1.EnvironmentItem{item}),
 		MultiEnv: false,
 	}
 }
@@ -333,6 +341,30 @@ func ConvertEnvironments(src *v0.Environments, ctx *StageConversionContext) *v1.
 		parallel = src.Metadata.Parallel
 	}
 
+	// Values may be a runtime input expression instead of a concrete list.
+	if src.Values != nil {
+		if expr, ok := src.Values.AsString(); ok {
+			if expr != "<+input>" && expr != "" {
+				messagelog.GetMessageLogger().LogWarning(
+					"UNSUPPORTED_EXPRESSION",
+					fmt.Sprintf("environments.values contains unsupported expression %q; skipping conversion", expr),
+					messagelog.WithContext(map[string]string{"expression": expr, "field": "environments.values"}),
+				)
+				return nil
+			}
+			if expr == "" {
+				return nil
+			}
+			// Runtime input: keep items as a runtime input expression in v1.
+			items := &flexible.Field[[]*v1.EnvironmentItem]{}
+			items.SetExpression(expr)
+			return &v1.EnvironmentRef{
+				Items:    items,
+				MultiEnv: true,
+			}
+		}
+	}
+
 	// Check if Values is nil or empty
 	hasValues := false
 	var values []*v0.Environment
@@ -395,7 +427,7 @@ func ConvertEnvironments(src *v0.Environments, ctx *StageConversionContext) *v1.
 
 	if len(items) > 0 {
 		return &v1.EnvironmentRef{
-			Items:    items,
+			Items:    v1.NewEnvironmentItems(items),
 			Parallel: parallel,
 			MultiEnv: true,
 		}
@@ -539,7 +571,7 @@ func ConvertDeploymentInfrastructure(src *v0.DeploymentInfrastructure) *v1.Envir
 	}
 
 	return &v1.EnvironmentRef{
-		Items: []*v1.EnvironmentItem{envItem},
+		Items: v1.NewEnvironmentItems([]*v1.EnvironmentItem{envItem}),
 	}
 }
 

--- a/convert/v0tov1/convert_helpers/convert_stage_deployment.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_deployment.go
@@ -24,6 +24,40 @@ import (
 	"github.com/drone/go-convert/internal/flexible"
 )
 
+// serviceDeploymentTypeConversionMap maps v0 ServiceDefinitionType values to
+// their semantically equivalent v1 ServiceType values. Types with no v1
+// equivalent (e.g. Ssh, WinRm, CustomDeployment, TAS, GoogleCloudFunctions,
+// Salesforce, GoogleManagedInstanceGroup, AiAgent, SERVICE_YAML_V1_TYPE) are
+// intentionally omitted.
+var serviceDeploymentTypeConversionMap = map[v0.ServiceDeploymentType]v1.ServiceType{
+	v0.ServiceDeploymentTypeKubernetes:          v1.ServiceTypeKubernetes,
+	v0.ServiceDeploymentTypeNativeHelm:          v1.ServiceTypeHelm,
+	v0.ServiceDeploymentTypeAwsSam:              v1.ServiceTypeAwsSam,
+	v0.ServiceDeploymentTypeServerlessAwsLambda: v1.ServiceTypeServerless,
+	v0.ServiceDeploymentTypeAwsLambda:           v1.ServiceTypeAwsLambda,
+	v0.ServiceDeploymentTypeGoogleCloudRun:      v1.ServiceTypeGoogleCloudRun,
+	v0.ServiceDeploymentTypeAzureFunction:       v1.ServiceTypeAzureFunction,
+	v0.ServiceDeploymentTypeAzureWebApp:         v1.ServiceTypeAzureWebApp,
+	v0.ServiceDeploymentTypeAzureContainerApps:  v1.ServiceTypeAzureContainerApps,
+	v0.ServiceDeploymentTypeECS:                 v1.ServiceTypeECS,
+	v0.ServiceDeploymentTypeAsg:                 v1.ServiceTypeAsg,
+	v0.ServiceDeploymentTypeElastigroup:         v1.ServiceTypeSpot,
+}
+
+// ConvertServiceDeploymentType converts a v0 deploymentType string to the
+// corresponding v1 ServiceType string. Returns an empty string if there is
+// no semantic match in v1.
+func ConvertServiceDeploymentType(deploymentType string) string {
+	if v1Type, ok := serviceDeploymentTypeConversionMap[v0.ServiceDeploymentType(deploymentType)]; ok {
+		return string(v1Type)
+	}
+	messagelog.GetMessageLogger().LogWarning(
+		"SERVICE_DEPLOYMENT_TYPE_MAPPING_NOT_FOUND",
+		fmt.Sprintf("mapping for service deployment type %q not found in v1", deploymentType),
+	)
+	return ""
+}
+
 // ConvertDeploymentService converts v0 DeploymentService to v1 ServiceRef
 func ConvertDeploymentService(src *v0.DeploymentService, ctx *StageConversionContext) *v1.ServiceRef {
 	if src == nil {
@@ -405,7 +439,7 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 			}
 			return &v1.EnvironmentRef{
 				Parallel: parallel,
-				Group:      groupConfig,
+				Group:    groupConfig,
 			}
 		}
 	}
@@ -418,7 +452,7 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 			}
 			return &v1.EnvironmentRef{
 				Parallel: parallel,
-				Group:      groupConfig,
+				Group:    groupConfig,
 			}
 		}
 	}
@@ -435,7 +469,7 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 				}
 				return &v1.EnvironmentRef{
 					Parallel: parallel,
-					Group:      groupConfig,
+					Group:    groupConfig,
 				}
 			}
 		}
@@ -459,7 +493,7 @@ func ConvertEnvironmentGroup(src *v0.EnvironmentGroup, ctx *StageConversionConte
 				}
 				return &v1.EnvironmentRef{
 					Parallel: parallel,
-					Group:      groupConfig,
+					Group:    groupConfig,
 				}
 			}
 		}

--- a/convert/v0tov1/pipeline_converter/convert_stage.go
+++ b/convert/v0tov1/pipeline_converter/convert_stage.go
@@ -42,8 +42,8 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 	}
 
 	stage := &v1.Stage{
-		Id:    src.ID,
-		Name:  src.Name,
+		Id:   src.ID,
+		Name: src.Name,
 	}
 
 	// Check for Template - if template exists, set it and continue converting rest
@@ -245,7 +245,7 @@ func (c *PipelineConverter) convertStage(src *v0.Stage, basePath string) *v1.Sta
 
 			// Map v0 deploymentType onto the v1 service ref type.
 			if stage.Service != nil && spec.DeploymentType != "" {
-				stage.Service.Type = spec.DeploymentType
+				stage.Service.Type = convert_helpers.ConvertServiceDeploymentType(spec.DeploymentType)
 			}
 
 		}

--- a/convert/v0tov1/pipeline_converter/stage_context_test.go
+++ b/convert/v0tov1/pipeline_converter/stage_context_test.go
@@ -12,8 +12,8 @@ import (
 func TestStageConversionContext_SetAndGet(t *testing.T) {
 	ctx := convert_helpers.NewStageConversionContext()
 
-	svc := &v1.ServiceRef{Items: []*v1.ServiceItem{{Id: "my-service"}}}
-	env := &v1.EnvironmentRef{Items: []*v1.EnvironmentItem{{Id: "my-env"}}}
+	svc := &v1.ServiceRef{Items: v1.NewServiceItems([]*v1.ServiceItem{{Id: "my-service"}})}
+	env := &v1.EnvironmentRef{Items: v1.NewEnvironmentItems([]*v1.EnvironmentItem{{Id: "my-env"}})}
 	rt := &v1.Runtime{Kubernetes: &v1.RuntimeKubernetes{Namespace: "default"}}
 
 	ctx.Set("Stage1", &convert_helpers.StageConvertedData{
@@ -99,14 +99,14 @@ func TestUseFromStage_DeploymentServiceAndEnvironment(t *testing.T) {
 	if first.Service == nil {
 		t.Fatal("first stage: service should not be nil")
 	}
-	if len(first.Service.Items) != 1 || first.Service.Items[0].Id != "dashboard-svc" {
-		t.Errorf("first stage: expected service 'dashboard-svc', got %v", first.Service.Items)
+	if items := first.Service.ItemList(); len(items) != 1 || items[0].Id != "dashboard-svc" {
+		t.Errorf("first stage: expected service 'dashboard-svc', got %v", items)
 	}
 	if first.Environment == nil {
 		t.Fatal("first stage: environment should not be nil")
 	}
-	if len(first.Environment.Items) != 1 || first.Environment.Items[0].Id != "prod-env" {
-		t.Errorf("first stage: expected environment 'prod-env', got %v", first.Environment.Items)
+	if items := first.Environment.ItemList(); len(items) != 1 || items[0].Id != "prod-env" {
+		t.Errorf("first stage: expected environment 'prod-env', got %v", items)
 	}
 
 	// Verify second stage copied service and environment from first
@@ -114,14 +114,14 @@ func TestUseFromStage_DeploymentServiceAndEnvironment(t *testing.T) {
 	if second.Service == nil {
 		t.Fatal("second stage: service should not be nil (useFromStage)")
 	}
-	if len(second.Service.Items) != 1 || second.Service.Items[0].Id != "dashboard-svc" {
-		t.Errorf("second stage: expected service 'dashboard-svc' from useFromStage, got %v", second.Service.Items)
+	if items := second.Service.ItemList(); len(items) != 1 || items[0].Id != "dashboard-svc" {
+		t.Errorf("second stage: expected service 'dashboard-svc' from useFromStage, got %v", items)
 	}
 	if second.Environment == nil {
 		t.Fatal("second stage: environment should not be nil (useFromStage)")
 	}
-	if len(second.Environment.Items) != 1 || second.Environment.Items[0].Id != "prod-env" {
-		t.Errorf("second stage: expected environment 'prod-env' from useFromStage, got %v", second.Environment.Items)
+	if items := second.Environment.ItemList(); len(items) != 1 || items[0].Id != "prod-env" {
+		t.Errorf("second stage: expected environment 'prod-env' from useFromStage, got %v", items)
 	}
 }
 
@@ -277,11 +277,11 @@ func TestUseFromStage_ServiceOnlyFromPreviousStage(t *testing.T) {
 
 	second := v1Stages[1]
 	// Service from useFromStage
-	if second.Service == nil || second.Service.Items[0].Id != "svc-alpha" {
+	if items := second.Service.ItemList(); second.Service == nil || len(items) == 0 || items[0].Id != "svc-alpha" {
 		t.Errorf("expected service 'svc-alpha' from useFromStage, got %v", second.Service)
 	}
 	// Environment is its own
-	if second.Environment == nil || len(second.Environment.Items) != 1 || second.Environment.Items[0].Id != "env-gamma" {
+	if items := second.Environment.ItemList(); second.Environment == nil || len(items) != 1 || items[0].Id != "env-gamma" {
 		t.Errorf("expected environment 'env-gamma' (own), got %v", second.Environment)
 	}
 }

--- a/convert/v0tov1/yaml/const.go
+++ b/convert/v0tov1/yaml/const.go
@@ -81,3 +81,21 @@ const (
 	StepTypeIACMTerraformPlugin = "terraformStep"
 	StepTypeIACMOpenTofuPlugin  = "openTofuStep"
 )
+
+// ServiceType represents the v1 `service.type` values for a Deployment stage.
+type ServiceType string
+
+const (
+	ServiceTypeKubernetes         ServiceType = "kubernetes"
+	ServiceTypeHelm                           = "helm"
+	ServiceTypeAwsSam                         = "aws-sam"
+	ServiceTypeServerless                     = "serverless"
+	ServiceTypeAwsLambda                      = "aws-lambda"
+	ServiceTypeGoogleCloudRun                 = "google-cloud-run"
+	ServiceTypeAzureFunction                  = "azure-function"
+	ServiceTypeAzureWebApp                    = "azure-web-app"
+	ServiceTypeAzureContainerApps             = "azure-container-apps"
+	ServiceTypeECS                            = "ecs"
+	ServiceTypeAsg                            = "asg"
+	ServiceTypeSpot                           = "spot"
+)

--- a/convert/v0tov1/yaml/container.go
+++ b/convert/v0tov1/yaml/container.go
@@ -49,7 +49,7 @@ type Container struct {
 	PortBindings *flexible.Field[map[string]string] `json:"port-bindings,omitempty" yaml:"port-bindings,omitempty"`
 	Privileged  *flexible.Field[bool]              `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	Pull        string            `json:"pull,omitempty" yaml:"pull,omitempty"`
-	Registry    string            `json:"registryRef,omitempty" yaml:"registryRef,omitempty"`
+	Registry    string            `json:"registry,omitempty" yaml:"registry,omitempty"`
 	ShmSize     StringorInt       `json:"shm-size,omitempty" yaml:"shm-size,omitempty"`
 	User        *flexible.Field[int]        `json:"user,omitempty" yaml:"user,omitempty"`
 	Volumes     []*Mount          `json:"volumes,omitempty" yaml:"volumes,omitempty"`
@@ -78,7 +78,7 @@ func (v *Container) UnmarshalJSON(data []byte) error {
 		PortBindings *flexible.Field[map[string]string] `json:"port-bindings,omitempty" yaml:"port-bindings,omitempty"`
 		Privileged  *flexible.Field[bool]              `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 		Pull        string            `json:"pull,omitempty" yaml:"pull,omitempty"`
-		Registry    string            `json:"registryRef,omitempty" yaml:"registryRef,omitempty"`
+		Registry    string            `json:"registry,omitempty" yaml:"registry,omitempty"`
 		ShmSize     StringorInt       `json:"shm-size,omitempty" yaml:"shm-size,omitempty"`
 		User        *flexible.Field[int]        `json:"user,omitempty" yaml:"user,omitempty"`
 		Volumes     []*Mount          `json:"volumes,omitempty" yaml:"volumes,omitempty"`

--- a/convert/v0tov1/yaml/environment_ref.go
+++ b/convert/v0tov1/yaml/environment_ref.go
@@ -16,23 +16,44 @@ package yaml
 
 import (
 	"encoding/json"
+
 	"github.com/drone/go-convert/internal/flexible"
 )
 
 // EnvironmentRef is the unified v1 environment configuration.
 type EnvironmentRef struct {
-	Items    []*EnvironmentItem    `json:"items,omitempty" yaml:"items,omitempty"`
-	Parallel *flexible.Field[bool] `json:"parallel,omitempty" yaml:"parallel,omitempty"`
-	Group    interface{}           `json:"group,omitempty" yaml:"group,omitempty"`
-	Filters  []*Filter             `json:"filters,omitempty" yaml:"filters,omitempty"`
-	MultiEnv bool                  `json:"-" yaml:"-"`
+	Items    *flexible.Field[[]*EnvironmentItem] `json:"items,omitempty" yaml:"items,omitempty"`
+	Parallel *flexible.Field[bool]               `json:"parallel,omitempty" yaml:"parallel,omitempty"`
+	Group    interface{}                         `json:"group,omitempty" yaml:"group,omitempty"`
+	Filters  []*Filter                           `json:"filters,omitempty" yaml:"filters,omitempty"`
+	MultiEnv bool                                `json:"-" yaml:"-"`
+}
+
+// NewEnvironmentItems wraps a list of environment items in a flexible field.
+func NewEnvironmentItems(items []*EnvironmentItem) *flexible.Field[[]*EnvironmentItem] {
+	field := &flexible.Field[[]*EnvironmentItem]{}
+	field.Set(items)
+	return field
+}
+
+// ItemList returns the environment items when Items holds a concrete list.
+// It returns nil when Items is unset or holds an expression.
+func (v *EnvironmentRef) ItemList() []*EnvironmentItem {
+	if v == nil || v.Items == nil {
+		return nil
+	}
+	items, ok := v.Items.AsStruct()
+	if !ok {
+		return nil
+	}
+	return items
 }
 
 // MarshalJSON implements json.Marshaler following the ServiceRef pattern.
 func (v EnvironmentRef) MarshalJSON() ([]byte, error) {
 	// Variant: single env – marshal as flat EnvironmentItem (like ServiceRef string)
-	if len(v.Items) == 1 && !v.MultiEnv {
-		return json.Marshal(v.Items[0])
+	if items := v.ItemList(); len(items) == 1 && !v.MultiEnv {
+		return json.Marshal(items[0])
 	}
 
 	// Variant: multi env – marshal as struct with items
@@ -44,15 +65,15 @@ func (v EnvironmentRef) MarshalJSON() ([]byte, error) {
 func (v *EnvironmentRef) UnmarshalJSON(data []byte) error {
 	var out1 string
 	var out2 = struct {
-		Items    []*EnvironmentItem    `json:"items,omitempty" yaml:"items,omitempty"`
-		Parallel *flexible.Field[bool] `json:"parallel,omitempty" yaml:"parallel,omitempty"`
-		Group    interface{}           `json:"group,omitempty" yaml:"group,omitempty"`
+		Items    *flexible.Field[[]*EnvironmentItem] `json:"items,omitempty" yaml:"items,omitempty"`
+		Parallel *flexible.Field[bool]               `json:"parallel,omitempty" yaml:"parallel,omitempty"`
+		Group    interface{}                         `json:"group,omitempty" yaml:"group,omitempty"`
 	}{}
 
 	if err := json.Unmarshal(data, &out1); err == nil {
-		v.Items = []*EnvironmentItem{
+		v.Items = NewEnvironmentItems([]*EnvironmentItem{
 			{Id: out1},
-		}
+		})
 		v.MultiEnv = false
 		return nil
 	}
@@ -63,7 +84,7 @@ func (v *EnvironmentRef) UnmarshalJSON(data []byte) error {
 		v.Group = out2.Group
 		// Set MultiEnv flag based on whether this is a multi-environment config
 		// MultiEnv is true if: multiple items, or has parallel/group fields
-		v.MultiEnv = len(out2.Items) > 0 || out2.Parallel != nil || out2.Group != nil
+		v.MultiEnv = len(v.ItemList()) > 0 || out2.Parallel != nil || out2.Group != nil
 		return nil
 	} else {
 		return err

--- a/convert/v0tov1/yaml/service_ref.go
+++ b/convert/v0tov1/yaml/service_ref.go
@@ -25,9 +25,9 @@ import (
 type ServiceItem struct {
 	Id   string                 `json:"id,omitempty"`
 	With map[string]interface{} `json:"with,omitempty"`
-	Ref  string                 `json:"ref,omitempty"` // git branch reference
+	Ref  string                 `json:"ref,omitempty"`  // git branch reference
 	Type string                 `json:"type,omitempty"` // Deployment Type: Kubernetes, Helm, etc.
-}	
+}
 
 // UnmarshalJSON implements json.Unmarshaler for ServiceItem.
 // Handles: string "service1" or object {id: "service1", with: {...}}
@@ -54,7 +54,7 @@ func (s *ServiceItem) UnmarshalJSON(data []byte) error {
 // Outputs: string "service1" if no With, or object {id: "service1", with: {...}} if With exists
 func (s ServiceItem) MarshalJSON() ([]byte, error) {
 	// If no With and no Ref, marshal as simple string
-	if len(s.With) == 0 && s.Ref == ""  && s.Type == "" {
+	if len(s.With) == 0 && s.Ref == "" && s.Type == "" {
 		return json.Marshal(s.Id)
 	}
 	// Otherwise marshal as full object
@@ -63,10 +63,30 @@ func (s ServiceItem) MarshalJSON() ([]byte, error) {
 }
 
 type ServiceRef struct {
-	Type string `json:"type,omitempty"` // Deployment Type: Kubernetes, Helm, etc.
-	Items        []*ServiceItem        `json:"items,omitempty"`
-	Parallel     *flexible.Field[bool] `json:"parallel,omitempty"`
-	MultiService bool                  `json:"-"` // Don't serialize this field
+	Type         string                          `json:"type,omitempty"` // Deployment Type: Kubernetes, Helm, etc.
+	Items        *flexible.Field[[]*ServiceItem] `json:"items,omitempty"`
+	Parallel     *flexible.Field[bool]           `json:"parallel,omitempty"`
+	MultiService bool                            `json:"-"` // Don't serialize this field
+}
+
+// NewServiceItems wraps a list of service items in a flexible field.
+func NewServiceItems(items []*ServiceItem) *flexible.Field[[]*ServiceItem] {
+	field := &flexible.Field[[]*ServiceItem]{}
+	field.Set(items)
+	return field
+}
+
+// ItemList returns the service items when Items holds a concrete list.
+// It returns nil when Items is unset or holds an expression.
+func (v *ServiceRef) ItemList() []*ServiceItem {
+	if v == nil || v.Items == nil {
+		return nil
+	}
+	items, ok := v.Items.AsStruct()
+	if !ok {
+		return nil
+	}
+	return items
 }
 
 // UnmarshalJSON implements json.Unmarshaler for ServiceRef.
@@ -78,7 +98,7 @@ func (v *ServiceRef) UnmarshalJSON(data []byte) error {
 	// Try as single string
 	var str string
 	if err := json.Unmarshal(data, &str); err == nil {
-		v.Items = []*ServiceItem{{Id: str}}
+		v.Items = NewServiceItems([]*ServiceItem{{Id: str}})
 		v.MultiService = false
 		return nil
 	}
@@ -86,29 +106,30 @@ func (v *ServiceRef) UnmarshalJSON(data []byte) error {
 	// Try as array of strings/items
 	var arr []json.RawMessage
 	if err := json.Unmarshal(data, &arr); err == nil {
-		v.Items = make([]*ServiceItem, 0, len(arr))
+		items := make([]*ServiceItem, 0, len(arr))
 		for _, raw := range arr {
 			var item ServiceItem
 			if err := json.Unmarshal(raw, &item); err != nil {
 				return err
 			}
-			v.Items = append(v.Items, &item)
+			items = append(items, &item)
 		}
-		v.MultiService = len(v.Items) > 1
+		v.Items = NewServiceItems(items)
+		v.MultiService = len(items) > 1
 		return nil
 	}
 
 	// Try as full object with items field
 	var out = struct {
-		Items    []*ServiceItem        `json:"items,omitempty"`
-		Parallel *flexible.Field[bool] `json:"parallel,omitempty"`
+		Items    *flexible.Field[[]*ServiceItem] `json:"items,omitempty"`
+		Parallel *flexible.Field[bool]           `json:"parallel,omitempty"`
 	}{}
 	if err := json.Unmarshal(data, &out); err != nil {
 		return err
 	}
 	v.Items = out.Items
 	v.Parallel = out.Parallel
-	v.MultiService = len(v.Items) > 1
+	v.MultiService = len(v.ItemList()) > 1
 	return nil
 }
 
@@ -118,8 +139,8 @@ func (v *ServiceRef) UnmarshalJSON(data []byte) error {
 // - Object with items if MultiService: {items: [...]} or {items: [...], parallel: true}
 func (v *ServiceRef) MarshalJSON() ([]byte, error) {
 	// Single item without With and not forced to be multi-service
-	if len(v.Items) == 1 && !v.MultiService && v.Parallel == nil {
-		item := v.Items[0]
+	if items := v.ItemList(); len(items) == 1 && !v.MultiService && v.Parallel == nil {
+		item := items[0]
 		if item.Type == "" {
 			item.Type = v.Type
 		}


### PR DESCRIPTION
## 1. v0 `deploymentType` is now mapped onto v1 `service.type`

Previously the v0 `deploymentType` string was copied verbatim onto the v1 service, producing invalid v1 values such as `type: Kubernetes` or `type: NativeHelm`. It is now translated through an explicit mapping table into the v1 `ServiceType` vocabulary.

v0:

```yaml
- stage:
    identifier: deploy
    type: Deployment
    spec:
      deploymentType: NativeHelm
      service:
        serviceRef: my_service
```

v1:

```yaml
- id: deploy
  service:
    id: my_service
    type: helm
```

### Mapping table

| v0 `deploymentType` | v1 `service.type` |
|---|---|
| `Kubernetes` | `kubernetes` |
| `NativeHelm` | `helm` |
| `AWS_SAM` | `aws-sam` |
| `ServerlessAwsLambda` | `serverless` |
| `AwsLambda` | `aws-lambda` |
| `GoogleCloudRun` | `google-cloud-run` |
| `AzureFunction` | `azure-function` |
| `AzureWebApp` | `azure-web-app` |
| `AzureContainerApps` | `azure-container-apps` |
| `ECS` | `ecs` |
| `Asg` | `asg` |
| `Elastigroup` | `spot` (Elastigroup was rebranded to Spot) |

### v0 types with no v1 equivalent

`Ssh`, `WinRm`, `CustomDeployment`, `TAS`, `GoogleCloudFunctions`, `Salesforce`, `GoogleManagedInstanceGroup`, `AiAgent`, `SERVICE_YAML_V1_TYPE`.

For these the `type` field is dropped (and a `SERVICE_DEPLOYMENT_TYPE_MAPPING_NOT_FOUND` warning is logged). A single service with no `type` collapses back to the short string form:

v0:

```yaml
spec:
  deploymentType: Ssh
  service:
    serviceRef: ssh_service
```

v1:

```yaml
service: ssh_service
```

## 2. `services.values: <+input>` / `environments.values: <+input>` now convert to `items: <+input>`

Runtime-input service and environment lists were silently dropped: the converter returned no `service` / `environment` block at all, so the stage lost its deployment target and failed v1 schema validation.

`ServiceRef.Items` and `EnvironmentRef.Items` are now `flexible.Field` (matching the pattern already used for v0 `values`), so they can hold either a concrete list or a runtime-input expression.

### Services

v0:

```yaml
spec:
  deploymentType: AwsLambda
  services:
    values: <+input>
```

v1:

```yaml
service:
  items: <+input>
  type: aws-lambda
```

### Environments

v0:

```yaml
spec:
  environments:
    values: <+input>
```

v1:

```yaml
environment:
  items: <+input>
```

Concrete lists are unchanged:

```yaml
service:
  items:
    - service_one
    - service_two
  parallel: true
  type: ecs
```

Non-`<+input>` expressions (e.g. `values: <+pipeline.variables.x>`) are still skipped with an `UNSUPPORTED_EXPRESSION` warning, and an empty string still yields no block.

## 3. Revert v1 `container.registryRef` back to `container.registry`

The v1 container field name is reverted to `registry` to match the v1 schema.

```yaml
run:
  container:
    image: alpine
    registry: my_docker_connector
```
