### PR TITLE
feat:[CI-22033]: map cache and build intelligence storage fields in v0…

### DIFF
--- a/convert/harness/yaml/pipeline.go
+++ b/convert/harness/yaml/pipeline.go
@@ -74,16 +74,28 @@ type (
 
 	// BuildIntelligence defines the build intelligence settings.
 	BuildIntelligence struct {
-		Enabled *flexible.Field[bool] `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+		Enabled      *flexible.Field[bool] `json:"enabled,omitempty"      yaml:"enabled,omitempty"`
+		ConnectorRef string                `json:"connectorRef,omitempty" yaml:"connectorRef,omitempty"`
+		Region       string                `json:"region,omitempty"       yaml:"region,omitempty"`
+		BucketName   string                `json:"bucket_name,omitempty"  yaml:"bucket_name,omitempty"`
+		RunAsUser    *flexible.Field[int]  `json:"runAsUser,omitempty"    yaml:"runAsUser,omitempty"`
+		Resources    *Resources            `json:"resources,omitempty"    yaml:"resources,omitempty"`
 	}
 
 	// Cache defines the cache settings.
 	Cache struct {
-		Enabled  *flexible.Field[bool]     `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-		Key      string                    `json:"key,omitempty"     yaml:"key,omitempty"`
-		Paths    *flexible.Field[[]string] `json:"paths,omitempty"   yaml:"paths,omitempty"`
-		Policy   string                    `json:"policy,omitempty"  yaml:"policy,omitempty"`
-		Override *flexible.Field[bool]     `json:"override,omitempty"  yaml:"override,omitempty"`
+		Enabled        *flexible.Field[bool]     `json:"enabled,omitempty"        yaml:"enabled,omitempty"`
+		Key            string                    `json:"key,omitempty"            yaml:"key,omitempty"`
+		Paths          *flexible.Field[[]string] `json:"paths,omitempty"          yaml:"paths,omitempty"`
+		Policy         string                    `json:"policy,omitempty"         yaml:"policy,omitempty"`
+		Override       *flexible.Field[bool]     `json:"override,omitempty"       yaml:"override,omitempty"`
+		ConnectorRef   string                    `json:"connectorRef,omitempty"   yaml:"connectorRef,omitempty"`
+		Region         string                    `json:"region,omitempty"         yaml:"region,omitempty"`
+		BucketName     string                    `json:"bucket_name,omitempty"    yaml:"bucket_name,omitempty"`
+		ContainerName  string                    `json:"containerName,omitempty"  yaml:"containerName,omitempty"`
+		StorageAccount string                    `json:"storageAccount,omitempty" yaml:"storageAccount,omitempty"`
+		RunAsUser      *flexible.Field[int]      `json:"runAsUser,omitempty"      yaml:"runAsUser,omitempty"`
+		Resources      *Resources                `json:"resources,omitempty"      yaml:"resources,omitempty"`
 	}
 
 	// Codebase defines a codebase.

--- a/convert/v0tov1/convert_helpers/convert_stage_ci.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_ci.go
@@ -24,21 +24,34 @@ func ConvertCaching(cache *v0.Cache) *v1.Cache {
 	}
 
 	return &v1.Cache{
-		Enabled:  cache.Enabled,
-		Key:      cache.Key,
-		Paths:    cache.Paths,
-		Policy:   cache.Policy,
-		Override: cache.Override,
+		Enabled:        cache.Enabled,
+		Key:            cache.Key,
+		Paths:          cache.Paths,
+		Policy:         cache.Policy,
+		Override:       cache.Override,
+		Connector:      cache.ConnectorRef,
+		Region:         cache.Region,
+		BucketName:     cache.BucketName,
+		ContainerName:  cache.ContainerName,
+		StorageAccount: cache.StorageAccount,
+		User:           cache.RunAsUser,
+		Resources:      ConvertContainerResources(cache.Resources),
 	}
 }
 
