### PR TITLE
fix: [CI-23523]: align V1 git clone pre-fetch and sparse checkout conversion

### DIFF
--- a/convert/v0tov1/convert_helpers/convert_step_git_clone.go
+++ b/convert/v0tov1/convert_helpers/convert_step_git_clone.go
@@ -81,12 +81,12 @@ func ConvertStepGitClone(src *v0.Step) *v1.StepTemplate {
 		}
 	}
 
-	// Sparse checkout - convert []string to comma-separated string for v1
+	// Sparse checkout - join paths with newlines for the git clone plugin (matches DRONE_NETRC_SPARSE_CHECKOUT).
 	if sp.SparseCheckout != nil && !sp.SparseCheckout.IsNil() {
 		if expr, ok := sp.SparseCheckout.AsString(); ok {
 			with["sparse_checkout"] = expr
 		} else if paths, ok := sp.SparseCheckout.AsStruct(); ok && len(paths) > 0 {
-			with["sparse_checkout"] = strings.Join(paths, ",")
+			with["sparse_checkout"] = strings.Join(paths, "\n")
 		}
 	}
 

--- a/convert/v0tov1/convert_helpers/convert_step_git_clone_sparse_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_git_clone_sparse_test.go
@@ -1,0 +1,35 @@
+package converthelpers
+
+import (
+	"testing"
+
+	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	"github.com/drone/go-convert/internal/flexible"
+)
+
+func TestConvertStepGitClone_SparseCheckoutPathsWithSpaces(t *testing.T) {
+	result := ConvertStepGitClone(&v0.Step{
+		Spec: &v0.StepGitClone{
+			ConnRef: "gitlab-connector",
+			SparseCheckout: &flexible.Field[[]string]{
+				Value: []string{"folder2", "folder with space"},
+			},
+		},
+	})
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	with, ok := result.With.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected with map, got %T", result.With)
+	}
+	got, ok := with["sparse_checkout"].(string)
+	if !ok {
+		t.Fatalf("expected sparse_checkout string, got %T", with["sparse_checkout"])
+	}
+	want := "folder2\nfolder with space"
+	if got != want {
+		t.Fatalf("sparse_checkout = %q, want %q", got, want)
+	}
+}

--- a/convert/v0tov1/convert_helpers/convert_step_git_clone_test.go
+++ b/convert/v0tov1/convert_helpers/convert_step_git_clone_test.go
@@ -136,7 +136,7 @@ func TestConvertStepGitClone(t *testing.T) {
 				"lfs_enabled":        true,
 				"debug":              true,
 				"fetch_tags":         true,
-				"sparse_checkout":    "src,lib",
+				"sparse_checkout":    "src\nlib",
 				"submodule_strategy": "recursive",
 				"pre_fetch":          "git config --global user.email test@test.com",
 			},

--- a/convert/v0tov1/pipeline_converter/convert_codebase_test.go
+++ b/convert/v0tov1/pipeline_converter/convert_codebase_test.go
@@ -1,0 +1,66 @@
+package pipelineconverter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	v0 "github.com/drone/go-convert/convert/harness/yaml"
+	"github.com/drone/go-convert/internal/flexible"
+)
+
+func TestConvertPipeline_CodebaseClonePreFetchAndSparseCheckout(t *testing.T) {
+	converter := NewPipelineConverter()
+
+	pipeline := &v0.Pipeline{
+		ID:   "git_clone_advanced",
+		Name: "git clone advanced",
+		Props: v0.Properties{
+			CI: v0.CI{
+				Codebase: &v0.Codebase{
+					Conn: "account.test",
+					Build: flexible.Field[v0.Build]{
+						Value: v0.Build{
+							Type: "branch",
+							Spec: v0.BuildSpec{Branch: "dev"},
+						},
+					},
+					PreFetchCommand: "mkdir preFetchDir",
+					SparseCheckout: &flexible.Field[[]string]{
+						Value: []string{"folder2", "folder with space"},
+					},
+					Lfs:               &flexible.Field[bool]{Value: true},
+					FetchTags:         &flexible.Field[bool]{Value: true},
+					SubmoduleStrategy: &flexible.Field[bool]{Value: "recursive"},
+				},
+			},
+		},
+	}
+
+	result := converter.ConvertPipeline(pipeline)
+	if result == nil || result.Clone == nil {
+		t.Fatal("expected pipeline clone config")
+	}
+	if result.Clone.PreFetchCommand != "mkdir preFetchDir" {
+		t.Fatalf("pre-fetch command = %q", result.Clone.PreFetchCommand)
+	}
+	paths, ok := result.Clone.SparseCheckout.AsStruct()
+	if !ok {
+		t.Fatal("expected sparse-checkout list")
+	}
+	if len(paths) != 2 || paths[0] != "folder2" || paths[1] != "folder with space" {
+		t.Fatalf("sparse-checkout = %#v", paths)
+	}
+
+	raw, err := json.Marshal(result.Clone)
+	if err != nil {
+		t.Fatalf("marshal clone: %v", err)
+	}
+	out := string(raw)
+	if strings.Contains(out, "pre-fetch-command") {
+		t.Fatalf("must emit pre-fetch, not pre-fetch-command: %s", out)
+	}
+	if strings.Contains(out, `"folder2,folder with space"`) {
+		t.Fatalf("sparse-checkout must stay an array: %s", out)
+	}
+}

--- a/convert/v0tov1/yaml/clone.go
+++ b/convert/v0tov1/yaml/clone.go
@@ -45,7 +45,7 @@ type Clone struct {
 	CloneDir   string `json:"clonedir,omitempty"`
 	Resources *ContainerResources `json:"resources,omitempty"`
 	SparseCheckout     *flexible.Field[[]string] `json:"sparse-checkout,omitempty"`
-	PreFetchCommand string `json:"pre-fetch-command,omitempty"`
+	PreFetchCommand string `json:"pre-fetch,omitempty"`
 	PersistCredentials *flexible.Field[bool] `json:"persist-credentials,omitempty"`
 	User *flexible.Field[int] `json:"user,omitempty"`
 }
@@ -68,7 +68,7 @@ func (v *Clone) UnmarshalJSON(data []byte) error {
 		CloneDir   string `json:"clonedir,omitempty"`
 		Resources *ContainerResources `json:"resources,omitempty"`
 		SparseCheckout     *flexible.Field[[]string] `json:"sparse-checkout,omitempty"`
-		PreFetchCommand string `json:"pre-fetch-command,omitempty"`
+		PreFetchCommand string `json:"pre-fetch,omitempty"`
 		PersistCredentials *flexible.Field[bool] `json:"persist-credentials,omitempty"`
 		User *flexible.Field[int] `json:"user,omitempty"`
 	}{}
@@ -79,7 +79,15 @@ func (v *Clone) UnmarshalJSON(data []byte) error {
 	}
 
 	if err := json.Unmarshal(data, &out2); err == nil {
-		*v = out2
+		*v = Clone(out2)
+		if v.PreFetchCommand == "" {
+			var legacy struct {
+				PreFetchCommand string `json:"pre-fetch-command"`
+			}
+			if err := json.Unmarshal(data, &legacy); err == nil {
+				v.PreFetchCommand = legacy.PreFetchCommand
+			}
+		}
 		return nil
 	} else {
 		return err

--- a/convert/v0tov1/yaml/clone_test.go
+++ b/convert/v0tov1/yaml/clone_test.go
@@ -1,0 +1,50 @@
+package yaml
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/drone/go-convert/internal/flexible"
+)
+
+func TestCloneJSONMarshalPreFetchAndSparseCheckout(t *testing.T) {
+	clone := Clone{
+		Enabled:        true,
+		PreFetchCommand: "mkdir preFetchDir",
+		SparseCheckout: &flexible.Field[[]string]{
+			Value: []string{"folder2", "folder with space"},
+		},
+	}
+
+	raw, err := json.Marshal(clone)
+	if err != nil {
+		t.Fatalf("marshal clone: %v", err)
+	}
+
+	out := string(raw)
+	if strings.Contains(out, "pre-fetch-command") {
+		t.Fatalf("expected pre-fetch key, got legacy pre-fetch-command in %s", out)
+	}
+	if !strings.Contains(out, `"pre-fetch":"mkdir preFetchDir"`) {
+		t.Fatalf("expected pre-fetch value in %s", out)
+	}
+	if strings.Contains(out, `"folder2,folder with space"`) {
+		t.Fatalf("sparse-checkout must remain a list, not comma string: %s", out)
+	}
+	if !strings.Contains(out, `"folder2"`) || !strings.Contains(out, `"folder with space"`) {
+		t.Fatalf("expected sparse-checkout array entries in %s", out)
+	}
+}
+
+func TestCloneJSONUnmarshalPreFetchLegacyKey(t *testing.T) {
+	raw := []byte(`{"enabled":true,"pre-fetch-command":"legacy command"}`)
+
+	var clone Clone
+	if err := json.Unmarshal(raw, &clone); err != nil {
+		t.Fatalf("unmarshal clone: %v", err)
+	}
+	if clone.PreFetchCommand != "legacy command" {
+		t.Fatalf("expected legacy pre-fetch-command to deserialize, got %q", clone.PreFetchCommand)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes V0→V1 git clone conversion issues tracked in [CI-23523](https://harness.atlassian.net/browse/CI-23523):

- Pipeline clone: emit `pre-fetch` (V1 schema) instead of `pre-fetch-command`; still accept legacy key on deserialize
- GitClone step: join sparse checkout paths with newlines instead of commas so paths like `folder2` + `folder with space` are preserved (not squashed into `"folder2,folder with space"`)

## Changes

| File | Change |
|------|--------|
| `convert/v0tov1/yaml/clone.go` | `pre-fetch` JSON key + legacy read fallback |
| `convert/v0tov1/convert_helpers/convert_step_git_clone.go` | newline-separated sparse paths for step template |
| `convert/v0tov1/convert_helpers/convert_step_git_clone_test.go` | update expected sparse output |

## Tests

- `convert/v0tov1/yaml/clone_test.go`
- `convert/v0tov1/convert_helpers/convert_step_git_clone_sparse_test.go`
- `convert/v0tov1/pipeline_converter/convert_codebase_test.go`

## Test plan

- [x] `go test ./convert/v0tov1/yaml/... ./convert/v0tov1/convert_helpers/... ./convert/v0tov1/pipeline_converter/...`

[CI-23523]: https://harness.atlassian.net/browse/CI-23523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