-// ConvertBuildIntelligence converts v0 BuildIntelligence to v1 bool
+// ConvertBuildIntelligence converts v0 BuildIntelligence to v1 BuildIntelligence.
+// v1-only fields (port, maven-url, container_name, storage_account) have no v0 source.
 func ConvertBuildIntelligence(bi *v0.BuildIntelligence) *v1.BuildIntelligence {
 	if bi == nil {
 		return nil
 	}
 	return &v1.BuildIntelligence{
-		Enabled: bi.Enabled,
+		Enabled:    bi.Enabled,
+		Connector:  bi.ConnectorRef,
+		Region:     bi.Region,
+		BucketName: bi.BucketName,
+		User:       bi.RunAsUser,
+		Resources:  ConvertContainerResources(bi.Resources),
 	}
 }
 

--- a/convert/v0tov1/convert_helpers/convert_stage_ci_test.go
+++ b/convert/v0tov1/convert_helpers/convert_stage_ci_test.go
@@ -96,6 +96,126 @@ func TestConvertRuntime(t *testing.T) {
 	}
 }
 
+func TestConvertCaching(t *testing.T) {
+	enabled := &flexible.Field[bool]{Value: true}
+	override := &flexible.Field[bool]{Value: false}
+	paths := &flexible.Field[[]string]{Value: []string{"/go/pkg/mod"}}
+	user := &flexible.Field[int]{Value: 1000}
+	resources := &v0.Resources{
+		Limits: &v0.ResourceSpec{
+			CPU:    &flexible.Field[*v0.MilliSize]{Value: "500m"},
+			Memory: &flexible.Field[*v0.BytesSize]{Value: "512Mi"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		input    *v0.Cache
+		expected *v1.Cache
+	}{
+		{
+			name:     "nil cache",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "maps storage, user, and resources fields",
+			input: &v0.Cache{
+				Enabled:        enabled,
+				Key:            "go-mod",
+				Paths:          paths,
+				Policy:         "pull-push",
+				Override:       override,
+				ConnectorRef:   "account.s3",
+				Region:         "us-east-1",
+				BucketName:     "ci-cache",
+				ContainerName:  "cache-container",
+				StorageAccount: "cacheacct",
+				RunAsUser:      user,
+				Resources:      resources,
+			},
+			expected: &v1.Cache{
+				Enabled:        enabled,
+				Key:            "go-mod",
+				Paths:          paths,
+				Policy:         "pull-push",
+				Override:       override,
+				Connector:      "account.s3",
+				Region:         "us-east-1",
+				BucketName:     "ci-cache",
+				ContainerName:  "cache-container",
+				StorageAccount: "cacheacct",
+				User:           user,
+				Resources: &v1.ContainerResources{
+					Limits: &v1.ContainerResourcesSpec{Cpu: "500m", Memory: "512Mi"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertCaching(tt.input)
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvertBuildIntelligence(t *testing.T) {
+	enabled := &flexible.Field[bool]{Value: true}
+	user := &flexible.Field[int]{Value: 1000}
+	resources := &v0.Resources{
+		Limits: &v0.ResourceSpec{
+			CPU:    &flexible.Field[*v0.MilliSize]{Value: "1"},
+			Memory: &flexible.Field[*v0.BytesSize]{Value: "1Gi"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		input    *v0.BuildIntelligence
+		expected *v1.BuildIntelligence
+	}{
+		{
+			name:     "nil build intelligence",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "maps connector, region, bucket, user, and resources",
+			input: &v0.BuildIntelligence{
+				Enabled:      enabled,
+				ConnectorRef: "account.gcs",
+				Region:       "us-west1",
+				BucketName:   "bi-cache",
+				RunAsUser:    user,
+				Resources:    resources,
+			},
+			expected: &v1.BuildIntelligence{
+				Enabled:    enabled,
+				Connector:  "account.gcs",
+				Region:     "us-west1",
+				BucketName: "bi-cache",
+				User:       user,
+				Resources: &v1.ContainerResources{
+					Limits: &v1.ContainerResourcesSpec{Cpu: "1", Memory: "1Gi"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertBuildIntelligence(tt.input)
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestConvertInfrastructureToRuntime(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -112,14 +232,14 @@ func TestConvertInfrastructureToRuntime(t *testing.T) {
 			input: &v0.Infrastructure{
 				Type: "KubernetesDirect",
 				Spec: &v0.InfrastructureKubernetesDirectSpec{
-					Conn:               "k8s-connector",
-					Namespace:          "ci-builds",
-					ServiceAccountName: "ci-sa",
-					InitTimeout:        "10m",
-					OS:                 "Linux",
+					Conn:                     "k8s-connector",
+					Namespace:                "ci-builds",
+					ServiceAccountName:       "ci-sa",
+					InitTimeout:              "10m",
+					OS:                       "Linux",
 					HarnessImageConnectorRef: "harness-docker",
-					ImagePullPolicy:    "Always",
-					PodSpecOverlay:     "overlay-spec",
+					ImagePullPolicy:          "Always",
+					PodSpecOverlay:           "overlay-spec",
 					Annotations: &flexible.Field[map[string]string]{Value: map[string]string{
 						"app": "ci",
 					}},
@@ -130,16 +250,16 @@ func TestConvertInfrastructureToRuntime(t *testing.T) {
 						"disktype": "ssd",
 					}},
 					AutomountServiceAccountToken: &flexible.Field[bool]{Value: true},
-					PriorityClassName: "high-priority",
-					HostNames: &flexible.Field[[]string]{Value: []string{"host1", "host2"}},
+					PriorityClassName:            "high-priority",
+					HostNames:                    &flexible.Field[[]string]{Value: []string{"host1", "host2"}},
 				},
 			},
 			expected: &v1.Runtime{
 				Kubernetes: &v1.RuntimeKubernetes{
-					Namespace:             "ci-builds",
-					Connector:             "k8s-connector",
-					ServiceAccount:        "ci-sa",
-					Timeout:               "10m",
+					Namespace:      "ci-builds",
+					Connector:      "k8s-connector",
+					ServiceAccount: "ci-sa",
+					Timeout:        "10m",
 					// OS intentionally omitted: V1 K8s stage OS is sourced from stage.Platform.Os
 					// (set by convert_stage.go), not from runtime.kubernetes.os.
 					HarnessImageConnector: "harness-docker",
@@ -280,7 +400,6 @@ func TestConvertServiceDependencyToBackgroundStep(t *testing.T) {
 					Env: &flexible.Field[map[string]interface{}]{Value: map[string]interface{}{
 						"REDIS_PORT": "6379",
 					}},
-					
 				},
 			},
 		},

--- a/convert/v0tov1/yaml/build_intelligence.go
+++ b/convert/v0tov1/yaml/build_intelligence.go
@@ -4,7 +4,14 @@ import "github.com/drone/go-convert/internal/flexible"
 
 // BuildIntelligence defines pipeline build intelligence behavior.
 type BuildIntelligence struct {
-	Enabled *flexible.Field[bool] `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Port    string                `json:"port,omitempty" yaml:"port,omitempty"`
-	MavenUrl string                `json:"maven-url,omitempty" yaml:"maven-url,omitempty"`	
+	Enabled        *flexible.Field[bool] `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Port           string                `json:"port,omitempty" yaml:"port,omitempty"`
+	MavenUrl       string                `json:"maven-url,omitempty" yaml:"maven-url,omitempty"`
+	Connector      string                `json:"connector,omitempty" yaml:"connector,omitempty"`
+	Region         string                `json:"region,omitempty" yaml:"region,omitempty"`
+	BucketName     string                `json:"bucket_name,omitempty" yaml:"bucket_name,omitempty"`
+	ContainerName  string                `json:"container_name,omitempty" yaml:"container_name,omitempty"`
+	StorageAccount string                `json:"storage_account,omitempty" yaml:"storage_account,omitempty"`
+	User           *flexible.Field[int]  `json:"user,omitempty" yaml:"user,omitempty"`
+	Resources      *ContainerResources   `json:"resources,omitempty" yaml:"resources,omitempty"`
 }

--- a/convert/v0tov1/yaml/cache.go
+++ b/convert/v0tov1/yaml/cache.go
@@ -20,9 +20,16 @@ import "github.com/drone/go-convert/internal/flexible"
 
 // Cache defines pipeline caching behavior.
 type Cache struct {
-	Enabled *flexible.Field[bool]          `json:"enabled"`
-	Key      string        `json:"key,omitempty"`
-	Paths    *flexible.Field[[]string] `json:"paths,omitempty"`
-	Policy   string        `json:"policy,omitempty"`
-	Override *flexible.Field[bool]    `json:"override,omitempty"`
+	Enabled        *flexible.Field[bool]     `json:"enabled" yaml:"enabled"`
+	Key            string                    `json:"key,omitempty" yaml:"key,omitempty"`
+	Paths          *flexible.Field[[]string] `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Policy         string                    `json:"policy,omitempty" yaml:"policy,omitempty"`
+	Override       *flexible.Field[bool]     `json:"override,omitempty" yaml:"override,omitempty"`
+	Connector      string                    `json:"connector,omitempty" yaml:"connector,omitempty"`
+	Region         string                    `json:"region,omitempty" yaml:"region,omitempty"`
+	BucketName     string                    `json:"bucket_name,omitempty" yaml:"bucket_name,omitempty"`
+	ContainerName  string                    `json:"container_name,omitempty" yaml:"container_name,omitempty"`
+	StorageAccount string                    `json:"storage_account,omitempty" yaml:"storage_account,omitempty"`
+	User           *flexible.Field[int]      `json:"user,omitempty" yaml:"user,omitempty"`
+	Resources      *ContainerResources       `json:"resources,omitempty" yaml:"resources,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Keep cache `paths` as `paths` (no longer convert to `path`).
- Parse the extra v0 cache and build-intelligence fields from harness-core and emit the matching v1 YAML names.
- Cover the converters with unit tests (`TestConvertCaching`, `TestConvertBuildIntelligence`).


## Cache (v0 `caching` → v1 `cache`)

| v0 YAML | v1 YAML | Conversion |
| --- | --- | --- |
| `enabled` | `enabled` | copy |
| `paths` | `paths` | copy (plural stays plural) |
| `key` | `key` | copy |
| `policy` | `policy` | copy |
| `override` | `override` | copy |
| `connectorRef` | `connector` | rename |
| `region` | `region` | copy |
| `bucket_name` | `bucket_name` | copy |
| `containerName` | `container_name` | camelCase → snake_case |
| `storageAccount` | `storage_account` | camelCase → snake_case |
| `runAsUser` | `user` | rename |
| `resources` | `resources` | `ConvertContainerResources` |

## Build intelligence (v0 `buildIntelligence` → v1 `build-intelligence`)

| v0 YAML | v1 YAML | Conversion |
| --- | --- | --- |
| `enabled` | `enabled` | copy |
| `connectorRef` | `connector` | rename |
| `region` | `region` | copy |
| `bucket_name` | `bucket_name` | copy |
| `runAsUser` | `user` | rename |
| `resources` | `resources` | `ConvertContainerResources` |
| — | `port` | v1-only; not set from v0 |
| — | `maven-url` | v1-only; not set from v0 |
| — | `container_name` | v1-only; not set from v0 |
| — | `storage_account` | v1-only; not set from v0 |

## Files

- `convert/harness/yaml/pipeline.go` — v0 `Cache` and `BuildIntelligence` structs
- `convert/v0tov1/yaml/cache.go` — v1 cache schema (`paths`, storage fields, `user`)
- `convert/v0tov1/yaml/build_intelligence.go` — v1 build-intelligence schema
- `convert/v0tov1/convert_helpers/convert_stage_ci.go` — `ConvertCaching` / `ConvertBuildIntelligence`
- `convert/v0tov1/convert_helpers/convert_stage_ci_test.go` — unit tests

